### PR TITLE
Scaffold llmkube application

### DIFF
--- a/applications/llmkube/kustomization.yaml
+++ b/applications/llmkube/kustomization.yaml
@@ -1,0 +1,12 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+namespace: llmkube-system
+resources:
+  - llmkube-system-namespace.yaml
+helmCharts:
+- name: llmkube
+  namespace: llmkube-system
+  version: 0.7.5
+  releaseName: llmkube
+  repo: https://defilantech.github.io/LLMKube
+  valuesInline: {}

--- a/applications/llmkube/llmkube-system-namespace.yaml
+++ b/applications/llmkube/llmkube-system-namespace.yaml
@@ -1,0 +1,5 @@
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: llmkube-system


### PR DESCRIPTION
Adds applications/llmkube/ with Namespace and kustomization wiring
the llmkube Helm chart (v0.7.5) from defilantech into the llmkube-system
namespace. valuesInline is empty pending operator-specific configuration.

https://claude.ai/code/session_01Mqo6R1iSm7oeQKT7YNTxoY