### PR TITLE
Set up OpenShift Pipelines as Code (operator layer)

### DIFF
--- a/components/openshift-pipelines/chains-signing-externalsecret.yaml
+++ b/components/openshift-pipelines/chains-signing-externalsecret.yaml
@@ -1,0 +1,30 @@
+---
+apiVersion: external-secrets.io/v1beta1
+kind: ExternalSecret
+metadata:
+  name: signing-secrets
+  namespace: tekton-chains
+  annotations:
+    argocd.argoproj.io/sync-wave: "12"
+    argocd.argoproj.io/sync-options: SkipDryRunOnMissingResource=true
+spec:
+  refreshInterval: 1h
+  secretStoreRef:
+    kind: ClusterSecretStore
+    name: onepassword-sdk-ocp-pull
+  target:
+    name: signing-secrets
+    creationPolicy: Owner
+  data:
+    - secretKey: cosign.key
+      remoteRef:
+        key: tekton-chains-signing
+        property: cosign.key
+    - secretKey: cosign.password
+      remoteRef:
+        key: tekton-chains-signing
+        property: cosign.password
+    - secretKey: cosign.pub
+      remoteRef:
+        key: tekton-chains-signing
+        property: cosign.pub

--- a/components/openshift-pipelines/kustomization.yaml
+++ b/components/openshift-pipelines/kustomization.yaml
@@ -1,4 +1,9 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
-- openshift-pipelines-operator-subscription.yaml
+  - openshift-pipelines-operator-subscription.yaml
+  - tekton-ci-low-priorityclass.yaml
+  - tektonconfig.yaml
+  - pac-github-app-externalsecret.yaml
+  - chains-signing-externalsecret.yaml
+  - pac-controller-funnel-service.yaml

--- a/components/openshift-pipelines/pac-controller-funnel-service.yaml
+++ b/components/openshift-pipelines/pac-controller-funnel-service.yaml
@@ -1,0 +1,22 @@
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: pac-controller-funnel
+  namespace: openshift-pipelines
+  annotations:
+    tailscale.com/expose: "true"
+    tailscale.com/funnel: "true"
+    tailscale.com/hostname: pac-ocp
+    argocd.argoproj.io/sync-wave: "13"
+    argocd.argoproj.io/sync-options: SkipDryRunOnMissingResource=true
+spec:
+  type: ClusterIP
+  selector:
+    app.kubernetes.io/name: controller
+    app.kubernetes.io/part-of: pipelines-as-code
+  ports:
+    - name: http
+      port: 8080
+      targetPort: 8080
+      protocol: TCP

--- a/components/openshift-pipelines/pac-github-app-externalsecret.yaml
+++ b/components/openshift-pipelines/pac-github-app-externalsecret.yaml
@@ -6,6 +6,7 @@ metadata:
   namespace: openshift-pipelines
   annotations:
     argocd.argoproj.io/sync-wave: "12"
+    argocd.argoproj.io/sync-options: SkipDryRunOnMissingResource=true
 spec:
   refreshInterval: 1h
   secretStoreRef:

--- a/components/openshift-pipelines/pac-github-app-externalsecret.yaml
+++ b/components/openshift-pipelines/pac-github-app-externalsecret.yaml
@@ -1,0 +1,29 @@
+---
+apiVersion: external-secrets.io/v1beta1
+kind: ExternalSecret
+metadata:
+  name: pipelines-as-code-secret
+  namespace: openshift-pipelines
+  annotations:
+    argocd.argoproj.io/sync-wave: "12"
+spec:
+  refreshInterval: 1h
+  secretStoreRef:
+    kind: ClusterSecretStore
+    name: onepassword-sdk-ocp-pull
+  target:
+    name: pipelines-as-code-secret
+    creationPolicy: Owner
+  data:
+    - secretKey: github-application-id
+      remoteRef:
+        key: pac-github-app
+        property: app-id
+    - secretKey: github-private-key
+      remoteRef:
+        key: pac-github-app
+        property: private-key
+    - secretKey: webhook.secret
+      remoteRef:
+        key: pac-github-app
+        property: webhook-secret

--- a/components/openshift-pipelines/tekton-ci-low-priorityclass.yaml
+++ b/components/openshift-pipelines/tekton-ci-low-priorityclass.yaml
@@ -1,0 +1,11 @@
+---
+apiVersion: scheduling.k8s.io/v1
+kind: PriorityClass
+metadata:
+  name: tekton-ci-low
+  annotations:
+    argocd.argoproj.io/sync-wave: "10"
+value: 100
+globalDefault: false
+description: PR PipelineRun pods. Preempted under cluster pressure.
+preemptionPolicy: PreemptLowerPriority

--- a/components/openshift-pipelines/tektonconfig.yaml
+++ b/components/openshift-pipelines/tektonconfig.yaml
@@ -1,0 +1,60 @@
+---
+apiVersion: operator.tekton.dev/v1alpha1
+kind: TektonConfig
+metadata:
+  name: config
+  annotations:
+    argocd.argoproj.io/sync-wave: "11"
+    argocd.argoproj.io/sync-options: SkipDryRunOnMissingResource=true,ServerSideApply=true
+spec:
+  profile: all
+  targetNamespace: openshift-pipelines
+  pruner:
+    disabled: false
+    schedule: "0 4 * * *"
+    keep: 20
+    keep-since: 10080
+    resources:
+      - pipelinerun
+      - taskrun
+  pipeline:
+    enable-bundles-resolver: true
+    enable-cluster-resolver: true
+    enable-git-resolver: true
+    enable-hub-resolver: true
+    default-service-account: pipeline-sa
+    default-timeout-minutes: 60
+    enable-step-actions: true
+    default-pod-template:
+      securityContext:
+        runAsNonRoot: true
+        seccompProfile:
+          type: RuntimeDefault
+      automountServiceAccountToken: false
+      enableServiceLinks: false
+      priorityClassName: tekton-ci-low
+  chain:
+    artifacts.taskrun.format: in-toto
+    artifacts.taskrun.storage: oci
+    artifacts.pipelinerun.format: in-toto
+    artifacts.pipelinerun.storage: oci
+    artifacts.oci.storage: oci
+    transparency.enabled: false
+    signers.x509.fulcio.enabled: false
+  platforms:
+    openshift:
+      pipelinesAsCode:
+        enable: true
+        settings:
+          application-name: OpenShift Pipelines (homelab)
+          auto-configure-new-github-repo: false
+          secret-auto-create: true
+          remote-tasks: true
+          max-keep-runs: "10"
+          enable-cancel-in-progress: "true"
+          custom-console-name: OpenShift Console
+          custom-console-url: https://console-openshift-console.apps.ocp.igou.systems
+          custom-console-url-pr-details: |
+            {{.openshift_console_url}}/k8s/ns/{{.namespace}}/tekton.dev~v1~PipelineRun/{{.pr}}
+          custom-console-url-pr-tasklog: |
+            {{.openshift_console_url}}/k8s/ns/{{.namespace}}/tekton.dev~v1~PipelineRun/{{.pr}}/logs/{{.task}}

--- a/docs/superpowers/plans/2026-05-09-pipelines-as-code.md
+++ b/docs/superpowers/plans/2026-05-09-pipelines-as-code.md
@@ -1,0 +1,1935 @@
+# OpenShift Pipelines as Code Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Stand up OpenShift Pipelines as Code on the OCP cluster with a Helm-templated per-tenant model, hardened-by-default per-repo namespaces, two onboarding skills, and a smoke-tested first migration of `igou-openshift`'s own `validate.yml`.
+
+**Architecture:** Existing operator Subscription stays. New: a TektonConfig CR that pins behavior (pruner, resolvers, Chains, PaC settings); a Tailscale-Funnel-fronted Service for the PaC controller webhook; ExternalSecrets for the GitHub App + cosign keypair; a `pac-tenant` Helm chart instantiated once at `clusters/ocp/pac-tenants/` whose values.yaml defines the entire CI fleet; two Claude skills (`/scaffold-pac-tenant`, `/convert-gha-workflow`).
+
+**Tech Stack:** OpenShift Pipelines operator, Tekton (Pipelines + Triggers + PaC + Chains), External Secrets Operator + 1Password ClusterSecretStore, ArgoCD app-of-apps, Helm 3, kustomize+helm, kubeconform, yamllint, Tailscale operator, Claude skills (markdown prompts).
+
+**Spec:** `docs/superpowers/specs/2026-05-09-pipelines-as-code-design.md`
+
+**Manual prerequisites the agent cannot do (Phase 0 below flags these as user-action checkpoints):**
+- Create the GitHub App on github.com.
+- Drop App credentials + cosign keypair into 1Password.
+- Edit Tailscale ACL to grant `funnel` to the operator's tag.
+- Install the GitHub App on each repo to be onboarded.
+
+---
+
+## Phase 0 — Manual prerequisites (user, not subagent)
+
+These are gates. The plan **stops** here for each step and waits for the user to confirm completion before the dependent tasks proceed.
+
+### Task 0.1: GitHub App created
+- [ ] User creates a GitHub App at https://github.com/settings/apps/new with these settings:
+  - Name: `ocp-pac-igou` (or similar; the exact name doesn't matter)
+  - Homepage URL: `https://github.com/igou-io`
+  - Webhook URL: `https://placeholder.example.com` (will be updated after Phase 3)
+  - Webhook secret: (generate a 32-byte random string; save it)
+  - Permissions: `Checks: Read & Write`, `Contents: Read`, `Issues: Read & Write`, `Metadata: Read`, `Pull requests: Read & Write`
+  - Subscribe to events: `Check run`, `Check suite`, `Commit comment`, `Issue comment`, `Pull request`, `Push`
+  - Where can this be installed: `Only on this account`
+- [ ] User downloads the App's private key (`.pem` file)
+- [ ] User notes the App ID (visible on the App settings page)
+
+### Task 0.2: GitHub App credentials in 1Password
+- [ ] User creates 1Password item `pac-github-app` in the homelab vault with three fields:
+  - `app-id` (the numeric App ID)
+  - `private-key` (paste the entire `.pem` file contents, including BEGIN/END lines)
+  - `webhook-secret` (the random string from Task 0.1)
+
+### Task 0.3: Cosign signing keypair in 1Password
+- [ ] User runs locally: `cosign generate-key-pair` (passphrase prompted, save it)
+- [ ] User creates 1Password item `tekton-chains-signing` with three fields:
+  - `cosign.key` (contents of `cosign.key`)
+  - `cosign.password` (the passphrase)
+  - `cosign.pub` (contents of `cosign.pub`)
+
+### Task 0.4: Tailscale ACL updated
+- [ ] User edits the tailnet ACL (https://login.tailscale.com/admin/acls) to grant `funnel` to the operator's device tag. Add to `nodeAttrs`:
+  ```jsonc
+  {
+    "target": ["tag:k8s"],
+    "attr": ["funnel"]
+  }
+  ```
+  (Verify the actual tag the tailscale-operator uses — check `mcp__kubernetes__resources_get` on the operator's `Connector` or similar; common defaults are `tag:k8s` or `tag:k8s-operator`.)
+
+**Checkpoint:** All four 0.x tasks complete before Phase 1 starts.
+
+---
+
+## Phase 1 — Operator-side resources
+
+Adds the TektonConfig, ExternalSecrets, Funnel Service, and PriorityClass to the existing `components/openshift-pipelines/` component.
+
+### Task 1.1: PriorityClass for low-priority CI pods
+
+**Files:**
+- Create: `components/openshift-pipelines/tekton-ci-low-priorityclass.yaml`
+
+- [ ] **Step 1: Write the PriorityClass manifest**
+
+```yaml
+---
+apiVersion: scheduling.k8s.io/v1
+kind: PriorityClass
+metadata:
+  name: tekton-ci-low
+  annotations:
+    argocd.argoproj.io/sync-wave: "10"
+value: 100
+globalDefault: false
+description: PR PipelineRun pods. Preempted under cluster pressure.
+preemptionPolicy: PreemptLowerPriority
+```
+
+- [ ] **Step 2: Validate the manifest with kubeconform**
+
+Run: `kubeconform -strict -summary components/openshift-pipelines/tekton-ci-low-priorityclass.yaml`
+Expected: `Summary: 1 resource found in 1 file - Valid: 1, Invalid: 0, Errors: 0, Skipped: 0`
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add components/openshift-pipelines/tekton-ci-low-priorityclass.yaml
+git commit -m "Add tekton-ci-low PriorityClass for PR PipelineRun pods"
+```
+
+### Task 1.2: TektonConfig CR
+
+**Files:**
+- Create: `components/openshift-pipelines/tektonconfig.yaml`
+
+- [ ] **Step 1: Write the TektonConfig manifest**
+
+```yaml
+---
+apiVersion: operator.tekton.dev/v1alpha1
+kind: TektonConfig
+metadata:
+  name: config
+  annotations:
+    argocd.argoproj.io/sync-wave: "11"
+    argocd.argoproj.io/sync-options: SkipDryRunOnMissingResource=true,ServerSideApply=true
+spec:
+  profile: all
+  targetNamespace: openshift-pipelines
+  pruner:
+    disabled: false
+    schedule: "0 4 * * *"
+    keep: 20
+    keep-since: 10080
+    resources:
+      - pipelinerun
+      - taskrun
+  pipeline:
+    enable-bundles-resolver: true
+    enable-cluster-resolver: true
+    enable-git-resolver: true
+    enable-hub-resolver: true
+    default-service-account: pipeline-sa
+    default-timeout-minutes: 60
+    enable-step-actions: true
+    default-pod-template:
+      securityContext:
+        runAsNonRoot: true
+        seccompProfile:
+          type: RuntimeDefault
+      automountServiceAccountToken: false
+      enableServiceLinks: false
+      priorityClassName: tekton-ci-low
+  chain:
+    artifacts.taskrun.format: in-toto
+    artifacts.taskrun.storage: oci
+    artifacts.pipelinerun.format: in-toto
+    artifacts.pipelinerun.storage: oci
+    artifacts.oci.storage: oci
+    transparency.enabled: false
+    signers.x509.fulcio.enabled: false
+  platforms:
+    openshift:
+      pipelinesAsCode:
+        enable: true
+        settings:
+          application-name: OpenShift Pipelines (homelab)
+          auto-configure-new-github-repo: false
+          secret-auto-create: true
+          remote-tasks: true
+          max-keep-runs: "10"
+          enable-cancel-in-progress: "true"
+          custom-console-name: OpenShift Console
+          custom-console-url: https://console-openshift-console.apps.ocp.igou.systems
+          custom-console-url-pr-details: |
+            {{.openshift_console_url}}/k8s/ns/{{.namespace}}/tekton.dev~v1~PipelineRun/{{.pr}}
+          custom-console-url-pr-tasklog: |
+            {{.openshift_console_url}}/k8s/ns/{{.namespace}}/tekton.dev~v1~PipelineRun/{{.pr}}/logs/{{.task}}
+```
+
+- [ ] **Step 2: Verify the schema is fetchable** (TektonConfig CRD lives in operator.tekton.dev/v1alpha1 — datreeio/CRDs-catalog has it; if not, kubeconform will skip with `-ignore-missing-schemas`)
+
+Run: `kubeconform -strict -ignore-missing-schemas -summary components/openshift-pipelines/tektonconfig.yaml`
+Expected: `Valid: 1` OR `Skipped: 1` (skipped is acceptable; the operator validates on apply).
+
+- [ ] **Step 3: yamllint passes**
+
+Run: `yamllint -c .yamllint components/openshift-pipelines/tektonconfig.yaml`
+Expected: no output (clean) or only document-start warnings (already accepted by the project config).
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add components/openshift-pipelines/tektonconfig.yaml
+git commit -m "Add TektonConfig with PaC, Chains, pruner, and resolver tuning"
+```
+
+### Task 1.3: GitHub App ExternalSecret
+
+**Files:**
+- Create: `components/openshift-pipelines/pac-github-app-externalsecret.yaml`
+
+- [ ] **Step 1: Verify the existing 1Password ClusterSecretStore name**
+
+Run: `mcp__kubernetes__resources_list` for `external-secrets.io/v1beta1 ClusterSecretStore` and confirm the name is `onepassword`. If different, use that name in step 2.
+
+- [ ] **Step 2: Write the ExternalSecret**
+
+```yaml
+---
+apiVersion: external-secrets.io/v1beta1
+kind: ExternalSecret
+metadata:
+  name: pipelines-as-code-secret
+  namespace: openshift-pipelines
+  annotations:
+    argocd.argoproj.io/sync-wave: "12"
+spec:
+  refreshInterval: 1h
+  secretStoreRef:
+    kind: ClusterSecretStore
+    name: onepassword
+  target:
+    name: pipelines-as-code-secret
+    creationPolicy: Owner
+  data:
+    - secretKey: github-application-id
+      remoteRef:
+        key: pac-github-app
+        property: app-id
+    - secretKey: github-private-key
+      remoteRef:
+        key: pac-github-app
+        property: private-key
+    - secretKey: webhook.secret
+      remoteRef:
+        key: pac-github-app
+        property: webhook-secret
+```
+
+- [ ] **Step 3: Validate**
+
+Run: `kubeconform -strict -ignore-missing-schemas -summary components/openshift-pipelines/pac-github-app-externalsecret.yaml`
+Expected: `Valid: 1` or `Skipped: 1`.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add components/openshift-pipelines/pac-github-app-externalsecret.yaml
+git commit -m "Add ExternalSecret for PaC GitHub App credentials"
+```
+
+### Task 1.4: Cosign signing ExternalSecret
+
+**Files:**
+- Create: `components/openshift-pipelines/chains-signing-externalsecret.yaml`
+
+- [ ] **Step 1: Write the ExternalSecret**
+
+The `tekton-chains` namespace is created by the operator when Chains is enabled (via `profile: all` + `chain:` settings). The ExternalSecret targets that namespace.
+
+```yaml
+---
+apiVersion: external-secrets.io/v1beta1
+kind: ExternalSecret
+metadata:
+  name: signing-secrets
+  namespace: tekton-chains
+  annotations:
+    argocd.argoproj.io/sync-wave: "12"
+    argocd.argoproj.io/sync-options: SkipDryRunOnMissingResource=true
+spec:
+  refreshInterval: 1h
+  secretStoreRef:
+    kind: ClusterSecretStore
+    name: onepassword
+  target:
+    name: signing-secrets
+    creationPolicy: Owner
+  data:
+    - secretKey: cosign.key
+      remoteRef:
+        key: tekton-chains-signing
+        property: cosign.key
+    - secretKey: cosign.password
+      remoteRef:
+        key: tekton-chains-signing
+        property: cosign.password
+    - secretKey: cosign.pub
+      remoteRef:
+        key: tekton-chains-signing
+        property: cosign.pub
+```
+
+- [ ] **Step 2: Validate**
+
+Run: `kubeconform -strict -ignore-missing-schemas -summary components/openshift-pipelines/chains-signing-externalsecret.yaml`
+Expected: `Valid: 1` or `Skipped: 1`.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add components/openshift-pipelines/chains-signing-externalsecret.yaml
+git commit -m "Add ExternalSecret for Tekton Chains cosign signing key"
+```
+
+### Task 1.5: Funnel Service for PaC controller
+
+**Files:**
+- Create: `components/openshift-pipelines/pac-controller-funnel-service.yaml`
+
+- [ ] **Step 1: Verify the live PaC controller Service selector labels**
+
+Run: `mcp__kubernetes__resources_get` for `v1 Service` named `pipelines-as-code-controller` in `openshift-pipelines` namespace (only works after operator reconciles the existing Subscription). Read `.spec.selector` and capture the actual labels — they may differ from the spec's assumption.
+
+If the namespace doesn't exist yet (operator hasn't installed PaC because TektonConfig isn't synced), use the spec's assumed labels (`app.kubernetes.io/name: controller`, `app.kubernetes.io/part-of: pipelines-as-code`) and verify after sync.
+
+- [ ] **Step 2: Write the Funnel Service**
+
+```yaml
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: pac-controller-funnel
+  namespace: openshift-pipelines
+  annotations:
+    tailscale.com/expose: "true"
+    tailscale.com/funnel: "true"
+    tailscale.com/hostname: pac-ocp
+    argocd.argoproj.io/sync-wave: "13"
+    argocd.argoproj.io/sync-options: SkipDryRunOnMissingResource=true
+spec:
+  type: ClusterIP
+  selector:
+    app.kubernetes.io/name: controller
+    app.kubernetes.io/part-of: pipelines-as-code
+  ports:
+    - name: http
+      port: 8080
+      targetPort: 8080
+      protocol: TCP
+```
+
+- [ ] **Step 3: Validate**
+
+Run: `kubeconform -strict -summary components/openshift-pipelines/pac-controller-funnel-service.yaml`
+Expected: `Valid: 1`.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add components/openshift-pipelines/pac-controller-funnel-service.yaml
+git commit -m "Expose PaC controller via Tailscale Funnel"
+```
+
+### Task 1.6: Update component kustomization
+
+**Files:**
+- Modify: `components/openshift-pipelines/kustomization.yaml`
+
+- [ ] **Step 1: Read the current file**
+
+Current contents:
+```yaml
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+- openshift-pipelines-operator-subscription.yaml
+```
+
+- [ ] **Step 2: Add all new resources**
+
+```yaml
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - openshift-pipelines-operator-subscription.yaml
+  - tekton-ci-low-priorityclass.yaml
+  - tektonconfig.yaml
+  - pac-github-app-externalsecret.yaml
+  - chains-signing-externalsecret.yaml
+  - pac-controller-funnel-service.yaml
+```
+
+- [ ] **Step 3: Validate the kustomization builds**
+
+Run: `kustomize build --enable-helm components/openshift-pipelines/ > /tmp/pipelines-render.yaml && wc -l /tmp/pipelines-render.yaml`
+Expected: 100+ lines. No errors.
+
+- [ ] **Step 4: Validate rendered output with kubeconform**
+
+Run: `kustomize build --enable-helm components/openshift-pipelines/ | kubeconform -strict -ignore-missing-schemas -summary`
+Expected: All resources Valid or Skipped (Subscription/TektonConfig may skip due to missing schemas; Service/PriorityClass/ExternalSecret should validate).
+
+- [ ] **Step 5: yamllint passes for the whole component**
+
+Run: `yamllint -c .yamllint components/openshift-pipelines/`
+Expected: clean.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add components/openshift-pipelines/kustomization.yaml
+git commit -m "Wire new openshift-pipelines resources into kustomization"
+```
+
+### Task 1.7: Run repo-wide make test
+
+- [ ] **Step 1: Run all validators**
+
+Run: `make test`
+Expected: lint, validate-kustomize, validate-schemas all pass. The new pipelines component appears in the output as `✅ components/openshift-pipelines`.
+
+If any failure: read the error, fix, re-run. Do not commit the fix as a separate task — amend the most recent commit if the failure is in code added in this phase, or fix-forward with a new commit if it's pre-existing.
+
+---
+
+## Phase 2 — pac-tenant Helm chart
+
+Builds the chart at `.helm/charts/pac-tenant/` with templates iterating over a `tenants:` list. Each subtask develops one template + a fixture-based render test.
+
+**Files in this phase:**
+- Create: `.helm/charts/pac-tenant/Chart.yaml`
+- Create: `.helm/charts/pac-tenant/values.yaml`
+- Create: `.helm/charts/pac-tenant/templates/_helpers.tpl`
+- Create: `.helm/charts/pac-tenant/templates/namespace.yaml`
+- Create: `.helm/charts/pac-tenant/templates/serviceaccount.yaml`
+- Create: `.helm/charts/pac-tenant/templates/networkpolicies.yaml`
+- Create: `.helm/charts/pac-tenant/templates/resourcequota.yaml`
+- Create: `.helm/charts/pac-tenant/templates/limitrange.yaml`
+- Create: `.helm/charts/pac-tenant/templates/repository.yaml`
+- Create: `.helm/charts/pac-tenant/templates/externalsecrets.yaml`
+- Create (test fixture): `.helm/charts/pac-tenant/test-values.yaml` (gitignored or kept; we keep it for repeatable testing)
+
+### Task 2.1: Chart skeleton
+
+- [ ] **Step 1: Create Chart.yaml**
+
+File: `.helm/charts/pac-tenant/Chart.yaml`
+
+```yaml
+apiVersion: v2
+name: pac-tenant
+version: 0.1.0
+description: Per-repository OpenShift Pipelines as Code tenant resources — namespace, ServiceAccount, NetworkPolicies, ResourceQuota, LimitRange, Repository CR, and optional ExternalSecrets, defined declaratively as a list in values.tenants.
+type: application
+kubeVersion: '>=1.28.0'
+maintainers:
+  - name: David Igou
+```
+
+- [ ] **Step 2: Create values.yaml with schema + empty list**
+
+File: `.helm/charts/pac-tenant/values.yaml`
+
+```yaml
+---
+defaults:
+  concurrencyLimit: 2
+  cancelInProgress: true
+
+  policy:
+    pullRequest:
+      - igou-david
+    okToTest:
+      - igou-david
+
+  quota:
+    requests.cpu: "8"
+    requests.memory: 16Gi
+    limits.cpu: "16"
+    limits.memory: 32Gi
+    pods: "20"
+    persistentvolumeclaims: "5"
+    requests.storage: 50Gi
+
+  limitRange:
+    defaultRequest:
+      cpu: 100m
+      memory: 256Mi
+    default:
+      cpu: 500m
+      memory: 1Gi
+    max:
+      cpu: "4"
+      memory: 8Gi
+
+  egressBlockedCIDRs:
+    - 10.128.0.0/14
+    - 172.30.0.0/16
+    - 169.254.169.254/32
+    - 192.168.0.0/16
+    - 10.0.0.0/8
+
+# tenants is the list of onboarded repositories. Each entry can override
+# any field from defaults; unspecified fields inherit defaults.
+#
+# Schema:
+#   - name: <slug used for namespace name>             # required, matches ^[a-z0-9-]+$
+#     url:  <full https github URL of the repo>        # required
+#     concurrencyLimit: <int>                          # optional, defaults to 2
+#     cancelInProgress: <bool>                         # optional
+#     policy:
+#       pullRequest: [<gh-username>, ...]              # optional
+#       okToTest:    [<gh-username>, ...]              # optional; auto-collapsed to pullRequest when secrets present
+#     quota: { ... }                                   # optional, full ResourceQuota.spec.hard map
+#     limitRange: { ... }                              # optional
+#     egressBlockedCIDRs: [<cidr>, ...]                # optional
+#     secrets:
+#       imagePullSecrets:                              # attached to pipeline-sa.imagePullSecrets
+#         - name: <k8s-secret-name>
+#           onepasswordItem: <1pwd-item-name>
+#       workspaceSecrets:                              # available to PipelineRun via workspace mount
+#         - name: <k8s-secret-name>
+#           onepasswordItem: <1pwd-item-name>
+tenants: []
+
+# Cluster constants — usually no need to override.
+clusterSecretStore: onepassword
+namespacePrefix: ci-
+```
+
+- [ ] **Step 3: Create test-values.yaml fixture (used for render testing throughout Phase 2)**
+
+File: `.helm/charts/pac-tenant/test-values.yaml`
+
+```yaml
+---
+tenants:
+  - name: simple-tenant
+    url: https://github.com/igou-io/simple-tenant
+
+  - name: secrets-tenant
+    url: https://github.com/igou-io/secrets-tenant
+    secrets:
+      imagePullSecrets:
+        - name: ghcr-readonly
+          onepasswordItem: ci-ghcr-readonly
+      workspaceSecrets:
+        - name: snyk-org-token
+          onepasswordItem: ci-snyk-org
+
+  - name: heavy-tenant
+    url: https://github.com/igou-io/heavy-tenant
+    quota:
+      requests.cpu: "16"
+      requests.memory: 32Gi
+      limits.cpu: "32"
+      limits.memory: 64Gi
+    concurrencyLimit: 1
+```
+
+- [ ] **Step 4: Verify the chart skeleton parses**
+
+Run: `helm lint .helm/charts/pac-tenant/`
+Expected: `[INFO] Chart.yaml: ...`, `1 chart(s) linted, 0 chart(s) failed`. (Chart has no templates yet — that's fine.)
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add .helm/charts/pac-tenant/Chart.yaml .helm/charts/pac-tenant/values.yaml .helm/charts/pac-tenant/test-values.yaml
+git commit -m "Add pac-tenant Helm chart skeleton with values schema"
+```
+
+### Task 2.2: _helpers.tpl with merge logic and shared computations
+
+**Files:**
+- Create: `.helm/charts/pac-tenant/templates/_helpers.tpl`
+
+- [ ] **Step 1: Write _helpers.tpl**
+
+```yaml
+{{/*
+pac-tenant.merged — returns the per-tenant config with defaults merged underneath.
+Per-tenant values take precedence. Use:
+  {{- $cfg := include "pac-tenant.merged" (dict "root" . "tenant" $tenant) | fromYaml -}}
+*/}}
+{{- define "pac-tenant.merged" -}}
+{{- $defaults := deepCopy .root.Values.defaults -}}
+{{- $tenant := .tenant -}}
+{{- $merged := mergeOverwrite $defaults (deepCopy $tenant) -}}
+{{- toYaml $merged -}}
+{{- end -}}
+
+{{/*
+pac-tenant.namespace — derives the namespace name from tenant.name + namespacePrefix.
+*/}}
+{{- define "pac-tenant.namespace" -}}
+{{- printf "%s%s" .root.Values.namespacePrefix .tenant.name -}}
+{{- end -}}
+
+{{/*
+pac-tenant.hasSecrets — returns "true" if the tenant declares any secrets, "" otherwise.
+*/}}
+{{- define "pac-tenant.hasSecrets" -}}
+{{- $s := .tenant.secrets | default dict -}}
+{{- if or (and $s.imagePullSecrets (gt (len $s.imagePullSecrets) 0)) (and $s.workspaceSecrets (gt (len $s.workspaceSecrets) 0)) -}}
+true
+{{- end -}}
+{{- end -}}
+
+{{/*
+pac-tenant.okToTest — returns the effective ok-to-test list for a tenant.
+If the tenant has any secrets, this collapses to the pullRequest list (no widening allowed).
+Otherwise returns the configured okToTest (default merged).
+*/}}
+{{- define "pac-tenant.okToTest" -}}
+{{- $cfg := include "pac-tenant.merged" (dict "root" .root "tenant" .tenant) | fromYaml -}}
+{{- if include "pac-tenant.hasSecrets" (dict "tenant" .tenant) -}}
+{{- toYaml $cfg.policy.pullRequest -}}
+{{- else -}}
+{{- toYaml $cfg.policy.okToTest -}}
+{{- end -}}
+{{- end -}}
+
+{{/*
+pac-tenant.labels — labels applied to every resource the chart produces.
+*/}}
+{{- define "pac-tenant.labels" -}}
+app.kubernetes.io/managed-by: helm
+app.kubernetes.io/part-of: pac-tenants
+igou.systems/pac-tenant: {{ .tenant.name | quote }}
+{{- end -}}
+```
+
+- [ ] **Step 2: Verify chart still lints**
+
+Run: `helm lint .helm/charts/pac-tenant/`
+Expected: passes.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add .helm/charts/pac-tenant/templates/_helpers.tpl
+git commit -m "Add _helpers.tpl with merge, namespace, ok-to-test logic"
+```
+
+### Task 2.3: namespace.yaml template
+
+**Files:**
+- Create: `.helm/charts/pac-tenant/templates/namespace.yaml`
+
+- [ ] **Step 1: Write the template**
+
+```yaml
+{{- range $tenant := .Values.tenants }}
+{{- $ns := include "pac-tenant.namespace" (dict "root" $ "tenant" $tenant) }}
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: {{ $ns | quote }}
+  labels:
+    igou.systems/tenant-type: pac-ci
+    pod-security.kubernetes.io/enforce: restricted
+    pod-security.kubernetes.io/enforce-version: latest
+    {{- include "pac-tenant.labels" (dict "tenant" $tenant) | nindent 4 }}
+  annotations:
+    openshift.io/description: "PaC CI tenant for {{ $tenant.url }}"
+    argocd.argoproj.io/sync-wave: "20"
+{{- end }}
+```
+
+- [ ] **Step 2: Render with the test fixture**
+
+Run: `helm template pac-tenants .helm/charts/pac-tenant/ -f .helm/charts/pac-tenant/test-values.yaml --show-only templates/namespace.yaml > /tmp/ns.yaml && cat /tmp/ns.yaml`
+Expected: 3 Namespace documents (`ci-simple-tenant`, `ci-secrets-tenant`, `ci-heavy-tenant`), each with the PSA labels and the part-of/managed-by labels.
+
+- [ ] **Step 3: Validate the render**
+
+Run: `helm template pac-tenants .helm/charts/pac-tenant/ -f .helm/charts/pac-tenant/test-values.yaml --show-only templates/namespace.yaml | kubeconform -strict -summary`
+Expected: `Valid: 3`.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add .helm/charts/pac-tenant/templates/namespace.yaml
+git commit -m "Add namespace template to pac-tenant chart"
+```
+
+### Task 2.4: serviceaccount.yaml template
+
+**Files:**
+- Create: `.helm/charts/pac-tenant/templates/serviceaccount.yaml`
+
+- [ ] **Step 1: Write the template**
+
+The SA is `pipeline-sa` per tenant. If the tenant declares `secrets.imagePullSecrets`, those names are appended to `imagePullSecrets`. `automountServiceAccountToken: false` always.
+
+```yaml
+{{- range $tenant := .Values.tenants }}
+{{- $ns := include "pac-tenant.namespace" (dict "root" $ "tenant" $tenant) }}
+{{- $imagePullSecrets := list }}
+{{- if $tenant.secrets }}
+{{- range $secret := ($tenant.secrets.imagePullSecrets | default list) }}
+{{- $imagePullSecrets = append $imagePullSecrets (dict "name" $secret.name) }}
+{{- end }}
+{{- end }}
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: pipeline-sa
+  namespace: {{ $ns | quote }}
+  annotations:
+    argocd.argoproj.io/sync-wave: "21"
+  labels:
+    {{- include "pac-tenant.labels" (dict "tenant" $tenant) | nindent 4 }}
+automountServiceAccountToken: false
+{{- if $imagePullSecrets }}
+imagePullSecrets:
+{{- toYaml $imagePullSecrets | nindent 2 }}
+{{- end }}
+{{- end }}
+```
+
+- [ ] **Step 2: Render and inspect**
+
+Run: `helm template pac-tenants .helm/charts/pac-tenant/ -f .helm/charts/pac-tenant/test-values.yaml --show-only templates/serviceaccount.yaml`
+Expected:
+- `simple-tenant` SA: no imagePullSecrets stanza.
+- `secrets-tenant` SA: `imagePullSecrets: [{name: ghcr-readonly}]`.
+- `heavy-tenant` SA: no imagePullSecrets stanza.
+- All three: `automountServiceAccountToken: false`.
+
+- [ ] **Step 3: Validate**
+
+Run: `helm template pac-tenants .helm/charts/pac-tenant/ -f .helm/charts/pac-tenant/test-values.yaml --show-only templates/serviceaccount.yaml | kubeconform -strict -summary`
+Expected: `Valid: 3`.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add .helm/charts/pac-tenant/templates/serviceaccount.yaml
+git commit -m "Add pipeline-sa template with optional imagePullSecrets"
+```
+
+### Task 2.5: networkpolicies.yaml template
+
+**Files:**
+- Create: `.helm/charts/pac-tenant/templates/networkpolicies.yaml`
+
+- [ ] **Step 1: Write the template — three NetworkPolicies per tenant**
+
+```yaml
+{{- range $tenant := .Values.tenants }}
+{{- $ns := include "pac-tenant.namespace" (dict "root" $ "tenant" $tenant) }}
+{{- $cfg := include "pac-tenant.merged" (dict "root" $ "tenant" $tenant) | fromYaml }}
+---
+# Default-deny all ingress and egress.
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: default-deny-all
+  namespace: {{ $ns | quote }}
+  annotations:
+    argocd.argoproj.io/sync-wave: "21"
+  labels:
+    {{- include "pac-tenant.labels" (dict "tenant" $tenant) | nindent 4 }}
+spec:
+  podSelector: {}
+  policyTypes:
+    - Ingress
+    - Egress
+---
+# Allow DNS to openshift-dns.
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: allow-dns
+  namespace: {{ $ns | quote }}
+  annotations:
+    argocd.argoproj.io/sync-wave: "21"
+  labels:
+    {{- include "pac-tenant.labels" (dict "tenant" $tenant) | nindent 4 }}
+spec:
+  podSelector: {}
+  policyTypes:
+    - Egress
+  egress:
+    - to:
+        - namespaceSelector:
+            matchLabels:
+              kubernetes.io/metadata.name: openshift-dns
+      ports:
+        - port: 53
+          protocol: UDP
+        - port: 53
+          protocol: TCP
+---
+# Allow external HTTPS/HTTP egress, block intra-cluster + LAN.
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: allow-external-egress
+  namespace: {{ $ns | quote }}
+  annotations:
+    argocd.argoproj.io/sync-wave: "21"
+  labels:
+    {{- include "pac-tenant.labels" (dict "tenant" $tenant) | nindent 4 }}
+spec:
+  podSelector: {}
+  policyTypes:
+    - Egress
+  egress:
+    - to:
+        - ipBlock:
+            cidr: 0.0.0.0/0
+            except:
+{{- range $cidr := $cfg.egressBlockedCIDRs }}
+              - {{ $cidr | quote }}
+{{- end }}
+      ports:
+        - port: 443
+          protocol: TCP
+        - port: 80
+          protocol: TCP
+{{- end }}
+```
+
+- [ ] **Step 2: Render and inspect**
+
+Run: `helm template pac-tenants .helm/charts/pac-tenant/ -f .helm/charts/pac-tenant/test-values.yaml --show-only templates/networkpolicies.yaml | grep -c '^kind: NetworkPolicy'`
+Expected: `9` (3 NetworkPolicies × 3 tenants).
+
+- [ ] **Step 3: Spot-check that egressBlockedCIDRs are inserted correctly**
+
+Run: `helm template pac-tenants .helm/charts/pac-tenant/ -f .helm/charts/pac-tenant/test-values.yaml --show-only templates/networkpolicies.yaml | grep -c '192.168.0.0/16'`
+Expected: `3` (one per tenant; defaults applied).
+
+- [ ] **Step 4: Validate**
+
+Run: `helm template pac-tenants .helm/charts/pac-tenant/ -f .helm/charts/pac-tenant/test-values.yaml --show-only templates/networkpolicies.yaml | kubeconform -strict -summary`
+Expected: `Valid: 9`.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add .helm/charts/pac-tenant/templates/networkpolicies.yaml
+git commit -m "Add NetworkPolicy template (default-deny + DNS + external)"
+```
+
+### Task 2.6: resourcequota.yaml template
+
+**Files:**
+- Create: `.helm/charts/pac-tenant/templates/resourcequota.yaml`
+
+- [ ] **Step 1: Write the template**
+
+```yaml
+{{- range $tenant := .Values.tenants }}
+{{- $ns := include "pac-tenant.namespace" (dict "root" $ "tenant" $tenant) }}
+{{- $cfg := include "pac-tenant.merged" (dict "root" $ "tenant" $tenant) | fromYaml }}
+---
+apiVersion: v1
+kind: ResourceQuota
+metadata:
+  name: ci-quota
+  namespace: {{ $ns | quote }}
+  annotations:
+    argocd.argoproj.io/sync-wave: "21"
+  labels:
+    {{- include "pac-tenant.labels" (dict "tenant" $tenant) | nindent 4 }}
+spec:
+  hard:
+{{- range $key, $value := $cfg.quota }}
+    {{ $key }}: {{ $value | quote }}
+{{- end }}
+{{- end }}
+```
+
+- [ ] **Step 2: Render and verify per-tenant overrides**
+
+Run: `helm template pac-tenants .helm/charts/pac-tenant/ -f .helm/charts/pac-tenant/test-values.yaml --show-only templates/resourcequota.yaml`
+Expected:
+- `simple-tenant` and `secrets-tenant` show defaults (`requests.cpu: "8"`).
+- `heavy-tenant` shows override (`requests.cpu: "16"`, `limits.memory: 64Gi`).
+
+- [ ] **Step 3: Validate**
+
+Run: `helm template pac-tenants .helm/charts/pac-tenant/ -f .helm/charts/pac-tenant/test-values.yaml --show-only templates/resourcequota.yaml | kubeconform -strict -summary`
+Expected: `Valid: 3`.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add .helm/charts/pac-tenant/templates/resourcequota.yaml
+git commit -m "Add ResourceQuota template with per-tenant override support"
+```
+
+### Task 2.7: limitrange.yaml template
+
+**Files:**
+- Create: `.helm/charts/pac-tenant/templates/limitrange.yaml`
+
+- [ ] **Step 1: Write the template**
+
+```yaml
+{{- range $tenant := .Values.tenants }}
+{{- $ns := include "pac-tenant.namespace" (dict "root" $ "tenant" $tenant) }}
+{{- $cfg := include "pac-tenant.merged" (dict "root" $ "tenant" $tenant) | fromYaml }}
+---
+apiVersion: v1
+kind: LimitRange
+metadata:
+  name: ci-limits
+  namespace: {{ $ns | quote }}
+  annotations:
+    argocd.argoproj.io/sync-wave: "21"
+  labels:
+    {{- include "pac-tenant.labels" (dict "tenant" $tenant) | nindent 4 }}
+spec:
+  limits:
+    - type: Container
+      defaultRequest:
+{{- toYaml $cfg.limitRange.defaultRequest | nindent 8 }}
+      default:
+{{- toYaml $cfg.limitRange.default | nindent 8 }}
+      max:
+{{- toYaml $cfg.limitRange.max | nindent 8 }}
+{{- end }}
+```
+
+- [ ] **Step 2: Render**
+
+Run: `helm template pac-tenants .helm/charts/pac-tenant/ -f .helm/charts/pac-tenant/test-values.yaml --show-only templates/limitrange.yaml`
+Expected: 3 LimitRange resources, defaults applied for all (no override tenant in fixture).
+
+- [ ] **Step 3: Validate**
+
+Run: `helm template pac-tenants .helm/charts/pac-tenant/ -f .helm/charts/pac-tenant/test-values.yaml --show-only templates/limitrange.yaml | kubeconform -strict -summary`
+Expected: `Valid: 3`.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add .helm/charts/pac-tenant/templates/limitrange.yaml
+git commit -m "Add LimitRange template"
+```
+
+### Task 2.8: repository.yaml template (PaC Repository CR)
+
+**Files:**
+- Create: `.helm/charts/pac-tenant/templates/repository.yaml`
+
+- [ ] **Step 1: Write the template**
+
+```yaml
+{{- range $tenant := .Values.tenants }}
+{{- $ns := include "pac-tenant.namespace" (dict "root" $ "tenant" $tenant) }}
+{{- $cfg := include "pac-tenant.merged" (dict "root" $ "tenant" $tenant) | fromYaml }}
+{{- $okToTest := include "pac-tenant.okToTest" (dict "root" $ "tenant" $tenant) | fromYamlArray }}
+---
+apiVersion: pipelinesascode.tekton.dev/v1alpha1
+kind: Repository
+metadata:
+  name: {{ $tenant.name | quote }}
+  namespace: {{ $ns | quote }}
+  annotations:
+    argocd.argoproj.io/sync-wave: "22"
+    argocd.argoproj.io/sync-options: SkipDryRunOnMissingResource=true
+  labels:
+    {{- include "pac-tenant.labels" (dict "tenant" $tenant) | nindent 4 }}
+spec:
+  url: {{ $tenant.url | quote }}
+  concurrency_limit: {{ $cfg.concurrencyLimit }}
+  policy:
+    pull_request:
+{{- range $user := $cfg.policy.pullRequest }}
+      - {{ $user | quote }}
+{{- end }}
+    ok_to_test:
+{{- range $user := $okToTest }}
+      - {{ $user | quote }}
+{{- end }}
+  settings:
+    cancel-in-progress: {{ $cfg.cancelInProgress }}
+{{- end }}
+```
+
+- [ ] **Step 2: Render and verify ok-to-test collapse for the secrets tenant**
+
+Run: `helm template pac-tenants .helm/charts/pac-tenant/ -f .helm/charts/pac-tenant/test-values.yaml --show-only templates/repository.yaml`
+Expected:
+- `simple-tenant` Repository: `pull_request: [igou-david]`, `ok_to_test: [igou-david]`.
+- `secrets-tenant` Repository: `pull_request: [igou-david]`, `ok_to_test: [igou-david]` (same — collapse rule applied because secrets present).
+- `heavy-tenant` Repository: `concurrency_limit: 1`.
+
+- [ ] **Step 3: Validate**
+
+Run: `helm template pac-tenants .helm/charts/pac-tenant/ -f .helm/charts/pac-tenant/test-values.yaml --show-only templates/repository.yaml | kubeconform -strict -ignore-missing-schemas -summary`
+Expected: `Valid: 3` or `Skipped: 3` (Repository CRD may not be in datreeio catalog).
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add .helm/charts/pac-tenant/templates/repository.yaml
+git commit -m "Add Repository template with auto-collapsed ok-to-test"
+```
+
+### Task 2.9: externalsecrets.yaml template
+
+**Files:**
+- Create: `.helm/charts/pac-tenant/templates/externalsecrets.yaml`
+
+- [ ] **Step 1: Write the template — one ES per imagePullSecret + workspaceSecret**
+
+```yaml
+{{- range $tenant := .Values.tenants }}
+{{- $ns := include "pac-tenant.namespace" (dict "root" $ "tenant" $tenant) }}
+{{- if $tenant.secrets }}
+
+{{- range $secret := ($tenant.secrets.imagePullSecrets | default list) }}
+---
+apiVersion: external-secrets.io/v1beta1
+kind: ExternalSecret
+metadata:
+  name: {{ $secret.name | quote }}
+  namespace: {{ $ns | quote }}
+  annotations:
+    argocd.argoproj.io/sync-wave: "21"
+  labels:
+    {{- include "pac-tenant.labels" (dict "tenant" $tenant) | nindent 4 }}
+spec:
+  refreshInterval: 1h
+  secretStoreRef:
+    kind: ClusterSecretStore
+    name: {{ $.Values.clusterSecretStore | quote }}
+  target:
+    name: {{ $secret.name | quote }}
+    creationPolicy: Owner
+    template:
+      type: kubernetes.io/dockerconfigjson
+      data:
+        .dockerconfigjson: "{{ `{{ .dockerconfigjson }}` }}"
+  data:
+    - secretKey: dockerconfigjson
+      remoteRef:
+        key: {{ $secret.onepasswordItem | quote }}
+        property: dockerconfigjson
+{{- end }}
+
+{{- range $secret := ($tenant.secrets.workspaceSecrets | default list) }}
+---
+apiVersion: external-secrets.io/v1beta1
+kind: ExternalSecret
+metadata:
+  name: {{ $secret.name | quote }}
+  namespace: {{ $ns | quote }}
+  annotations:
+    argocd.argoproj.io/sync-wave: "21"
+  labels:
+    {{- include "pac-tenant.labels" (dict "tenant" $tenant) | nindent 4 }}
+spec:
+  refreshInterval: 1h
+  secretStoreRef:
+    kind: ClusterSecretStore
+    name: {{ $.Values.clusterSecretStore | quote }}
+  target:
+    name: {{ $secret.name | quote }}
+    creationPolicy: Owner
+  dataFrom:
+    - extract:
+        key: {{ $secret.onepasswordItem | quote }}
+{{- end }}
+
+{{- end }}
+{{- end }}
+```
+
+- [ ] **Step 2: Render and verify**
+
+Run: `helm template pac-tenants .helm/charts/pac-tenant/ -f .helm/charts/pac-tenant/test-values.yaml --show-only templates/externalsecrets.yaml`
+Expected:
+- `simple-tenant` and `heavy-tenant` produce no output (no `secrets:` block).
+- `secrets-tenant` produces 2 ExternalSecrets:
+  - `ghcr-readonly` (type dockerconfigjson, points at 1pwd item `ci-ghcr-readonly`).
+  - `snyk-org-token` (type Opaque via dataFrom.extract, points at `ci-snyk-org`).
+
+- [ ] **Step 3: Validate**
+
+Run: `helm template pac-tenants .helm/charts/pac-tenant/ -f .helm/charts/pac-tenant/test-values.yaml --show-only templates/externalsecrets.yaml | kubeconform -strict -ignore-missing-schemas -summary`
+Expected: `Valid: 2` or `Skipped: 2`.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add .helm/charts/pac-tenant/templates/externalsecrets.yaml
+git commit -m "Add ExternalSecret template for imagePullSecrets and workspaceSecrets"
+```
+
+### Task 2.10: End-to-end chart render test
+
+- [ ] **Step 1: Render the entire chart with the test fixture**
+
+Run: `helm template pac-tenants .helm/charts/pac-tenant/ -f .helm/charts/pac-tenant/test-values.yaml > /tmp/all.yaml && wc -l /tmp/all.yaml`
+Expected: 200+ lines, no errors.
+
+- [ ] **Step 2: Resource counts**
+
+Run: `grep -c '^kind:' /tmp/all.yaml`
+Expected: `17` (3 Namespace + 3 SA + 9 NetworkPolicy + 3 ResourceQuota + 3 LimitRange + 3 Repository + 2 ExternalSecret = 26... wait, recount).
+
+Verify the breakdown:
+```bash
+grep '^kind:' /tmp/all.yaml | sort | uniq -c
+```
+Expected:
+```
+   2 ExternalSecret
+   3 LimitRange
+   3 Namespace
+   9 NetworkPolicy
+   3 Repository
+   3 ResourceQuota
+   3 ServiceAccount
+```
+Total: 26 resources.
+
+- [ ] **Step 3: Render with empty tenants (the production-bootstrap case)**
+
+Run: `helm template pac-tenants .helm/charts/pac-tenant/ > /tmp/empty.yaml && grep -c '^kind:' /tmp/empty.yaml || true`
+Expected: `0` (empty `tenants: []` from default values renders no resources).
+
+- [ ] **Step 4: Validate the full render with kubeconform**
+
+Run: `helm template pac-tenants .helm/charts/pac-tenant/ -f .helm/charts/pac-tenant/test-values.yaml | kubeconform -strict -ignore-missing-schemas -summary`
+Expected: All Valid or Skipped, zero Invalid.
+
+- [ ] **Step 5: helm lint**
+
+Run: `helm lint .helm/charts/pac-tenant/`
+Expected: passes.
+
+- [ ] **Step 6: yamllint the chart**
+
+Run: `yamllint -c .yamllint .helm/charts/pac-tenant/`
+Expected: clean (the chart itself is plain YAML; templates are excluded by Helm convention but yamllint may complain about Go template syntax — if so, add `.helm/charts/pac-tenant/templates/` to `.yamllint` ignore list).
+
+If yamllint complains about templates: edit `.yamllint` and add `.helm/charts/*/templates/` to the `ignore:` list. Commit that change separately.
+
+- [ ] **Step 7: Commit (if test-values.yaml or .yamllint changed)**
+
+If no changes are needed (clean state from Tasks 2.1–2.9), skip this step.
+
+```bash
+git add .yamllint  # if modified
+git commit -m "Exclude helm chart templates from yamllint"
+```
+
+---
+
+## Phase 3 — Cluster instantiation
+
+### Task 3.1: Create clusters/ocp/pac-tenants/ kustomization
+
+**Files:**
+- Create: `clusters/ocp/pac-tenants/kustomization.yaml`
+- Create: `clusters/ocp/pac-tenants/values.yaml`
+
+- [ ] **Step 1: Create kustomization.yaml that wraps the chart**
+
+Path: `clusters/ocp/pac-tenants/kustomization.yaml`
+
+```yaml
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+helmCharts:
+  - name: pac-tenant
+    path: ../../../.helm/charts/pac-tenant
+    releaseName: pac-tenants
+    valuesFile: values.yaml
+    includeCRDs: false
+```
+
+- [ ] **Step 2: Create empty cluster values**
+
+Path: `clusters/ocp/pac-tenants/values.yaml`
+
+```yaml
+---
+# PaC tenants for the OCP cluster.
+# Schema and defaults: see .helm/charts/pac-tenant/values.yaml
+#
+# Tenants are added/removed via the /scaffold-pac-tenant skill.
+tenants: []
+```
+
+- [ ] **Step 3: Build and verify**
+
+Run: `kustomize build --enable-helm clusters/ocp/pac-tenants/`
+Expected: empty output (no tenants → no resources).
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add clusters/ocp/pac-tenants/
+git commit -m "Add empty pac-tenants instantiation for OCP cluster"
+```
+
+### Task 3.2: Wire pac-tenants into the cluster app-of-apps
+
+**Files:**
+- Modify: `clusters/ocp/values.yaml`
+
+- [ ] **Step 1: Read the current `clusters/ocp/values.yaml`**
+
+The file uses the app-of-apps pattern with one entry per app. New entry goes alongside `openshift-pipelines`.
+
+- [ ] **Step 2: Add the pac-tenants entry**
+
+Append after the `openshift-pipelines:` block (find that block first, place this immediately after, preserving alphabetical-ish ordering since neighboring entries already mix it):
+
+```yaml
+  pac-tenants:
+    annotations:
+      argocd.argoproj.io/sync-wave: '20'
+    source:
+      path: clusters/ocp/pac-tenants
+```
+
+- [ ] **Step 3: Validate the full app-of-apps render**
+
+Run: `make validate-kustomize`
+Expected: all kustomizations build successfully, including `clusters/ocp/pac-tenants` (will appear in the output).
+
+- [ ] **Step 4: Validate schemas**
+
+Run: `make validate-schemas`
+Expected: clean (the empty render produces nothing for kubeconform to fail on).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add clusters/ocp/values.yaml
+git commit -m "Wire pac-tenants Application into OCP app-of-apps"
+```
+
+---
+
+## Phase 4 — Makefile updates
+
+### Task 4.1: Add `lint-helm` target
+
+**Files:**
+- Modify: `Makefile`
+
+- [ ] **Step 1: Add a new lint-helm target after `lint:`**
+
+Insert after the `lint:` target (line 6 in current file):
+
+```makefile
+.PHONY: lint-helm
+lint-helm: ## Lint all Helm charts under .helm/charts/
+	@find $(REPO_ROOT)/.helm/charts -mindepth 1 -maxdepth 1 -type d -print0 | \
+		xargs -0 -I{} sh -c 'echo "--- helm lint: {}"; helm lint "{}"'
+```
+
+- [ ] **Step 2: Update the `test:` target to include lint-helm**
+
+Change:
+```makefile
+.PHONY: test
+test: lint validate-kustomize validate-schemas ## Run all tests (lint, validate-kustomize, validate-schemas)
+```
+
+To:
+```makefile
+.PHONY: test
+test: lint lint-helm validate-kustomize validate-schemas ## Run all tests (lint, lint-helm, validate-kustomize, validate-schemas)
+```
+
+- [ ] **Step 3: Verify the new target works**
+
+Run: `make lint-helm`
+Expected: each chart in `.helm/charts/` (argocd-app-of-app, ocp-base-config, pac-tenant) is linted and reports `1 chart(s) linted, 0 chart(s) failed`.
+
+- [ ] **Step 4: Verify make test still passes end-to-end**
+
+Run: `make test`
+Expected: all four sub-targets pass.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add Makefile
+git commit -m "Add make lint-helm target and chain into make test"
+```
+
+---
+
+## Phase 5 — Skills
+
+The skills follow this repo's existing convention: each lives at `.claude/skills/<name>/SKILL.md`, with YAML frontmatter (`name`, `description`, `argument-hint`, `disable-model-invocation: true`, `allowed-tools`).
+
+### Task 5.1: /scaffold-pac-tenant skill
+
+**Files:**
+- Create: `.claude/skills/scaffold-pac-tenant/SKILL.md`
+
+- [ ] **Step 1: Write the skill prompt**
+
+```markdown
+---
+name: scaffold-pac-tenant
+description: Add a new PaC tenant entry to clusters/ocp/pac-tenants/values.yaml. Verifies the GitHub repo exists, derives a name from the URL, applies defaults, supports optional --imagePullSecret and --workspaceSecret flags. Validates the rendered chart with helm template + kubeconform before reporting completion. Does NOT commit — user reviews diffs first.
+argument-hint: <github-url-or-owner/repo> [--imagePullSecret name:1pwd-item] [--workspaceSecret name:1pwd-item ...]
+disable-model-invocation: true
+allowed-tools: Read, Edit, Bash(gh repo view *), Bash(yq *), Bash(helm template *), Bash(kubeconform *), Bash(grep *), Bash(cat *), Bash(ls *)
+---
+
+# Scaffold a PaC tenant
+
+Add one tenant entry to `clusters/ocp/pac-tenants/values.yaml`. The entry will be picked up by ArgoCD on next sync of the `pac-tenants` Application.
+
+## Parsing arguments
+
+`$ARGUMENTS` may contain:
+- A GitHub URL (`https://github.com/<owner>/<repo>`) or `<owner>/<repo>` shorthand. Required.
+- Zero or more `--imagePullSecret <name>:<1pwd-item>` flags.
+- Zero or more `--workspaceSecret <name>:<1pwd-item>` flags.
+
+Examples:
+- `https://github.com/igou-io/igou-openshift`
+- `igou-io/llmkube --imagePullSecret ghcr-readonly:ci-ghcr-readonly`
+- `igou-io/foo --workspaceSecret snyk:ci-snyk-org --workspaceSecret codecov:ci-codecov`
+
+## Step 1: Resolve repo
+
+If the input is a shorthand `owner/repo`, expand to `https://github.com/owner/repo`.
+
+Derive `<tenant-name>` from the repo path (last segment of the URL, lowercase, with non-`[a-z0-9-]` characters replaced by `-`). Confirm the derived name with the user before proceeding.
+
+Verify the repo exists:
+```bash
+gh repo view <owner>/<repo> --json name,visibility,isPrivate
+```
+Refuse to proceed if the command fails.
+
+## Step 2: Check existing values.yaml
+
+Read `clusters/ocp/pac-tenants/values.yaml`. If a tenant with the derived name already exists under `tenants:`, abort with a clear error: "Tenant `<name>` is already defined at line <N> — use Edit to modify it."
+
+## Step 3: Build the new entry
+
+Construct the entry. Minimum:
+```yaml
+- name: <tenant-name>
+  url: <full-https-url>
+```
+
+If `--imagePullSecret name:1pwd-item` flags were passed, add a `secrets.imagePullSecrets:` list. If `--workspaceSecret` flags, add `secrets.workspaceSecrets:`.
+
+Tell the user explicitly: "This tenant has secrets — `okToTest` will be auto-collapsed to the `pullRequest` allowlist by the chart. Adding contributors will require a kustomization commit, not a PR comment."
+
+## Step 4: Insert the entry alphabetically
+
+Edit `clusters/ocp/pac-tenants/values.yaml`. The `tenants:` list should be ordered alphabetically by `name` to keep diffs stable. Insert the new entry at the correct position.
+
+If the list is currently empty (`tenants: []`), replace with `tenants:` on its own line followed by the new entry.
+
+## Step 5: Validate the rendered chart
+
+Run from the repo root:
+```bash
+helm template pac-tenants .helm/charts/pac-tenant/ -f clusters/ocp/pac-tenants/values.yaml > /tmp/pac-render.yaml
+echo "Rendered $(grep -c '^kind:' /tmp/pac-render.yaml) resources"
+kubeconform -strict -ignore-missing-schemas -summary /tmp/pac-render.yaml
+```
+
+If kubeconform reports any Invalid resources, abort and report the errors. Do not leave a broken values.yaml in place; revert the edit.
+
+## Step 6: Report completion
+
+Print to the user:
+- Path of the file modified.
+- Diff of the change (use `git diff` on the file).
+- Reminder: "GitHub App must be installed on this repo. Install URL: <App-page-from-github>/installations/new"
+- Reminder: "Run `/convert-gha-workflow` against the target repo to generate `.tekton/pull-request.yaml`."
+- "User must review and commit. Skill does not auto-commit."
+```
+
+- [ ] **Step 2: Commit**
+
+```bash
+git add .claude/skills/scaffold-pac-tenant/
+git commit -m "Add scaffold-pac-tenant skill"
+```
+
+### Task 5.2: /convert-gha-workflow mappings.yaml
+
+**Files:**
+- Create: `.claude/skills/convert-gha-workflow/mappings.yaml`
+
+- [ ] **Step 1: Write the mapping table**
+
+```yaml
+---
+# GitHub Actions → Tekton mapping table.
+# Used by the /convert-gha-workflow skill.
+#
+# Format:
+#   <action-name>:
+#     mode: image | hub-task | inline | drop | flag-publish | flag-unmapped
+#     image: <image-ref>          # for mode=image
+#     hubTask: <task-name>        # for mode=hub-task
+#     inlineSnippet: |            # for mode=inline (Tekton step yaml fragment)
+#       ...
+#     note: <human-readable note shown in migration report>
+
+actions/checkout:
+  mode: drop
+  note: Checkout is implicit — PaC pre-populates the source workspace with the PR HEAD.
+
+actions/setup-go:
+  mode: image
+  imageTemplate: docker.io/golang:{{ .with.go-version | default "1.22" }}
+  note: setup-go becomes a container image; the rest of the steps in the same job inherit it.
+
+actions/setup-node:
+  mode: image
+  imageTemplate: docker.io/node:{{ .with.node-version | default "20" }}-bookworm
+
+actions/setup-python:
+  mode: image
+  imageTemplate: docker.io/python:{{ .with.python-version | default "3.12" }}
+
+actions/setup-java:
+  mode: image
+  imageTemplate: docker.io/eclipse-temurin:{{ .with.java-version | default "21" }}
+
+actions/cache:
+  mode: flag-unmapped
+  note: Cache via Tekton workspace PVC + cache-key script. Manual translation needed.
+
+docker/setup-buildx-action:
+  mode: drop
+  note: buildah handles cross-platform natively.
+
+docker/setup-qemu-action:
+  mode: flag-unmapped
+  note: Multi-arch buildah is non-trivial. Out of scope for v1; flag for manual.
+
+docker/login-action:
+  mode: flag-imagePullSecret
+  note: Add the registry credential to the tenant's secrets.imagePullSecrets in values.yaml.
+
+docker/build-push-action:
+  mode: hub-task
+  hubTask: buildah
+  note: Use Hub task buildah with --isolation=chroot. Push step is publish; flag for GHA-stays.
+
+docker/metadata-action:
+  mode: inline
+  inlineSnippet: |
+    - name: derive-tags
+      image: docker.io/alpine/git:latest
+      script: |
+        SHA=$(params.revision)
+        SHORT=${SHA:0:7}
+        REF=$(params.git-ref)
+        echo -n "$SHORT" > $(results.short-sha.path)
+        echo -n "$REF"   > $(results.ref.path)
+  note: Replaces docker/metadata-action — exposes short-sha and ref as Tekton results.
+
+golangci/golangci-lint-action:
+  mode: image
+  imageTemplate: docker.io/golangci/golangci-lint:v1-alpine
+  note: golangci-lint runs from a published image.
+
+pre-commit/action:
+  mode: inline
+  inlineSnippet: |
+    - name: pre-commit
+      image: docker.io/python:3.12
+      workingDir: $(workspaces.source.path)
+      script: |
+        pip install pre-commit
+        pre-commit run --all-files
+
+azure/setup-helm:
+  mode: image
+  imageTemplate: docker.io/alpine/helm:{{ .with.version | default "3.16" }}
+
+imranismail/setup-kustomize:
+  mode: image
+  imageTemplate: registry.k8s.io/kustomize/kustomize:v5.4.3
+
+yannh/kubeconform:
+  mode: inline
+  inlineSnippet: |
+    - name: kubeconform
+      image: docker.io/alpine:3.20
+      workingDir: $(workspaces.source.path)
+      script: |
+        wget -qO- https://github.com/yannh/kubeconform/releases/download/v0.6.7/kubeconform-linux-amd64.tar.gz | tar xz -C /usr/local/bin
+        find . -name 'kustomization.yaml' -exec dirname {} \; | xargs -I{} kubeconform -strict {}
+
+actions/github-script:
+  mode: flag-unmapped
+  note: Would need GitHub App API call from the cluster pod. Out of scope for v1 — leave in GHA.
+
+actions/upload-artifact:
+  mode: flag-unmapped
+  note: No native artifact storage in Tekton. Either persist via workspace PVC or skip.
+
+redhat-actions/podman-login:
+  mode: flag-imagePullSecret
+  note: Same as docker/login-action — add the registry credential to tenant secrets.
+
+redhat-actions/push-to-registry:
+  mode: flag-publish
+  note: This is a publish step. Stays in GHA, scoped to push:main.
+
+bjw-s-labs/action-changed-files:
+  mode: inline
+  inlineSnippet: |
+    - name: changed-files
+      image: docker.io/alpine/git:latest
+      workingDir: $(workspaces.source.path)
+      script: |
+        git diff --name-only $(params.base-revision)...$(params.revision) > $(results.changed-files.path)
+
+anchore/sbom-action:
+  mode: hub-task
+  hubTask: syft-sbom
+  note: Generate SBOM with syft (Hub task) or inline syft on docker.io/anchore/syft.
+
+devcontainers/ci:
+  mode: flag-unmapped
+  note: Recursive devcontainer build. Stays in GHA.
+```
+
+- [ ] **Step 2: Commit**
+
+```bash
+git add .claude/skills/convert-gha-workflow/mappings.yaml
+git commit -m "Add convert-gha-workflow mapping table"
+```
+
+### Task 5.3: /convert-gha-workflow skill
+
+**Files:**
+- Create: `.claude/skills/convert-gha-workflow/SKILL.md`
+
+- [ ] **Step 1: Write the skill prompt**
+
+```markdown
+---
+name: convert-gha-workflow
+description: Convert a target repo's .github/workflows/*.yml into .tekton/*.yaml for OpenShift Pipelines as Code, prune the GHA workflows to publish-on-main only, and emit a secret-migration report. Operates on a target repo path; refuses to run on igou-openshift unless explicitly --target=. is passed.
+argument-hint: [path-to-target-repo] [--auto|-y]
+disable-model-invocation: true
+allowed-tools: Read, Write, Edit, Bash(yq *), Bash(find *), Bash(ls *), Bash(cat *), Bash(git *)
+---
+
+# Convert GitHub Actions workflows to Tekton PipelineRuns
+
+Reads `.github/workflows/*.yml` in the target repo, categorizes each job, generates `.tekton/pull-request.yaml`, prunes the GHA workflow to publish-on-main, and emits a migration report.
+
+## Parsing arguments
+
+`$ARGUMENTS` may contain:
+- A path to the target repo. If omitted, use `$PWD`.
+- `--auto` or `-y` to skip confirmations (use cautiously).
+
+If `$PWD` is the `igou-openshift` repo, refuse unless the user explicitly passed `--target=.` — otherwise the user is probably running the skill from the wrong directory.
+
+## Step 1: Discover workflows
+
+```bash
+find <target>/.github/workflows -maxdepth 1 \( -name '*.yml' -o -name '*.yaml' \) -type f
+```
+
+For each workflow file, parse with `yq '.'` and extract:
+- Top-level `on:` triggers (push branches, pull_request events, workflow_dispatch).
+- Each `jobs.<name>`: its `runs-on`, `steps`, `strategy.matrix`, `if:`, `env:`, secret references (`${{ secrets.X }}`).
+- Every `uses:` reference (the action name and the `with:` block).
+- Every `run:` block (verbatim shell).
+
+## Step 2: Categorize each job
+
+| Bucket | Heuristics | Destination |
+|--------|------------|-------------|
+| PR-checkable | name contains lint/format/test/check, or all steps are read-only | `.tekton/pull-request.yaml` |
+| Build, no publish | `go build`, `npm build`, image build with `push: false` | `.tekton/pull-request.yaml` |
+| Publish | docker push, npm publish, github release, deploy ssh, pages, helm push | stays in GHA |
+| Unsupported | self-hosted runner, github-script, devcontainers/ci | flagged, stays in GHA |
+
+If unclear, ask the user per job.
+
+## Step 3: Load mappings
+
+Read `.claude/skills/convert-gha-workflow/mappings.yaml`. For each `uses:` reference, look up the action (without `@version`); fall back to `flag-unmapped` mode if not found.
+
+## Step 4: Generate .tekton/pull-request.yaml
+
+For each PR-bucket job, generate a Tekton Task in a `pipelineSpec.tasks[]` list. Use this skeleton:
+
+```yaml
+---
+apiVersion: tekton.dev/v1
+kind: PipelineRun
+metadata:
+  name: pr
+  annotations:
+    pipelinesascode.tekton.dev/on-event: "[pull_request]"
+    pipelinesascode.tekton.dev/on-target-branch: "[main]"
+    pipelinesascode.tekton.dev/max-keep-runs: "5"
+spec:
+  params:
+    - name: revision
+      value: "{{ revision }}"
+    - name: repo-url
+      value: "{{ repo_url }}"
+    - name: git-ref
+      value: "{{ source_branch }}"
+  pipelineSpec:
+    params:
+      - name: revision
+        type: string
+      - name: repo-url
+        type: string
+      - name: git-ref
+        type: string
+    workspaces:
+      - name: source
+    tasks:
+      # ... one entry per migrated job ...
+  workspaces:
+    - name: source
+      volumeClaimTemplate:
+        spec:
+          accessModes: [ReadWriteOnce]
+          resources:
+            requests:
+              storage: 1Gi
+          storageClassName: freenas-nvmeof-ssd-csi
+```
+
+Each task in `tasks[]`:
+```yaml
+- name: <gha-job-name>
+  workspaces:
+    - name: source
+      workspace: source
+  taskSpec:
+    workspaces:
+      - name: source
+    params:
+      - name: revision
+        type: string
+    steps:
+      # ... transformed steps ...
+```
+
+For each step in the GHA job:
+- If `uses:` matches a `mode: drop` entry — skip the step entirely.
+- If `uses:` matches `mode: image` — set the *next* step's `image:` to the rendered image template, drop this step.
+- If `uses:` matches `mode: inline` — inline the snippet from mappings.yaml.
+- If `uses:` matches `mode: hub-task` — emit a `taskRef.resolver: hub` reference.
+- If `uses:` matches `mode: flag-imagePullSecret` — emit a comment `# imagePullSecret required: <action> — add to tenant.secrets.imagePullSecrets` and skip the step.
+- If `uses:` matches `mode: flag-publish` or `mode: flag-unmapped` — emit a comment `# UNMAPPED ACTION: <action> — implement manually` and a stub step.
+- If the step is `run:` — wrap in a Tekton step:
+  ```yaml
+  - name: <derived-name>
+    image: <inherited-or-default>
+    workingDir: $(workspaces.source.path)
+    script: |
+      <verbatim-run-content>
+  ```
+
+For matrix strategies (Tekton 0.50+):
+```yaml
+- name: <job-name>
+  matrix:
+    params:
+      - name: <matrix-key>
+        value: [<v1>, <v2>, ...]
+  ...
+```
+
+Inside the task, parameterize the image: `image: docker.io/golang:$(params.go-version)`.
+
+## Step 5: Prune the original GHA workflow
+
+For each workflow file:
+- If ALL jobs were migrated to PaC: rename the file to `<base>-publish.yml` and either delete it (if empty after pruning) or leave a stub.
+- If SOME jobs were migrated: remove the migrated jobs from the file, restrict `on:` to `push: branches: [main]` only.
+- If NO jobs were migrated (all publish): leave the file alone but restrict `on:` to `push: branches: [main]` (it should already be).
+
+## Step 6: Generate .tekton/README.md
+
+Write a brief `.tekton/README.md` summarizing what was migrated, when, and how to test:
+
+```markdown
+# Tekton PipelineRuns
+
+This directory is consumed by OpenShift Pipelines as Code on the homelab cluster.
+
+- `pull-request.yaml` runs on every PR opened against `main`.
+- Status reported back to GitHub via the Checks API.
+
+To test locally, install `tkn pac` CLI and run `tkn pac resolve -f .tekton/pull-request.yaml`.
+
+Migrated from `.github/workflows/<file>.yml` on <date> by /convert-gha-workflow.
+```
+
+## Step 7: Print migration report
+
+Print to terminal:
+```
+Migration of <repo>:
+  ✓ Job '<name>' → .tekton/pull-request.yaml (Task: <name>)
+  ↩ Job '<name>' → stays in .github/workflows/<file>.yml (push:main only)
+  ⚠ Job '<name>' uses <action> — flagged: <reason>
+
+Secret migration:
+  <SECRET>  → tenant.secrets.<mode> (1Password: <suggested-item>)
+
+Next steps:
+  1. Review .tekton/pull-request.yaml for unmapped steps (search 'UNMAPPED ACTION')
+  2. In igou-openshift: /scaffold-pac-tenant <owner>/<repo>  (if not already onboarded)
+  3. Add secret entries to clusters/ocp/pac-tenants/values.yaml under tenant '<name>'
+  4. Add secrets to 1Password if not already present
+  5. Commit + push both repos; verify PaC fires on first PR.
+```
+
+The skill does NOT commit, NOT push, and NOT install the GitHub App. User does those after reviewing diffs.
+```
+
+- [ ] **Step 2: Commit**
+
+```bash
+git add .claude/skills/convert-gha-workflow/SKILL.md
+git commit -m "Add convert-gha-workflow skill"
+```
+
+---
+
+## Phase 6 — Smoke test (gated on Phase 0)
+
+Onboards `igou-openshift` itself as the first PaC tenant, migrates `validate.yml`, and verifies the round-trip.
+
+### Task 6.1: Confirm Phase 0 prerequisites
+
+- [ ] **Step 1: Check 1Password items exist**
+
+Run: `op item get pac-github-app --vault <homelab-vault>`
+Expected: returns the item with `app-id`, `private-key`, `webhook-secret` fields.
+
+Run: `op item get tekton-chains-signing --vault <homelab-vault>`
+Expected: returns the item with `cosign.key`, `cosign.password`, `cosign.pub` fields.
+
+- [ ] **Step 2: Confirm Tailscale ACL has funnel attr**
+
+Ask the user to confirm the ACL was edited per Task 0.4.
+
+- [ ] **Step 3: Confirm GitHub App exists**
+
+Ask the user for the App installation URL (https://github.com/settings/apps/<app-name>).
+
+If any prerequisite is missing, stop and surface it. Do not proceed.
+
+### Task 6.2: Wait for Phase 1 sync to complete on cluster
+
+The component changes from Phase 1 should be auto-synced by ArgoCD.
+
+- [ ] **Step 1: Verify ArgoCD synced openshift-pipelines**
+
+Run: `argocd app get openshift-pipelines -o json | jq '.status.sync.status, .status.health.status'`
+Expected: `"Synced"`, `"Healthy"`.
+
+If not synced: `argocd app sync openshift-pipelines --prune` (with user authorization).
+
+- [ ] **Step 2: Verify TektonConfig is reconciled on the cluster**
+
+Run via MCP: `mcp__kubernetes__resources_get` for `operator.tekton.dev/v1alpha1 TektonConfig` named `config`.
+Expected: `.status.conditions[?(@.type=="Ready")].status` is `True`.
+
+- [ ] **Step 3: Verify pipelines-as-code-secret exists in openshift-pipelines**
+
+Run via MCP: `mcp__kubernetes__resources_get` for `v1 Secret` named `pipelines-as-code-secret` in `openshift-pipelines`.
+Expected: present, with three keys.
+
+- [ ] **Step 4: Verify Funnel hostname is up**
+
+Run via MCP: get `Service/pac-controller-funnel` annotations. Look for `tailscale.com/operator-status: ready` or similar.
+Expected: ready, with the URL `pac-ocp.<tailnet>.ts.net` resolvable via `dig +short pac-ocp.<tailnet>.ts.net`.
+
+If any of these fail: troubleshoot before continuing. Common failure: webhook secret mismatch; verify the 1Password value matches what was set in the GitHub App.
+
+### Task 6.3: Update GitHub App webhook URL
+
+- [ ] **Step 1: Ask user to update the webhook URL**
+
+Tell the user: "GitHub App's webhook URL needs to be updated to `https://pac-ocp.<tailnet>.ts.net/`. Go to https://github.com/settings/apps/<app-name> → Webhook → URL field. Save changes."
+
+Wait for user confirmation.
+
+### Task 6.4: Install GitHub App on igou-openshift
+
+- [ ] **Step 1: Ask user to install the App**
+
+Tell the user: "Install the GitHub App on the `igou-io/igou-openshift` repo. Go to the App's installation URL (find it on the App settings page → Install App) → Install only on `igou-io/igou-openshift` for the smoke test."
+
+Wait for user confirmation.
+
+### Task 6.5: Onboard igou-openshift via /scaffold-pac-tenant
+
+- [ ] **Step 1: Run the skill**
+
+User runs: `/scaffold-pac-tenant igou-io/igou-openshift`
+
+Expected: skill adds an entry to `clusters/ocp/pac-tenants/values.yaml`, runs `helm template` + `kubeconform`, prints diff.
+
+- [ ] **Step 2: User reviews + commits**
+
+User reviews the diff, commits with a message like:
+```
+Onboard igou-openshift as first PaC tenant
+```
+and pushes.
+
+- [ ] **Step 3: Verify ArgoCD picks up the change**
+
+Run: `argocd app sync pac-tenants --prune=false` (after user authorization).
+Expected: namespace `ci-igou-openshift`, `pipeline-sa`, three NetworkPolicies, ResourceQuota, LimitRange, Repository CR all created.
+
+- [ ] **Step 4: Verify the namespace looks right**
+
+Run via MCP: `mcp__kubernetes__resources_list` for `NetworkPolicy` in `ci-igou-openshift`.
+Expected: 3 entries (default-deny-all, allow-dns, allow-external-egress).
+
+### Task 6.6: Migrate igou-openshift's validate.yml
+
+This skill operates on the target repo. Since the target repo IS `igou-openshift`, the skill must be invoked with the explicit `--target=.` flag.
+
+- [ ] **Step 1: Run the skill**
+
+User runs: `/convert-gha-workflow . --target=.`
+
+Expected: skill writes:
+- `.tekton/pull-request.yaml` containing PipelineRun with three tasks (lint, validate-kustomize, validate-schemas) — analogous to the three GHA jobs.
+- `.tekton/README.md`.
+- Modifies `.github/workflows/validate.yml`: nothing to prune in the strict sense (validate.yml has no publish work), but trigger restricted to `push: branches: [main]` (drop `pull_request`).
+
+- [ ] **Step 2: User reviews diffs**
+
+The user inspects `.tekton/pull-request.yaml`. Particular check: the `imranismail/setup-kustomize` and `azure/setup-helm` actions must have been mapped to the correct images.
+
+- [ ] **Step 3: User opens a PR**
+
+User creates a branch, commits, and opens a PR against `main`.
+
+### Task 6.7: Verify PaC fires and reports green
+
+- [ ] **Step 1: Watch the PaC controller logs**
+
+Run via MCP: `mcp__kubernetes__pods_log` for the `pipelines-as-code-controller` pod in `openshift-pipelines`.
+Expected: webhook received, signature validated, PipelineRun created in `ci-igou-openshift`.
+
+- [ ] **Step 2: Verify PipelineRun appears in tenant namespace**
+
+Run via MCP: `mcp__kubernetes__resources_list` for `tekton.dev/v1 PipelineRun` in `ci-igou-openshift`.
+Expected: one PipelineRun, status condition `Succeeded`.
+
+- [ ] **Step 3: Verify TaskRun pod hardening**
+
+Run via MCP: `mcp__kubernetes__pods_get` for one of the TaskRun pods in `ci-igou-openshift` (find via `mcp__kubernetes__pods_list_in_namespace`).
+Verify the spec contains:
+- `automountServiceAccountToken: false`
+- `securityContext.runAsNonRoot: true`
+- `priorityClassName: tekton-ci-low`
+- `enableServiceLinks: false`
+
+- [ ] **Step 4: Verify NetworkPolicy enforcement**
+
+Spawn a debug pod in `ci-igou-openshift` (with user authorization) and try to reach `192.168.1.1:22`:
+```bash
+oc -n ci-igou-openshift run nettest --rm -it --image=alpine:3.20 --restart=Never -- sh -c 'apk add --no-cache busybox-extras; nc -zv 192.168.1.1 22'
+```
+Expected: hangs / times out (NetworkPolicy blocks 192.168.0.0/16).
+
+Then test that github.com is reachable:
+```bash
+oc -n ci-igou-openshift run nettest --rm -it --image=alpine:3.20 --restart=Never -- sh -c 'wget -qO- https://api.github.com/zen'
+```
+Expected: returns a string (egress to public internet works).
+
+- [ ] **Step 5: Verify GitHub PR shows the check**
+
+Open the PR in GitHub. Expected: check named "OpenShift Pipelines (homelab) / pr" reports green.
+
+- [ ] **Step 6: Merge the PR (user decision)**
+
+If everything is green, the user merges the PR. After merge, `validate.yml` should run on `push: main` via GitHub Actions (still works) and PaC should NOT fire (because the PR is closed/merged).
+
+---
+
+## Phase 7 — Onboard remaining repos (incremental, post-smoke-test)
+
+After the smoke test, onboard each of the four remaining active-CI repos in sequence. Each is a tiny task: scaffold the tenant, convert the workflow, open a PR, verify, merge.
+
+### Task 7.1: igou-inventory (lint.yml)
+
+Repeat Tasks 6.4–6.7 with `igou-io/igou-inventory`. Workflow uses `actions/setup-python` and pre-commit (likely) — both are mapped.
+
+### Task 7.2: igou-ansible (lint.yml + syntax-check.yml)
+
+Repeat for `igou-io/igou-ansible`. Two PR-side workflows; the three EE-build publishers stay in GHA.
+
+### Task 7.3: igou-containers (build-containers.yml — split)
+
+This one is mixed. The user must explicitly review which parts of `build-containers.yml` are PR-side (build, no push) vs publish (build + push).
+
+The skill will categorize as best it can; user should adjust before committing.
+
+---
+
+## Self-review
+
+**Spec coverage:** Each spec section maps to tasks:
+- Architecture overview → Phase 1 + Phase 2 + Phase 3 (the manifests)
+- Per-repo namespace hardening → Tasks 2.3–2.7 (chart templates implementing it)
+- Operator install + TektonConfig → Phase 1 (Tasks 1.1–1.7)
+- Tailscale Funnel exposure → Task 1.5 + 1.6 + Phase 0.4
+- Per-tenant onboarding chart → Phase 2
+- Secret access → Task 2.4 (SA + imagePullSecrets), Task 2.9 (ExternalSecrets), Task 2.8 (auto-collapsed okToTest)
+- Conversion skill → Phase 5 (Tasks 5.1–5.3)
+- Rollout sequence → Phases ordered to match
+- Validation → Phase 4 (Makefile)
+- Smoke test → Phase 6
+
+**Placeholder scan:** No "TBD"; all code blocks complete; commands have expected outputs.
+
+**Type consistency:** SA name `pipeline-sa` is consistent across TektonConfig (`default-service-account`), chart template, and skill prompts. Namespace prefix `ci-` consistent. Resource names (`default-deny-all`, `allow-dns`, `allow-external-egress`, `ci-quota`, `ci-limits`) consistent across spec, plan, and chart templates.
+
+**Open verification points the agent must handle at runtime (not plan defects):**
+- Cluster pod/service CIDRs (Task 1.x notes verification command).
+- Tailscale operator's actual device tag (Task 0.4 notes verification).
+- PaC controller Service selector labels (Task 1.5 notes verification).
+- 1Password ClusterSecretStore name (Task 1.3 notes verification).
+- TektonConfig schema availability in datreeio catalog (Task 1.2 notes graceful skip).

--- a/docs/superpowers/specs/2026-05-09-pipelines-as-code-design.md
+++ b/docs/superpowers/specs/2026-05-09-pipelines-as-code-design.md
@@ -1,0 +1,748 @@
+# OpenShift Pipelines as Code — design
+
+**Status:** draft, awaiting user review
+**Date:** 2026-05-09
+**Author:** David Igou (with Claude)
+
+## Goals
+
+- Stand up GitHub-driven CI on the homelab OCP cluster using OpenShift Pipelines as Code (PaC), the `.tekton/`-per-repo model. Goal is to displace the GitHub Actions workflows that are burning the user's free GHA minutes.
+- **Initial migration scope (verified by org survey):** 5 active repos with workflows worth moving to PaC — `igou-inventory` (lint), `igou-ansible` (lint + syntax-check; the three EE publishers stay in GHA), `igou-openshift` (validate), `igou-containers` (PR-side image builds; the publish path stays in GHA), and `igou-devenv` (stays entirely in GHA — devcontainer build is recursive). The system is sized for growth (chart defaults assume up to ~20 tenants), but the immediate fleet is 4 tenants.
+- Tune the OpenShift Pipelines operator deliberately (TektonConfig, pruner, resolvers, Chains, PaC settings) rather than running stock defaults.
+- Hybrid CI model: PRs and working-branch pushes run on PaC; `push:main` keeps running on GitHub Actions to handle release/publish/deploy steps that need GH-side secrets or external integrations.
+- Hardened-by-default per-repo namespace: zero secrets on PR runs, default-deny NetworkPolicies, ResourceQuota, restricted SCC, no privileged builds.
+- Two Claude skills to make onboarding mechanical: `/scaffold-pac-tenant` (per-repo entry in this repo) and `/convert-gha-workflow` (per-repo `.tekton/` generation in the target repo).
+
+## Non-goals
+
+- Running PaC across multiple clusters. Single cluster (`ocp.igou.systems`) only; the chart is cluster-pinned.
+- Migrating release/publish workflows. Those stay in GitHub Actions, scoped to `push: branches: [main]`.
+- Self-hosted GitHub Actions runners. Different problem; PaC is the chosen path.
+- Trigger-based PaC (the legacy webhook+PAT model). GitHub App only.
+- Auto-onboarding new repos. PaC's `auto-configure-new-github-repo` is explicitly disabled — onboarding is always a deliberate commit.
+
+## Architecture overview
+
+```
+┌──────────────────┐                     ┌─────────────────────────────┐
+│  github.com      │                     │  ocp.igou.systems (SNO)     │
+│                  │                     │                             │
+│  GitHub App      │                     │  openshift-pipelines ns     │
+│  "ocp-pac"       │   webhook (HMAC)    │   ├─ pac-controller         │
+│  Installed on    ├────────────────────►│   ├─ pac-watcher            │
+│  ~20 repos       │   via Funnel URL    │   ├─ pac-webhook            │
+│                  │                     │   ├─ tekton-* controllers   │
+│                  │                     │   └─ chains-controller      │
+│                  │◄────────────────────┤                             │
+│                  │   Checks API        │  tailscale-operator         │
+│                  │   (App JWT)         │   exposes pac-controller    │
+└──────────────────┘                     │   Service via Funnel        │
+                                         │   → pac-ocp.<tailnet>.ts.net│
+                                         │                             │
+                                         │  ci-<repo> ns (× ~20)       │
+                                         │   ├─ Repository CR          │
+                                         │   ├─ pipeline-sa (no creds) │
+                                         │   ├─ NetworkPolicies        │
+                                         │   ├─ ResourceQuota          │
+                                         │   └─ PipelineRuns (PRs)     │
+                                         └─────────────────────────────┘
+```
+
+**Trigger flow.** Developer pushes a PR branch → GitHub App fires webhook to the Funnel URL → PaC controller validates HMAC + GitHub App JWT → checks `Repository.spec.policy.pull_request` allowlist → resolves `.tekton/pull-request.yaml` from the PR HEAD → creates `PipelineRun` in `ci-<repo>` namespace → run uses `pipeline-sa` (zero credentials) → Tasks come from Tekton Hub via the Hub Resolver → status reported back to the PR via the Checks API. PR merges to main → no PaC run; GitHub Actions fires its pruned `publish.yml` (trigger restricted to `push: branches: [main]` only).
+
+## Per-repo `ci-<repo>` namespace hardening
+
+### Threat model
+
+The PR run executes attacker-controlled code from the PR. Shared Tasks come from Tekton Hub (or inline Task specs), but user `script:` blocks and the build itself run whatever the PR contains. The build pod is treated as hostile. The `policy.pull_request` allowlist on the Repository CR keeps strangers from triggering it; the hardening below assumes a trusted user's PR is still capable of running malicious code (a compromised dev account, a bad merge, a copy-pasted build step).
+
+### `pipeline-sa` ServiceAccount
+
+One SA per `ci-<repo>` namespace. Used by every PR PipelineRun. Designed to be as close to powerless as possible.
+
+```yaml
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: pipeline-sa
+  namespace: ci-<repo>
+automountServiceAccountToken: false   # token never lands in the build pod
+imagePullSecrets: []                  # default: no registry creds (overridable per-tenant)
+```
+
+- **No RBAC.** No Role, no RoleBinding, no ClusterRoleBinding. The OpenShift Pipelines operator binds its standard `pipelines-scc` to the SA via the operator-shipped ClusterRoleBinding; we don't touch that.
+- **SCC: `pipelines-scc`** (≈ `restricted-v2` plus minor tweaks). Never `pipelines-scc-privileged`.
+- Container image builds use rootless Buildah (`--isolation=chroot --storage-driver=vfs`) — no privileged required.
+- Belt-and-suspenders at the pod-template default level (set in `TektonConfig`):
+  ```yaml
+  spec:
+    pipeline:
+      default-pod-template:
+        securityContext:
+          runAsNonRoot: true
+          seccompProfile: { type: RuntimeDefault }
+        automountServiceAccountToken: false
+        enableServiceLinks: false
+        priorityClassName: tekton-ci-low
+  ```
+
+PR runs never publish. There is no second SA in `ci-<repo>` for pushing images — that work happens in GHA on `push:main`, with a GitHub-side secret that never enters the cluster.
+
+### NetworkPolicies — default-deny + three explicit allows
+
+```yaml
+# 1. default-deny — everything below has to opt in
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: default-deny-all
+  namespace: ci-<repo>
+spec:
+  podSelector: {}
+  policyTypes: [Ingress, Egress]
+---
+# 2. allow DNS (openshift-dns)
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: allow-dns
+  namespace: ci-<repo>
+spec:
+  podSelector: {}
+  policyTypes: [Egress]
+  egress:
+    - to:
+        - namespaceSelector:
+            matchLabels:
+              kubernetes.io/metadata.name: openshift-dns
+      ports:
+        - { port: 53, protocol: UDP }
+        - { port: 53, protocol: TCP }
+---
+# 3. allow egress to public internet (HTTPS + HTTP), block intra-cluster + LAN
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: allow-external-egress
+  namespace: ci-<repo>
+spec:
+  podSelector: {}
+  policyTypes: [Egress]
+  egress:
+    - to:
+        - ipBlock:
+            cidr: 0.0.0.0/0
+            except:
+              - 10.128.0.0/14         # OCP pod CIDR — verify on cluster
+              - 172.30.0.0/16         # OCP service CIDR — verify on cluster
+              - 169.254.169.254/32    # cloud metadata IP
+              - 192.168.0.0/16        # home LAN (TrueNAS, router)
+              - 10.0.0.0/8            # other RFC1918
+      ports:
+        - { port: 443, protocol: TCP }
+        - { port: 80,  protocol: TCP }
+```
+
+**No ingress rule.** The Tekton TaskRun controller in `openshift-pipelines` reads pod logs/status via the K8s API server, not by dialing the build pod. The build pod is a sink, not a server.
+
+**Why HTTP/80.** Apt mirrors and a handful of legacy package mirrors. If the migrated repos don't actually need it, drop it before commit.
+
+**Why we block 192.168.0.0/16 and 10.0.0.0/8.** Workspace PVCs go through CSI in the kubelet's mount namespace — the build pod talks to the kernel, not to the storage box's network IP — so blocking `192.168.x.x` doesn't break storage. This blocks LAN scanning from a compromised PR run.
+
+**Pod/service CIDR values must be verified on the live cluster** before commit:
+```
+oc get network.config/cluster -o jsonpath='{.spec.clusterNetwork}'
+oc get network.config/cluster -o jsonpath='{.spec.serviceNetwork}'
+```
+
+### ResourceQuota + LimitRange
+
+```yaml
+apiVersion: v1
+kind: ResourceQuota
+metadata:
+  name: ci-quota
+  namespace: ci-<repo>
+spec:
+  hard:
+    requests.cpu:    "8"
+    requests.memory: 16Gi
+    limits.cpu:      "16"
+    limits.memory:   32Gi
+    pods:            "20"
+    persistentvolumeclaims: "5"
+    requests.storage: 50Gi
+---
+apiVersion: v1
+kind: LimitRange
+metadata:
+  name: ci-limits
+  namespace: ci-<repo>
+spec:
+  limits:
+    - type: Container
+      defaultRequest: { cpu: 100m, memory: 256Mi }
+      default:        { cpu: 500m, memory: 1Gi   }
+      max:            { cpu: 4,    memory: 8Gi   }
+```
+
+PaC-side concurrency cap on `Repository.spec.concurrency_limit: 2` per repo. With `pods: 20` quota and 2 concurrent runs of ≤10 steps each, we stay well within limits.
+
+### PriorityClass (cluster-wide, shipped with the operator component)
+
+```yaml
+apiVersion: scheduling.k8s.io/v1
+kind: PriorityClass
+metadata:
+  name: tekton-ci-low
+value: 100   # below user-workload (1000) and system (10k+)
+globalDefault: false
+description: "PR PipelineRun pods. Preempted under cluster pressure."
+```
+
+Pinned as the default in `TektonConfig.spec.pipeline.default-pod-template.priorityClassName`. CI yields to user-facing apps under pressure.
+
+### Namespace-level Pod Security Admission
+
+```yaml
+metadata:
+  labels:
+    pod-security.kubernetes.io/enforce: restricted
+    pod-security.kubernetes.io/enforce-version: latest
+```
+
+Belt-and-suspenders: even if the SCC story slips, PSA blocks privileged pods at admission.
+
+## Operator install + TektonConfig tuning
+
+`components/openshift-pipelines/openshift-pipelines-operator-subscription.yaml` already exists and is wired into `clusters/ocp/values.yaml` at sync-wave 10. We add three new files plus a PriorityClass:
+
+```
+components/openshift-pipelines/
+├── kustomization.yaml
+├── openshift-pipelines-operator-subscription.yaml   # existing
+├── tektonconfig.yaml                                # NEW
+├── chains-signing-externalsecret.yaml               # NEW
+├── pac-github-app-externalsecret.yaml               # NEW
+├── pac-controller-funnel-service.yaml               # NEW
+└── tekton-ci-low-priorityclass.yaml                 # NEW
+```
+
+### `tektonconfig.yaml`
+
+```yaml
+apiVersion: operator.tekton.dev/v1alpha1
+kind: TektonConfig
+metadata:
+  name: config            # must be 'config' — the operator only reconciles this name
+  annotations:
+    argocd.argoproj.io/sync-wave: "11"
+    argocd.argoproj.io/sync-options: SkipDryRunOnMissingResource=true,ServerSideApply=true
+spec:
+  profile: all                         # installs Pipelines + Triggers + PaC + Chains
+  targetNamespace: openshift-pipelines
+  pruner:
+    disabled: false
+    schedule: "0 4 * * *"
+    keep: 20
+    keep-since: 10080                  # 7 days in minutes
+    resources: [pipelinerun, taskrun]
+  pipeline:
+    enable-bundles-resolver: true
+    enable-cluster-resolver: true
+    enable-git-resolver: true
+    enable-hub-resolver: true
+    default-service-account: pipeline-sa
+    default-timeout-minutes: 60
+    default-pod-template:
+      securityContext:
+        runAsNonRoot: true
+        seccompProfile: { type: RuntimeDefault }
+      automountServiceAccountToken: false
+      enableServiceLinks: false
+      priorityClassName: tekton-ci-low
+    enable-step-actions: true
+  chain:
+    artifacts.taskrun.format: in-toto
+    artifacts.taskrun.storage: oci
+    artifacts.pipelinerun.format: in-toto
+    artifacts.pipelinerun.storage: oci
+    artifacts.oci.storage: oci
+    transparency.enabled: false        # no Rekor for now
+    signers.x509.fulcio.enabled: false # static cosign key, not keyless
+  platforms:
+    openshift:
+      pipelinesAsCode:
+        enable: true
+        settings:
+          application-name: "OpenShift Pipelines (homelab)"
+          auto-configure-new-github-repo: false
+          secret-auto-create: true
+          remote-tasks: true
+          max-keep-runs: 10
+          enable-cancel-in-progress: true
+          custom-console-name: "OpenShift Console"
+          custom-console-url: "https://console-openshift-console.apps.ocp.igou.systems"
+          custom-console-url-pr-details: |
+            {{.openshift_console_url}}/k8s/ns/{{.namespace}}/tekton.dev~v1~PipelineRun/{{.pr}}
+          custom-console-url-pr-tasklog: |
+            {{.openshift_console_url}}/k8s/ns/{{.namespace}}/tekton.dev~v1~PipelineRun/{{.pr}}/logs/{{.task}}
+```
+
+Key settings rationale:
+
+- **`profile: all`** — installs Pipelines, Triggers, PaC, Chains, Dashboard. Triggers ships free; Dashboard is suppressed in the OCP console plugin (built-in Pipelines tab).
+- **Pruner: 20 runs / 7 days.** With ~20 repos × ~5 runs/week, steady-state ~400 runs is comfortable.
+- **`default-service-account: pipeline-sa`** — every PipelineRun in any namespace defaults to this SA name. Per-repo namespaces all create a SA called `pipeline-sa`, so no per-PipelineRun `serviceAccountName` is needed.
+- **All four resolvers enabled** — Cluster + Git + Hub + Bundles. Hub and Git are the primary path; Cluster is a future option (if we ever need shared local Tasks); Bundles is for OCI-distributed Task catalogs.
+- **`auto-configure-new-github-repo: false`** — critical security setting. Stops PaC from auto-creating Repository CRs for repos it's never seen. Onboarding is always an explicit `clusters/ocp/pac-tenants/values.yaml` commit.
+- **`enable-cancel-in-progress: true`** — global default; per-repo override available.
+- **Chains in `oci` storage mode** — attestations push to the same registry as the image. `transparency.enabled: false` skips Rekor (would require external Rekor infra).
+
+### Cosign keypair for Chains
+
+Generate once: `cosign generate-key-pair k8s://tekton-chains/signing-secrets`. Put the resulting `cosign.key`, `cosign.password`, `cosign.pub` into 1Password as item `tekton-chains-signing`. ExternalSecret materializes the in-cluster `signing-secrets` Secret:
+
+```yaml
+apiVersion: external-secrets.io/v1beta1
+kind: ExternalSecret
+metadata:
+  name: signing-secrets
+  namespace: tekton-chains
+spec:
+  refreshInterval: 1h
+  secretStoreRef:
+    kind: ClusterSecretStore
+    name: onepassword
+  target:
+    name: signing-secrets
+  data:
+    - { secretKey: cosign.key,      remoteRef: { key: tekton-chains-signing, property: cosign.key } }
+    - { secretKey: cosign.password, remoteRef: { key: tekton-chains-signing, property: cosign.password } }
+    - { secretKey: cosign.pub,      remoteRef: { key: tekton-chains-signing, property: cosign.pub } }
+```
+
+The `tekton-chains` namespace is created by the operator when Chains is enabled — we add the ExternalSecret into it.
+
+## Tailscale Funnel exposure
+
+GitHub needs to reach the PaC controller webhook from the public internet without us opening a port on the home router. The existing `tailscale-operator` does this via Service annotations.
+
+The PaC operator owns `Service/pipelines-as-code-controller` in `openshift-pipelines` (port 8080, HTTP). We don't modify it (the operator would revert changes on reconcile). Instead, a parallel Service points at the same selector and carries the Tailscale annotations:
+
+```yaml
+# components/openshift-pipelines/pac-controller-funnel-service.yaml
+apiVersion: v1
+kind: Service
+metadata:
+  name: pac-controller-funnel
+  namespace: openshift-pipelines
+  annotations:
+    tailscale.com/expose: "true"
+    tailscale.com/funnel: "true"
+    tailscale.com/hostname: "pac-ocp"      # → pac-ocp.<tailnet>.ts.net
+    argocd.argoproj.io/sync-wave: "12"
+spec:
+  type: ClusterIP
+  selector:
+    app.kubernetes.io/name: controller
+    app.kubernetes.io/part-of: pipelines-as-code
+  ports:
+    - name: http
+      port: 8080
+      targetPort: 8080
+      protocol: TCP
+```
+
+The Tailscale proxy terminates TLS using a Tailscale-issued cert (Funnel hostnames get them automatically). Inside the tunnel, traffic to the backend is HTTP on 8080, which is fine — it never leaves the cluster network.
+
+**Webhook URL GitHub will hit:** `https://pac-ocp.<tailnet>.ts.net/`
+
+### Funnel constraints
+
+- Funnel external ports are restricted to **443, 8443, 10000**. We use 443.
+- Tailnet ACL must grant `funnel` to the operator's device tag. One-time admin change:
+  ```
+  "nodeAttrs": [
+    { "target": ["tag:k8s"], "attr": ["funnel"] }
+  ]
+  ```
+  This is called out as a manual prerequisite in the implementation plan.
+- The proxy is one Tailscale device; doesn't scale per repo.
+- **No fallback exposure.** If Funnel breaks, GitHub webhooks fail and PaC stops working. Acceptable for a homelab.
+
+### GitHub App webhook secret
+
+```yaml
+apiVersion: external-secrets.io/v1beta1
+kind: ExternalSecret
+metadata:
+  name: pipelines-as-code-secret
+  namespace: openshift-pipelines
+spec:
+  refreshInterval: 1h
+  secretStoreRef:
+    kind: ClusterSecretStore
+    name: onepassword
+  target:
+    name: pipelines-as-code-secret      # exact name PaC controller looks for
+  data:
+    - { secretKey: github-application-id, remoteRef: { key: pac-github-app, property: app-id } }
+    - { secretKey: github-private-key,    remoteRef: { key: pac-github-app, property: private-key } }
+    - { secretKey: webhook.secret,        remoteRef: { key: pac-github-app, property: webhook-secret } }
+```
+
+## Per-tenant onboarding — Helm chart
+
+Tenants are defined declaratively in a single values file. A Helm chart templates the per-tenant resources.
+
+### Layout
+
+```
+.helm/charts/pac-tenant/                  # NEW chart, follows existing .helm/charts pattern
+├── Chart.yaml
+├── values.yaml                           # schema + defaults, empty tenants list
+└── templates/
+    ├── _helpers.tpl
+    ├── namespace.yaml                    # range over .Values.tenants
+    ├── serviceaccount.yaml               # range
+    ├── networkpolicies.yaml              # range
+    ├── resourcequota.yaml                # range
+    ├── limitrange.yaml                   # range
+    ├── repository.yaml                   # range
+    └── externalsecrets.yaml              # range over .secrets.* for tenants that have them
+
+clusters/ocp/pac-tenants/                 # cluster-specific instantiation
+├── Chart.yaml                            # depends on ../../../.helm/charts/pac-tenant
+└── values.yaml                           # the entire CI fleet lives here
+```
+
+### Single ArgoCD app — wiring in `clusters/ocp/values.yaml`
+
+```yaml
+# Added once, never edited again.
+pac-tenants:
+  annotations:
+    argocd.argoproj.io/sync-wave: '20'
+  source:
+    path: clusters/ocp/pac-tenants
+```
+
+All future onboarding lives inside `clusters/ocp/pac-tenants/values.yaml`. No new ArgoCD apps per repo.
+
+### Example `clusters/ocp/pac-tenants/values.yaml`
+
+```yaml
+defaults:
+  concurrencyLimit: 2
+  cancelInProgress: true
+
+  policy:
+    pullRequest: ["igou-david"]
+    okToTest:    ["igou-david"]
+
+  quota:
+    requests.cpu:    "8"
+    requests.memory: "16Gi"
+    limits.cpu:      "16"
+    limits.memory:   "32Gi"
+    pods:            "20"
+    persistentvolumeclaims: "5"
+    requests.storage: "50Gi"
+
+  limitRange:
+    defaultRequest: { cpu: 100m, memory: 256Mi }
+    default:        { cpu: 500m, memory: 1Gi   }
+    max:            { cpu: 4,    memory: 8Gi   }
+
+  egressBlockedCIDRs:
+    - 10.128.0.0/14
+    - 172.30.0.0/16
+    - 169.254.169.254/32
+    - 192.168.0.0/16
+    - 10.0.0.0/8
+
+tenants:
+  - name: igou-openshift
+    url:  https://github.com/igou-io/igou-openshift
+
+  - name: gitea-config
+    url:  https://github.com/igou-io/gitea-config
+
+  - name: llmkube
+    url:  https://github.com/igou-io/llmkube
+
+  # Per-tenant overrides — only specify what differs from defaults.
+  - name: heavy-image-builder
+    url:  https://github.com/igou-io/heavy-image-builder
+    quota:
+      requests.cpu:    "16"
+      requests.memory: "32Gi"
+      limits.cpu:      "32"
+      limits.memory:   "64Gi"
+    concurrencyLimit: 1
+
+  # Tenant with secrets — chart enforces stricter okToTest (see Secret access section).
+  - name: image-builder-repo
+    url:  https://github.com/igou-io/image-builder-repo
+    secrets:
+      imagePullSecrets:
+        - name: ghcr-readonly
+          onepasswordItem: ci-ghcr-readonly
+      workspaceSecrets:
+        - name: snyk-org-token
+          onepasswordItem: ci-snyk-org
+```
+
+### Defaults-merge logic
+
+`templates/_helpers.tpl`:
+
+```yaml
+{{- define "pac-tenant.merged" -}}
+{{- $defaults := .root.Values.defaults -}}
+{{- $tenant := .tenant -}}
+{{- $merged := mergeOverwrite (deepCopy $defaults) $tenant -}}
+{{- toYaml $merged -}}
+{{- end -}}
+```
+
+Templates iterate `.Values.tenants`, computing the merged config per tenant. Tenant entries only specify what differs from defaults.
+
+### Trade-off: single ArgoCD app for the whole fleet
+
+A YAML mistake in one tenant entry breaks the sync of all tenants until fixed. Mitigation: the `/scaffold-pac-tenant` skill always runs `helm template | kubeconform` before writing. ArgoCD's auto-sync halts on render failure rather than half-applying — previous good state stays running.
+
+## Secret access for tenants
+
+The default — zero secrets on PR runs — covers most repos. Cases that legitimately need PR-time secrets are accommodated by two opt-in modes.
+
+### Allowed secret types
+
+| Need | Examples | Risk if leaked |
+|---|---|---|
+| Private base image pull | private GHCR/quay.io org pulls | Read access to one registry path |
+| Private package index | private npm/pip/Go proxy tokens | Read access to packages |
+| Test fixtures | Stripe test-mode key, sandbox API tokens | Bounded — test-scoped accounts |
+| Linter / scanner tokens | SonarCloud, Snyk org token | Reporting auth |
+| Read-only SaaS for integration tests | sandbox AWS keys, dev-DB password | Variable — depends on scope |
+
+**Never allowed on PR runs:** production credentials, registry write tokens, deploy SSH keys, signing keys, OIDC client secrets that mint elevated tokens. Those stay in GHA `push:main` workflows.
+
+### Two modes
+
+**Mode A: imagePullSecrets** (registry credentials for pulling base images). Attached to `pipeline-sa.imagePullSecrets` because the kubelet uses them at pod creation, before workspaces mount.
+
+**Mode B: workspaceSecrets** (everything else). Chart provisions the ExternalSecret; the PipelineRun explicitly mounts it as a workspace volume. The SA itself has no permission — the binding is "this PipelineRun mounts this Secret as a volume by name." Preferred because the secret usage is visible in the target repo's git history.
+
+### What the chart renders per secret entry
+
+For each `imagePullSecrets[*]`:
+- `ExternalSecret` of `type: kubernetes.io/dockerconfigjson` syncing the 1Password item.
+- An entry appended to `pipeline-sa.imagePullSecrets`.
+
+For each `workspaceSecrets[*]`:
+- `ExternalSecret` of `type: Opaque` syncing the 1Password item.
+- Nothing on the SA. The `.tekton/pull-request.yaml` PipelineRun must mount it explicitly.
+
+### Auto-collapsed `okToTest` when secrets present
+
+A tenant with secrets must not allow `/ok-to-test` to expand the trust circle — it would let an arbitrary user exfiltrate every secret in the namespace via a PR that mounts and `cat`s them. The chart computes `okToTest` per tenant:
+
+```yaml
+{{- define "pac-tenant.okToTest" -}}
+{{- if or .tenant.secrets.imagePullSecrets .tenant.secrets.workspaceSecrets -}}
+  {{- toYaml (.tenant.policy.pullRequest | default .root.Values.defaults.policy.pullRequest) -}}
+{{- else -}}
+  {{- toYaml (.tenant.policy.okToTest | default .root.Values.defaults.policy.okToTest) -}}
+{{- end -}}
+```
+
+If a tenant declares any secret, `okToTest` ≡ `pullRequest` allowlist. Adding a contributor to a secret-bearing tenant is a kustomization commit, not a chat command.
+
+## Conversion skill — `/convert-gha-workflow`
+
+Skill at `.claude/skills/convert-gha-workflow/SKILL.md`. Frontmatter:
+
+```yaml
+---
+name: convert-gha-workflow
+description: Convert a target repo's .github/workflows/*.yml into .tekton/*.yaml for OpenShift Pipelines as Code, prune the GHA workflows to publish-on-main only, and emit a secret-migration report.
+argument-hint: [path-to-target-repo] [--auto|-y]
+disable-model-invocation: true
+allowed-tools: Read, Write, Edit, Bash(yq *), Bash(find *), Bash(ls *), Bash(cat *), Bash(git *)
+---
+```
+
+### What it does
+
+1. **Discover** all `.github/workflows/*.{yml,yaml}` in the target repo.
+2. **Parse** each (`yq '.'`) into structured form: triggers, jobs, steps, matrix, secrets references, action references.
+3. **Categorize** each job:
+
+   | Bucket | Examples | Destination |
+   |---|---|---|
+   | PR-checkable | lint, format, vet, type-check, unit test | `.tekton/pull-request.yaml` |
+   | Build/test artifact-producing, non-publishing | `go build`, `npm build`, image build (no push) | `.tekton/pull-request.yaml` |
+   | Publish/release/deploy | docker push, GitHub Release, deploy ssh, npm publish, helm push | stays in GHA, pruned to `push:main` |
+   | Unsupported | self-hosted-runner-only, GHA-specific actions with no Tekton analog | flagged in report, left in GHA with TODO |
+
+4. **Transform** PR-bucket jobs to Tekton Tasks (see mapping table below).
+5. **Prune** the original workflow file: remove migrated jobs, restrict trigger to `on: push: branches: [main]`, rename file from `ci.yml` to `publish.yml` if all migrated jobs were CI.
+6. **Emit** `.tekton/pull-request.yaml`, `.tekton/README.md`, and a terminal migration report.
+
+### Action mapping table (`.claude/skills/convert-gha-workflow/mappings.yaml`)
+
+Initial set:
+
+| GHA action | Tekton replacement |
+|---|---|
+| `actions/checkout@v4` | (drop — implicit; PaC pre-populates `source` workspace) |
+| `actions/setup-go@v5` | `image: docker.io/golang:<v>` |
+| `actions/setup-node@v4` | `image: docker.io/node:<v>-bookworm` |
+| `actions/setup-python@v5` | `image: docker.io/python:<v>` |
+| `actions/setup-java@v4` | `image: docker.io/eclipse-temurin:<v>` |
+| `actions/cache@v4` | volumeClaimTemplate or workspace PVC + cache key script |
+| `docker/setup-buildx-action@v3` | (drop — buildah handles natively) |
+| `docker/login-action@v3` | imagePullSecrets on SA (Mode A) — flagged for tenant config |
+| `docker/build-push-action@v6` | Hub task `buildah` with `--isolation=chroot` |
+| `golangci/golangci-lint-action@v6` | `image: docker.io/golangci/golangci-lint:v<x>-alpine` |
+| `pre-commit/action@v3` | `image: docker.io/python:3.12` + `pip install pre-commit && pre-commit run --all-files` |
+| `azure/setup-helm@v5` | `image: alpine/helm:<v>` |
+| `imranismail/setup-kustomize@v3` | `image: registry.k8s.io/kustomize/kustomize:v5.4.3` |
+| `yannh/kubeconform@v1` | inline `curl + tar` install in alpine, or custom step |
+| `actions/github-script@v7` | UNMAPPED (flag — would need GH App API call from cluster, not in scope) |
+| `actions/upload-artifact@v4` | flagged — Tekton has no native artifact storage; user picks workspace persistence or skips |
+| `redhat-actions/podman-login@v1` | imagePullSecrets on SA (Mode A) — same flow as `docker/login-action`, just different registry target |
+| `redhat-actions/push-to-registry@v2` | flagged PUBLISH — stays in GHA per the hybrid split |
+| `docker/setup-qemu-action@v4` | UNMAPPED (flag — multi-arch buildah is non-trivial; out of scope for v1) |
+| `docker/metadata-action@v6` | inline `script:` step deriving tags from `$(params.revision)` / `$(params.git-ref)` / git-tag lookup |
+| `bjw-s-labs/action-changed-files@v0.6.0` | inline `git diff --name-only $(params.base-revision)...$(params.revision)` exported via `results.changed-files` |
+| `anchore/sbom-action@v0` | Hub task `syft-sbom`, or inline `syft` on `docker.io/anchore/syft:latest` |
+| `devcontainers/ci@v0.3` | UNMAPPED — recursive devcontainer build; stays in GHA |
+
+Stored as data, not embedded in the prompt — grow-able without skill edits.
+
+### Reusable workflows (`uses: ./.github/workflows/foo.yml`)
+
+`igou-ansible` has three publisher workflows that all `uses: ./.github/workflows/ee-build.yml`. The Tekton analog is a shared Pipeline definition referenced from multiple PipelineRuns via the git resolver. v1 of the conversion skill **does not** auto-migrate this pattern — when it encounters a workflow-call reference, it:
+
+1. Logs the reference in the migration report.
+2. Leaves the calling workflow in GHA with a TODO comment.
+3. Does not attempt to inline the called workflow.
+
+For `igou-ansible` specifically, the EE-build workflows are publish-side anyway (per the GHA-stays-on-main split), so they all stay in GHA. The reusable-workflow → shared-Pipeline migration is a v2 skill enhancement, only relevant when a *PR-side* workflow chains to a reusable.
+
+### Output structure
+
+Target repo after running the skill:
+
+```
+target-repo/
+├── .github/workflows/
+│   └── publish.yml                # was ci.yml; pruned to publish-only,
+│                                  # trigger restricted to push:main
+└── .tekton/
+    ├── pull-request.yaml          # PR PipelineRun
+    └── README.md                  # generated: how to test, what was migrated
+```
+
+### Migration report (printed to terminal)
+
+```
+Migration of github.com/igou-io/foo:
+  ✓ Job 'lint' → .tekton/pull-request.yaml (Task: lint)
+  ✓ Job 'test' → .tekton/pull-request.yaml (Task: test, matrix: go-version)
+  ✓ Job 'build-image' → .tekton/pull-request.yaml (Task: image-build, no push)
+  ↩ Job 'publish' → stays in .github/workflows/publish.yml (push:main only)
+  ⚠ Job 'release-notes' uses actions/github-script — left in GHA with TODO
+
+Secret migration:
+  GHCR_TOKEN  → tenant.secrets.imagePullSecrets (1Password: ci-ghcr-readonly)
+  CODECOV_TOKEN → tenant.secrets.workspaceSecrets (1Password: ci-codecov)
+
+Next steps:
+  1. Review .tekton/pull-request.yaml for unmapped steps (search 'UNMAPPED ACTION')
+  2. In igou-openshift: /scaffold-pac-tenant igou-io/foo  (if not already onboarded)
+  3. Add secret entries to clusters/ocp/pac-tenants/values.yaml under tenant 'foo'
+  4. Add 'ci-ghcr-readonly' + 'ci-codecov' to 1Password vault
+  5. Commit + push both repos; verify PaC fires on first PR.
+```
+
+### Sibling skill — `/scaffold-pac-tenant`
+
+Skill at `.claude/skills/scaffold-pac-tenant/SKILL.md`. Frontmatter:
+
+```yaml
+---
+name: scaffold-pac-tenant
+description: Add a new PaC tenant entry to clusters/ocp/pac-tenants/values.yaml. Verifies the GitHub repo exists, derives a name from the URL, applies defaults, supports optional --imagePullSecret and --workspaceSecret flags. Validates the rendered chart with helm template + kubeconform before reporting completion.
+argument-hint: <github-url-or-owner/repo> [--imagePullSecret name:1pwd-item] [--workspaceSecret name:1pwd-item ...]
+disable-model-invocation: true
+allowed-tools: Read, Edit, Bash(gh repo view *), Bash(yq *), Bash(helm template *), Bash(kubeconform *)
+---
+```
+
+Edits one file (`clusters/ocp/pac-tenants/values.yaml`), runs validation, asks the user to commit.
+
+### What both skills don't do
+
+- **Don't auto-commit.** Skills write files and exit. User reviews diffs before committing.
+- **Don't install the GitHub App on a repo.** Manual one-click in the GitHub UI per repo. Skill prints the App URL.
+- **Don't push.** PaC fires on the PR opening — that's also the test of the conversion.
+
+## Rollout sequence
+
+1. **Manual: create GitHub App** on github.com. Permissions: `Checks: R/W`, `Contents: R`, `Issues: R/W`, `Metadata: R`, `Pull requests: R/W`. Subscribe: `Check run`, `Check suite`, `Commit comment`, `Issue comment`, `Pull request`, `Push`. Webhook URL = placeholder.
+2. **Manual: store GitHub App credentials** in 1Password as item `pac-github-app`.
+3. **Manual: store cosign key** in 1Password as item `tekton-chains-signing`.
+4. **Manual: edit Tailscale ACL** to grant `funnel` to operator's device tag.
+5. **Commit `components/openshift-pipelines/` updates.** ArgoCD reconciles in waves 10/11/12.
+6. **Wait for Funnel hostname** to come up. Update GitHub App webhook URL.
+7. **Commit `.helm/charts/pac-tenant/`.**
+8. **Commit `clusters/ocp/pac-tenants/`** with empty `tenants:` list, plus the `pac-tenants` entry in `clusters/ocp/values.yaml`.
+9. **Commit `.claude/skills/scaffold-pac-tenant/` and `.claude/skills/convert-gha-workflow/`.**
+10. **First tenant onboarding (smoke test):** install GitHub App on `igou-io/igou-openshift`. Run `/scaffold-pac-tenant igou-io/igou-openshift`. Run `/convert-gha-workflow .` (against this repo). Open a PR with the resulting `.tekton/pull-request.yaml`. Watch PaC fire.
+11. **Onboard remaining repos** in waves of 2–3.
+
+## Validation
+
+Existing `make` targets:
+- `make lint` — yamllint
+- `make validate-kustomize` — `kustomize build` over every `kustomization.yaml`
+- `make validate-schemas` — kubeconform
+
+Required additions to the Makefile:
+- **CRD schemas for kubeconform** — `operator.tekton.dev/v1alpha1.TektonConfig`, `pipelinesascode.tekton.dev/v1alpha1.Repository`, `tekton.dev/v1.PipelineRun`. Add to schema lookup paths.
+- **`make lint-helm`** — runs `helm lint` over `.helm/charts/pac-tenant`, `.helm/charts/argocd-app-of-app`, `.helm/charts/ocp-base-config`. New target; chained into `make test`.
+- **`clusters/ocp/pac-tenants/` validation** — `helm template` it, pipe through kubeconform. Add to existing `validate-kustomize` (which is the umbrella render-then-validate target).
+
+## Smoke test acceptance criteria
+
+A single PR on `igou-io/igou-openshift` that:
+1. Adds `.tekton/pull-request.yaml` with one task that runs `make lint`.
+2. Touches no other file.
+
+Expected:
+- PaC controller logs show webhook received + signature verified.
+- New PipelineRun appears in `ci-igou-openshift` namespace.
+- GitHub PR shows a "Pipelines as Code (homelab) / lint" check that turns green.
+- ArgoCD's `pac-tenants` app stays Synced/Healthy.
+- TaskRun pod spec shows: `automountServiceAccountToken: false`, `runAsNonRoot: true`, `priorityClassName: tekton-ci-low`.
+- Three NetworkPolicies in `ci-igou-openshift`. Egress to github.com works; egress to `192.168.x.x` fails (`oc rsh` into a paused pod, `nc -zv 192.168.1.1 22` should hang).
+
+If all pass, hardening is real and the rest of the migration is mechanical.
+
+## Rollback paths
+
+- **Per-tenant disable:** delete the tenant entry from `clusters/ocp/pac-tenants/values.yaml`. Sync. Namespace stays orphaned (auto-prune is off per repo convention) but PaC stops reacting to that repo.
+- **Cluster-wide disable:** flip `TektonConfig.spec.platforms.openshift.pipelinesAsCode.enable: false`. Operator scales the PaC controller to zero. Webhooks 503; GitHub will show webhook delivery failures and back off.
+- **Full uninstall:** delete the `pac-tenants` ArgoCD app + the `openshift-pipelines` ArgoCD app. The operator's CSV cleans up most resources. Tenant namespaces remain (manual cleanup).
+
+## Open questions / things to verify at implementation time
+
+1. **OCP pod and service CIDRs** — `clusters/ocp/values.yaml` excerpts and `oc get network.config/cluster` should be checked before committing the NetworkPolicy CIDR allowlist.
+2. **Tailscale operator's device tag** — verify the actual tag the operator uses on its proxy device, then write the matching ACL entry. Default is typically `tag:k8s` but is configurable.
+3. **`pipelines-as-code-secret` exact key names** — operator versions have shifted these slightly. Verify against the deployed operator's PaC controller env-var bindings.
+4. **PaC controller Service selector labels** — confirm `app.kubernetes.io/name: controller` + `app.kubernetes.io/part-of: pipelines-as-code` against the live cluster's Service. The Funnel Service uses the same selector to attach.
+5. **First conversion target** — `igou-openshift`'s own `validate.yml` is the obvious smoke-test candidate, but it uses `imranismail/setup-kustomize` and `azure/setup-helm` which are in the mapping table. Verify these resolve cleanly before committing.


### PR DESCRIPTION
## Summary

Phase 1 of OpenShift Pipelines as Code adoption — operator-side resources only. Chart, cluster instantiation, Makefile, and skills follow in PR-2 once this PR's cluster health is verified.

This PR adds (under `components/openshift-pipelines/`):

- `tekton-ci-low-priorityclass.yaml` — low-priority class for PR PipelineRun pods, preempted under cluster pressure.
- `tektonconfig.yaml` — pins operator behavior: `profile: all`, pruner (20 keep / 7d max), all four resolvers, Chains in OCI mode (no Rekor / no Fulcio), PaC settings including `auto-configure-new-github-repo: false`, hardened pod-template defaults (no token mount, RuntimeDefault seccomp, runAsNonRoot, `tekton-ci-low` priority).
- `pac-github-app-externalsecret.yaml` — materializes `pipelines-as-code-secret` from 1Password item `pac-github-app`.
- `chains-signing-externalsecret.yaml` — materializes `signing-secrets` in `tekton-chains` from 1Password item `tekton-chains-signing`.
- `pac-controller-funnel-service.yaml` — second Service fronting the operator-owned PaC controller, annotated for Tailscale Funnel exposure (hostname `pac-ocp.<tailnet>.ts.net`).
- Updated `kustomization.yaml` to include all five.

Plus the design spec (`docs/superpowers/specs/2026-05-09-pipelines-as-code-design.md`) and implementation plan (`docs/superpowers/plans/2026-05-09-pipelines-as-code.md`) for context.

Sync-wave order: `10` (PriorityClass) → `11` (TektonConfig) → `12` (ExternalSecrets) → `13` (Funnel Service).

## Required prereqs (cluster will be unhealthy without these)

Before merging, both 1Password items must exist in the vault that `onepassword-sdk-ocp-pull` reads from. The Tailscale ACL must grant `funnel` to the operator's device tag. The GitHub App must exist on github.com. See the spec/plan docs for exact field names and the App permissions/events.

## Verification after merge

```bash
argocd app get openshift-pipelines | grep -E 'Sync Status|Health Status'
oc get externalsecret -n openshift-pipelines pipelines-as-code-secret
oc get externalsecret -n tekton-chains signing-secrets
oc get tektonconfig config -o jsonpath='{.status.conditions[?(@.type=="Ready")].status}'
oc get pods -n openshift-pipelines -l app.kubernetes.io/part-of=pipelines-as-code
oc get pods -n tekton-chains
oc get svc -n openshift-pipelines pac-controller-funnel -o yaml | grep tailscale.com
```

Once Funnel hostname is up, update the GitHub App's webhook URL on github.com to the `https://pac-ocp.<tailnet>.ts.net/` URL.

## Test plan

- [ ] 1Password items `pac-github-app` and `tekton-chains-signing` created with correct field names
- [ ] Tailscale ACL updated with `funnel` attribute for operator tag
- [ ] GitHub App created (placeholder webhook URL OK pre-merge)
- [ ] PR merged
- [ ] ArgoCD reports `openshift-pipelines` as Synced/Healthy
- [ ] Both ExternalSecrets report `STATUS=SecretSynced, READY=True`
- [ ] TektonConfig `Ready=True`
- [ ] PaC controller and Chains controller pods Running
- [ ] Funnel hostname resolvable via DNS, returns HTTPS
- [ ] GitHub App webhook URL updated to Funnel hostname
- [ ] First webhook delivery from "save changes" returns HTTP 200

🤖 Generated with [Claude Code](https://claude.com/claude-code)