### PR TITLE
fix(ci): skip NVIDIADriver in kubeconform (stale datreeio schema)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -16,13 +16,15 @@ validate-kustomize: ## Validate all kustomization.yaml files build successfully
 			exit 1; \
 		fi'
 
-# CoreProvider/InfrastructureProvider/IPAMProvider skipped: the
-# datreeio catalog ships the deprecated `manifestPatches` field but
-# not the newer `patches` field that v1alpha2 actually supports
-# (verified against the live CRD on cluster). Re-enable when
-# datreeio/CRDs-catalog catches up.
+# Kinds skipped because the datreeio CRDs-catalog schema is stale vs the live CRD:
+#  - CoreProvider/InfrastructureProvider/IPAMProvider: catalog ships the deprecated
+#    `manifestPatches` field but not the newer `patches` field that v1alpha2 supports.
+#  - NVIDIADriver: catalog's nvidiadriver_v1alpha1.json lacks the `kernelModuleType`
+#    field the operator added (used by the 580/595 side-by-side drivers; valid on the
+#    live CRD), so `-strict` rejects it as an additional property.
+# All verified against the live CRDs on cluster. Re-enable each when datreeio catches up.
 KUBECONFORM_FLAGS := -strict -ignore-missing-schemas \
-	-skip ClusterSecretStore,MachineSet,CoreProvider,InfrastructureProvider,IPAMProvider \
+	-skip ClusterSecretStore,MachineSet,CoreProvider,InfrastructureProvider,IPAMProvider,NVIDIADriver \
 	-schema-location default \
 	-schema-location 'https://raw.githubusercontent.com/datreeio/CRDs-catalog/main/{{.Group}}/{{.ResourceKind}}_{{.ResourceAPIVersion}}.json' \
 	-summary


### PR DESCRIPTION
## Summary
The **Schema Validation** CI job (`make validate-schemas`) has been failing on every push/PR (incl. `main` and the open renovate PRs). Root cause: the `nvidia-gpu-operator` `NVIDIADriver` CRs (`burst-595`, `pascal-580`) set `spec.kernelModuleType`, but the upstream **datreeio CRDs-catalog** `nvidiadriver_v1alpha1.json` schema is stale and lacks that field — so `kubeconform -strict` rejects it as `additional properties 'kernelModuleType' not allowed` (the field is valid on the live CRD).

Fix: add `NVIDIADriver` to the kubeconform `-skip` list — the **same pattern already used** for the stale CAPI provider schemas (CoreProvider/InfrastructureProvider/IPAMProvider) — with a documenting comment. Re-enable when the catalog catches up.

## Test Plan
- [x] `make validate-schemas` -> rc 0 (was failing); 0 invalid resources anywhere
- [x] `make lint` and `make validate-kustomize` still pass (no regression)
- [x] only `Makefile` changed

🤖 Generated with [Claude Code](https://claude.com/claude-code)