### PR TITLE
fix(hermes-agent): allow qwen35-2b egress + make VAP masquerade-exclusive

### DIFF
--- a/applications/hermes-agent/hermes-egress-networkpolicy.yaml
+++ b/applications/hermes-agent/hermes-egress-networkpolicy.yaml
@@ -22,14 +22,20 @@ spec:
           port: 53
         - protocol: TCP
           port: 53
-    # qwen3 inference service (east-west default LLM)
+    # in-cluster LLM inference (east-west). Allowlist the specific model pods by
+    # label: qwen3-35b-a3b (intended default) and qwen35-2b (currently Ready).
+    # Least-privilege: only these named models are reachable on 8080.
     - to:
         - namespaceSelector:
             matchLabels:
               kubernetes.io/metadata.name: llmkube-system
           podSelector:
-            matchLabels:
-              app: qwen3-35b-a3b
+            matchExpressions:
+              - key: app
+                operator: In
+                values:
+                  - qwen3-35b-a3b
+                  - qwen35-2b
       ports:
         - protocol: TCP
           port: 8080

--- a/applications/hermes-agent/hermes-vm-hardening-validatingadmissionpolicy.yaml
+++ b/applications/hermes-agent/hermes-vm-hardening-validatingadmissionpolicy.yaml
@@ -18,8 +18,12 @@ spec:
   validations:
     - expression: "has(object.spec.template.spec.domain.devices.interfaces) && size(object.spec.template.spec.domain.devices.interfaces) > 0"
       message: "hermes VMs must declare at least one (masquerade) network interface"
-    - expression: "object.spec.template.spec.domain.devices.interfaces.all(i, has(i.masquerade))"
-      message: "hermes VMs must use masquerade networking so EgressFirewall/NetworkPolicy apply"
+    # masquerade must be the EXCLUSIVE binding on every interface: has(masquerade)
+    # alone is presence-only and admits an interface that sets masquerade AND bridge
+    # (etc.), which would escape EgressFirewall/NetworkPolicy. Forbid every other
+    # binding sibling so the interface can only ride the pod network via masquerade.
+    - expression: "object.spec.template.spec.domain.devices.interfaces.all(i, has(i.masquerade) && !has(i.bridge) && !has(i.slirp) && !has(i.sriov) && !has(i.macvtap) && !has(i.passt) && !has(i.binding))"
+      message: "hermes VMs must use masquerade networking exclusively (no bridge/slirp/sriov/macvtap/passt/binding) so EgressFirewall/NetworkPolicy apply"
     - expression: "!has(object.spec.template.spec.domain.devices.hostDevices) || size(object.spec.template.spec.domain.devices.hostDevices) == 0"
       message: "hermes VMs must not attach host devices"
     - expression: "!has(object.spec.template.spec.domain.devices.gpus) || size(object.spec.template.spec.domain.devices.gpus) == 0"


### PR DESCRIPTION
## Summary
Two guardrail hardening fixes surfaced by the live red-team validation of the `hermes` namespace VM guardrails (deployed a conforming CentOS Stream 10 VM + 4 parallel evaluation agents):

- **hermes-egress NetworkPolicy** — allowlist the running `qwen35-2b` model alongside `qwen3-35b-a3b` via `podSelector.matchExpressions In`. `qwen3-35b-a3b` is Stopped while `qwen35-2b` is Ready but was not allowlisted, so the agent had no reachable in-cluster LLM.
- **hermes-vm-hardening VAP rule 2** — require masquerade as the **exclusive** interface binding. The old `all(i, has(i.masquerade))` was presence-only and admitted an interface declaring *both* `masquerade` and `bridge`, which would escape EgressFirewall/NetworkPolicy. Now forbids the `bridge/slirp/sriov/macvtap/passt/binding` siblings (all confirmed in the live `kubevirt.io/v1` Interface schema; CEL compiles via server-side dry-run).

## Test Plan
- [x] `yamllint`, `kustomize build` + `kubeconform` pass
- [x] VAP CEL compiles (server-side dry-run `configured`)
- [ ] Post-merge: Argo syncs; re-run egress probe → `qwen35-2b:8080` reachable; re-run VAP dry-run → masquerade+bridge VM now **denied**

🤖 Generated with [Claude Code](https://claude.com/claude-code)