### PR TITLE
fix(tailscale): clear tailscale-operator OutOfSync on the VPS node-exporter egress

### DIFF
--- a/clusters/ocp/values.yaml
+++ b/clusters/ocp/values.yaml
@@ -262,6 +262,16 @@ applications:
       namespace: tailscale
     source:
       path: components/tailscale-operator
+    # The operator rewrites the igou-io-node-exporter egress Service's
+    # spec.externalName from the git placeholder to its proxy FQDN. Defer that
+    # field to the operator so the app doesn't sit permanently OutOfSync.
+    ignoreDifferences:
+      - group: ""
+        kind: Service
+        name: igou-io-node-exporter
+        namespace: tailscale
+        jsonPointers:
+          - /spec/externalName
 
   cloudnative-pg:
     annotations:

--- a/components/tailscale-operator/igou-io-node-exporter-egress.yml
+++ b/components/tailscale-operator/igou-io-node-exporter-egress.yml
@@ -54,5 +54,8 @@ spec:
       interval: 30s
       relabelings:
         # The target address is the in-cluster proxy; name the real source.
-        - targetLabel: instance
+        # action:replace is the CRD default — set it explicitly so the rendered
+        # manifest matches the live object and ArgoCD stays Synced.
+        - action: replace
+          targetLabel: instance
           replacement: igou.io


### PR DESCRIPTION
## Summary

The `tailscale-operator` ArgoCD app has been stuck **OutOfSync** (pre-existing, since the VPS node-exporter egress setup landed) because two fields are mutated after apply with no `ignoreDifferences`:

- **`Service/igou-io-node-exporter`** — the Tailscale operator rewrites `spec.externalName` from the git `placeholder` to its proxy FQDN (`ts-igou-io-node-exporter-…tailscale.svc.cluster.local`). `oc diff` confirms this is the *only* Service drift.
- **`ServiceMonitor/igou-io-node-exporter`** — the CRD defaults `relabelings[].action: replace`, which is absent from the git manifest.

Both are controller/CRD-defaulted fields, not real config drift, so the fix is non-destructive — the egress proxy + Prometheus scraping keep working:

- Add `ignoreDifferences` for the Service's `/spec/externalName` to the `tailscale-operator` app entry (defer that field to the operator).
- Set `action: replace` explicitly on the ServiceMonitor relabeling so the rendered manifest matches the live object.

## Test Plan

- [x] `make test` green (yamllint + kustomize build + kubeconform)
- [x] rendered `tailscale-operator` Application carries the `ignoreDifferences` block for `Service/igou-io-node-exporter` `/spec/externalName`
- [ ] after merge + sync: `tailscale-operator` app returns to **Synced / Healthy**

🤖 Generated with [Claude Code](https://claude.com/claude-code)
