### PR TITLE
feat(tailscale): scrape the VPS node_exporter via UWM

### DIFF
--- a/components/tailscale-operator/igou-io-node-exporter-egress.yml
+++ b/components/tailscale-operator/igou-io-node-exporter-egress.yml
@@ -20,3 +20,39 @@ spec:
     - name: metrics
       port: 9100
       protocol: TCP
+---
+# Scrape plumbing: the operator's own headless Service carries no ports, so
+# this selector Service targets the proxy pod (stable tailscale.com/* labels
+# survive pod restarts) and the ServiceMonitor hands it to user-workload
+# monitoring. Traffic to the pod on 9100 is DNAT'd to the VPS exporter.
+apiVersion: v1
+kind: Service
+metadata:
+  name: igou-io-node-exporter-metrics
+  labels:
+    app.kubernetes.io/name: igou-io-node-exporter-metrics
+spec:
+  selector:
+    tailscale.com/managed: "true"
+    tailscale.com/parent-resource: igou-io-node-exporter
+  ports:
+    - name: metrics
+      port: 9100
+      targetPort: 9100
+      protocol: TCP
+---
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  name: igou-io-node-exporter
+spec:
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: igou-io-node-exporter-metrics
+  endpoints:
+    - port: metrics
+      interval: 30s
+      relabelings:
+        # The target address is the in-cluster proxy; name the real source.
+        - targetLabel: instance
+          replacement: igou.io


### PR DESCRIPTION
Selector Service over the egress proxy pod + ServiceMonitor for user-workload monitoring; `instance` relabeled to `igou.io`. Completes the scrape path from igou-io/igou-openshift#304.

🤖 Generated with [Claude Code](https://claude.com/claude-code)