### PR TITLE
feat(tailscale): roll out tailscale-operator on ocp

### DIFF
--- a/clusters/ocp/values.yaml
+++ b/clusters/ocp/values.yaml
@@ -247,6 +247,15 @@ applications:
     source:
       path: components/grafana
 
+  tailscale-operator:
+    annotations:
+      argocd.argoproj.io/compare-options: IgnoreExtraneous
+      argocd.argoproj.io/sync-wave: '10'
+    destination:
+      namespace: tailscale
+    source:
+      path: components/tailscale-operator
+
   cloudnative-pg:
     annotations:
       argocd.argoproj.io/compare-options: IgnoreExtraneous


### PR DESCRIPTION
Register `components/tailscale-operator` in the cluster app list (sync wave 10).

Prerequisites provisioned out-of-band:
- Tailscale OAuth client (tags `tag:k8s-operator`, `tag:k8s`)
- 1Password `tailscale-oauth` item, pulled by the `operator-oauth` ExternalSecret via `onepassword-sdk-ocp-pull`

Already applied to the cluster with `oc apply -k` for testing: the ExternalSecret synced, the operator pod is 1/1 Running, and logs show a clean OAuth login (`machineAuthorized=true`). Merging lets Argo CD adopt and manage the resources.

🤖 Generated with [Claude Code](https://claude.com/claude-code)