### PR TITLE
feat(hermes-agent): AAP SSH ingress + egress install-window doc

### DIFF
--- a/applications/hermes-agent/default-egressfirewall.yaml
+++ b/applications/hermes-agent/default-egressfirewall.yaml
@@ -6,6 +6,16 @@ metadata:
   namespace: hermes
 spec:
   egress:
+    # === Phase-2b install window (MANUAL operator toggle — no Ansible touches this file) ===
+    # Hermes's installer + dnf need broad internet. To run the convergence's
+    # install phase, PREPEND an allow-all rule here (OVN evaluates in order,
+    # first match wins), commit, let Argo sync, run the workflow's install
+    # nodes, then REVERT it to re-lock:
+    #   - type: Allow
+    #     to:
+    #       cidrSelector: 0.0.0.0/0
+    # The committed default below stays LOCKED.
+    #
     # the one messaging channel enabled in POC (swap dnsName for your channel)
     - type: Allow
       to:

--- a/applications/hermes-agent/hermes-deny-ingress-networkpolicy.yaml
+++ b/applications/hermes-agent/hermes-deny-ingress-networkpolicy.yaml
@@ -7,4 +7,13 @@ spec:
   podSelector: {}
   policyTypes:
     - Ingress
-  # no ingress rules => deny all ingress
+  ingress:
+    # SSH from the AAP namespace only, so Ansible can converge the guest over
+    # the masquerade pod IP. All other inbound is still denied.
+    - from:
+        - namespaceSelector:
+            matchLabels:
+              kubernetes.io/metadata.name: ansible-automation-platform
+      ports:
+        - protocol: TCP
+          port: 22


### PR DESCRIPTION
Phase-2b guardrail prep: allow tcp/22 ingress to the hermes VM from the `ansible-automation-platform` namespace (so Ansible can converge the guest), and document the manual egress install-window toggle in the EgressFirewall (committed default stays locked).

🤖 Generated with [Claude Code](https://claude.com/claude-code)