### PR TITLE
feat(monitoring): blackbox probe for https://igou.io

### DIFF
--- a/components/user-workload-monitoring/exporters/blackbox-exporter/kustomization.yaml
+++ b/components/user-workload-monitoring/exporters/blackbox-exporter/kustomization.yaml
@@ -6,6 +6,7 @@ resources:
   - blackbox-exporter-prometheusrule.yaml
   - probes/infra-https-probe.yaml
   - probes/saas-https-probe.yaml
+  - probes/igou-io-probe.yaml
 helmCharts:
   - name: prometheus-blackbox-exporter
     namespace: blackbox-exporter

--- a/components/user-workload-monitoring/exporters/blackbox-exporter/probes/igou-io-probe.yaml
+++ b/components/user-workload-monitoring/exporters/blackbox-exporter/probes/igou-io-probe.yaml
@@ -1,0 +1,28 @@
+---
+# External (public-internet) uptime + TLS probe of the personal website. The
+# in-cluster blackbox-exporter reaches https://igou.io over egress, a true
+# outside-in check of the VPS site, independent of the tailnet path used for
+# node_exporter. tier=critical enrolls it in BlackboxProbeFailedCritical and
+# the BlackboxSSLCertExpiring* alerts (the LE cert is auto-renewed weekly by
+# AAP; this catches a renewal that did not land). http_2xx follows the apex
+# 80->443 redirect and asserts a 2xx over TLS.
+apiVersion: monitoring.coreos.com/v1
+kind: Probe
+metadata:
+  name: igou-io
+  namespace: blackbox-exporter
+  labels:
+    app.kubernetes.io/name: blackbox-exporter
+spec:
+  interval: 60s
+  module: http_2xx
+  prober:
+    url: blackbox-exporter.blackbox-exporter.svc:9115
+  targets:
+    staticConfig:
+      static:
+        - https://igou.io
+      labels:
+        tier: critical
+        category: website
+        owner: platform


### PR DESCRIPTION
Adds a `tier=critical` blackbox `Probe` for the public website **https://igou.io**, scraped by the existing in-cluster blackbox-exporter over egress — an outside-in uptime + TLS check, independent of the tailnet path used for node_exporter.

No new infra: reuses the deployed blackbox-exporter, the `http_2xx` module, and the generic PrometheusRule (BlackboxProbeFailed/Critical, slow, SSL-cert-expiry all key off `probe_success`/`probe_ssl_earliest_cert_expiry`, so igou.io is auto-covered). Surfaces in the existing Blackbox dashboard (7587).

Verified pre-merge: `oc apply --dry-run=server` accepts the Probe; igou.io returns 200 over TLS.

🤖 Generated with [Claude Code](https://claude.com/claude-code)