### PR TITLE
storage: set NVMe-oF ctrl-loss-tmo=-1 to survive network outages

### DIFF
--- a/clusters/ocp/democratic-csi/democratic-csi-nvmeof-cold-externalsecret.yml
+++ b/clusters/ocp/democratic-csi/democratic-csi-nvmeof-cold-externalsecret.yml
@@ -63,8 +63,13 @@ spec:
             zvolEnableReservation: true
             zvolBlocksize:
           nvmeof:
+            # ctrl-loss-tmo=-1 keeps the NVMe-oF controller alive indefinitely when the
+            # transport drops (e.g. a network outage) instead of tearing it down after the
+            # 600s default. This preserves the /dev/nvmeXn1 device identity so it reconnects
+            # cleanly, avoiding the failure mode where a renumbered device makes kubelet's
+            # NodeUnstageVolume fail and leaves RWO volumes permanently Multi-Attach stuck.
             transports:
-              - "tcp://{{ .truenas_host }}:4420"
+              - "tcp://{{ .truenas_host }}:4420?ctrl-loss-tmo=-1&reconnect-delay=10"
             namePrefix: "csi-"
             nameSuffix: "-ocp"
             ports:

--- a/clusters/ocp/democratic-csi/democratic-csi-nvmeof-fast-externalsecret.yml
+++ b/clusters/ocp/democratic-csi/democratic-csi-nvmeof-fast-externalsecret.yml
@@ -63,8 +63,13 @@ spec:
             zvolEnableReservation: false
             zvolBlocksize:
           nvmeof:
+            # ctrl-loss-tmo=-1 keeps the NVMe-oF controller alive indefinitely when the
+            # transport drops (e.g. a network outage) instead of tearing it down after the
+            # 600s default. This preserves the /dev/nvmeXn1 device identity so it reconnects
+            # cleanly, avoiding the failure mode where a renumbered device makes kubelet's
+            # NodeUnstageVolume fail and leaves RWO volumes permanently Multi-Attach stuck.
             transports:
-              - "tcp://{{ .truenas_host }}:4420"
+              - "tcp://{{ .truenas_host }}:4420?ctrl-loss-tmo=-1&reconnect-delay=10"
             namePrefix: "csi-"
             nameSuffix: "-ocp"
             ports:

--- a/clusters/ocp/democratic-csi/democratic-csi-nvmeof-ssd-externalsecret.yml
+++ b/clusters/ocp/democratic-csi/democratic-csi-nvmeof-ssd-externalsecret.yml
@@ -63,8 +63,13 @@ spec:
             zvolEnableReservation: false
             zvolBlocksize:
           nvmeof:
+            # ctrl-loss-tmo=-1 keeps the NVMe-oF controller alive indefinitely when the
+            # transport drops (e.g. a network outage) instead of tearing it down after the
+            # 600s default. This preserves the /dev/nvmeXn1 device identity so it reconnects
+            # cleanly, avoiding the failure mode where a renumbered device makes kubelet's
+            # NodeUnstageVolume fail and leaves RWO volumes permanently Multi-Attach stuck.
             transports:
-              - "tcp://{{ .truenas_host }}:4420"
+              - "tcp://{{ .truenas_host }}:4420?ctrl-loss-tmo=-1&reconnect-delay=10"
             namePrefix: "csi-"
             nameSuffix: "-ocp"
             ports:


### PR DESCRIPTION
After a network outage, the NVMe-oF TCP controllers were torn down once the transport loss exceeded the kernel default ctrl_loss_tmo (600s). On reconnect they came back with new controller numbers, so the cached /dev/nvmeXn1 device paths vanished. democratic-csi's NodeUnstageVolume then failed permanently (lsblk on the missing device), kubelet kept the volumes in node.status.volumesInUse, and the attach-detach controller refused to detach them — leaving RWO volumes stuck in Multi-Attach and their pods unschedulable until kubelet was restarted on the holding node.

Append ctrl-loss-tmo=-1&reconnect-delay=10 to the nvmeof transport URLs (fast/ssd/cold pools) so the controller is never torn down and reconnects with the same device identity, eliminating the stuck-unstage failure mode.