### PR TITLE
pac-tenants: silence pipeline SA dockercfg drift in ArgoCD

### DIFF
--- a/clusters/ocp/values.yaml
+++ b/clusters/ocp/values.yaml
@@ -204,6 +204,16 @@ applications:
       argocd.argoproj.io/sync-wave: '20'
     source:
       path: clusters/ocp/pac-tenants
+    # OpenShift's image-registry-pull-secrets controller injects the
+    # auto-generated `<sa>-dockercfg-*` entry into the operator-owned
+    # `pipeline` SA's imagePullSecrets/secrets. SSA prevents us from
+    # overwriting it, but ArgoCD's diff still flags it as OutOfSync.
+    # Defer those fields to that controller via field-manager scoping.
+    ignoreDifferences:
+      - group: ""
+        kind: ServiceAccount
+        managedFieldsManagers:
+          - openshift.io/image-registry-pull-secrets_service-account-controller
 
   intel-device-plugins-operator:
     annotations:


### PR DESCRIPTION
## Summary

The `pac-tenants` ArgoCD Application has been stuck `OutOfSync` since the migration to the operator-managed `pipeline` ServiceAccount (commits f787260 / 5fc202e / 5e16a52). Three resources were flagged:

| Resource | Cause | Fix |
|---|---|---|
| `ServiceAccount/ci-igou-ansible/pipeline-sa` | Orphaned by chart; auto-prune disabled | Deleted manually (no live consumers) |
| `RoleBinding/ci-igou-ansible/pipeline-sa-pipelines-scc` | Same | Deleted manually |
| `ServiceAccount/ci-igou-ansible/pipeline` | OpenShift's `image-registry-pull-secrets_service-account-controller` injects `pipeline-dockercfg-*` into `imagePullSecrets`/`secrets`; SSA prevents overwrite but ArgoCD's diff still flags it | This PR — `ignoreDifferences` scoped to that field manager |

The orphan deletions are already done on the cluster (independent of git state). This PR fixes the recurring drift.

### Why field-manager scoping vs `jsonPointers`

`managedFieldsManagers` only ignores fields owned by that controller. Chart-driven changes to `imagePullSecrets`/`secrets` (e.g. adding a new `serviceAccountSecret` in tenant values) still surface as drift. `jsonPointers: [/imagePullSecrets, /secrets]` would mask those too.

## Test plan

- [x] `make test` passes locally
- [ ] After merge, ArgoCD `pac-tenants` reports `Synced` + `Healthy`
- [ ] Adding a new `serviceAccountSecret` to a tenant in `values.yaml` still triggers OutOfSync (i.e. the ignore is correctly scoped)

🤖 Generated with [Claude Code](https://claude.com/claude-code)