### PR TITLE
feat(grafana): add Node Exporter Full dashboard (1860)

### DIFF
--- a/components/grafana/grafana-dashboard-1860.yaml
+++ b/components/grafana/grafana-dashboard-1860.yaml
@@ -1,0 +1,18 @@
+---
+apiVersion: grafana.integreatly.org/v1beta1
+kind: GrafanaDashboard
+metadata:
+  name: grafana-dashboard-1860
+  namespace: grafana
+  annotations:
+    argocd.argoproj.io/sync-wave: '12'
+spec:
+  instanceSelector:
+    matchLabels:
+      dashboards: grafana
+  resyncPeriod: 24h
+  datasources:
+    - inputName: DS_PROMETHEUS
+      datasourceName: thanos-querier
+  grafanaCom:
+    id: 1860

--- a/components/grafana/kustomization.yaml
+++ b/components/grafana/kustomization.yaml
@@ -18,6 +18,7 @@ resources:
   - grafana-dashboard-14584.yaml
   - grafana-dashboard-20417.yaml
   - grafana-dashboard-13679.yaml
+  - grafana-dashboard-1860.yaml
   - grafana-dashboard-kubevirt-control-plane.yaml
   - grafana-dashboard-kubevirt-top-consumers.yaml
   - grafana-dashboard-external-secrets.yaml


### PR DESCRIPTION
Adds grafana.com dashboard **1860 (Node Exporter Full)** as a `GrafanaDashboard` CR, following the same pattern as the other community dashboards (`DS_PROMETHEUS` → `thanos-querier`, sync-wave 12).

Surfaces the igou.io VPS node_exporter (`instance="igou.io"`, scraped via the tailscale egress proxy from igou-io/igou-openshift#304/#305) alongside the cluster nodes. Verified before opening: the thanos-querier datasource returns `node_uname_info`/`node_load1` for `instance="igou.io"`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)