### PR TITLE
fix(tailscale): write ExternalSecret extract defaults explicitly

### DIFF
--- a/components/tailscale-operator/operator-oauth-externalsecret.yml
+++ b/components/tailscale-operator/operator-oauth-externalsecret.yml
@@ -13,3 +13,10 @@ spec:
   dataFrom:
   - extract:
       key: tailscale-oauth
+      # Defaults written explicitly: dataFrom merges atomically, so ArgoCD's
+      # predicted live state drops API-defaulted fields and the app reports
+      # perpetually OutOfSync without them.
+      conversionStrategy: Default
+      decodingStrategy: None
+      metadataPolicy: None
+      nullBytePolicy: Ignore


### PR DESCRIPTION
Follow-up to #302: the `operator-oauth` ExternalSecret reports perpetually OutOfSync because `dataFrom` merges atomically — ArgoCD's predicted live state drops the API-defaulted extract fields (`conversionStrategy`, `decodingStrategy`, `metadataPolicy`, `nullBytePolicy`). Writing them explicitly makes target == live. Verified against the app's `predictedLiveState` vs `normalizedLiveState` via the ArgoCD API.

🤖 Generated with [Claude Code](https://claude.com/claude-code)