### PR TITLE
feat(tailscale): egress proxy to node_exporter on the igou.io VPS

### DIFF
--- a/components/tailscale-operator/igou-io-node-exporter-egress.yml
+++ b/components/tailscale-operator/igou-io-node-exporter-egress.yml
@@ -1,0 +1,22 @@
+---
+# Cluster egress to node_exporter on the igou.io VPS. The operator replaces
+# this ExternalName Service with a proxy pod that joins the tailnet tagged
+# tag:openshift - the tag the ACL grant (tag:openshift -> tag:vps tcp/9100)
+# matches. Workloads (Prometheus) reach the VPS at
+# igou-io-node-exporter.tailscale.svc.cluster.local:9100.
+apiVersion: v1
+kind: Service
+metadata:
+  name: igou-io-node-exporter
+  annotations:
+    # MagicDNS name of the VPS; tracks the device if its tailnet IP changes.
+    tailscale.com/tailnet-fqdn: "racknerd-49580b0.weasel-alioth.ts.net"
+    # Override the proxy's device tags (default would be tag:k8s).
+    tailscale.com/tags: "tag:openshift"
+spec:
+  type: ExternalName
+  externalName: placeholder  # rewritten by the operator
+  ports:
+    - name: metrics
+      port: 9100
+      protocol: TCP

--- a/components/tailscale-operator/kustomization.yaml
+++ b/components/tailscale-operator/kustomization.yaml
@@ -4,6 +4,7 @@ resources:
   - tailscale-operator-anyuid-clusterrolebinding.yaml
   - tailscale-proxies-privileged-clusterrolebinding.yaml
   - operator-oauth-externalsecret.yml
+  - igou-io-node-exporter-egress.yml
 helmCharts:
 - name: tailscale-operator
   includeCRDs: true


### PR DESCRIPTION
Adds an ExternalName Service to the tailscale-operator component; the operator replaces it with an egress proxy pod that joins the tailnet tagged `tag:openshift` — the src of the one-way `tag:openshift → tag:vps tcp/9100` grant. Cluster workloads (Prometheus) reach the VPS node_exporter at `igou-io-node-exporter.tailscale.svc.cluster.local:9100`; the VPS cannot initiate connections back.

Pairs with igou-io/igou-inventory#47 (node_exporter rebind to the VPS tailnet address).

🤖 Generated with [Claude Code](https://claude.com/claude-code)