### PR TITLE
fix(llmkube): RWX model-cache so qwen35-2b + qwen3-35b-a3b run concurrently

### DIFF
--- a/applications/llmkube/kustomization.yaml
+++ b/applications/llmkube/kustomization.yaml
@@ -120,8 +120,19 @@ helmCharts:
       install: true
       keep: true
 
+    # Shared model cache for ALL InferenceServices (the llmkube controller mounts
+    # one fixed-name `llmkube-model-cache` PVC into every model pod). It MUST be
+    # ReadWriteMany: qwen35-2b is pinned to p330 and qwen3-35b-a3b to the casval
+    # burst node, so an RWO cache can only attach to one node and the second model
+    # deadlocks on a Multi-Attach error. RWX requires an NFS class (the iscsi/nvmeof
+    # block classes are RWO-only); nfs-ssd only slows one-time pod startup (weights
+    # load into VRAM), not inference. Enabling this makes the chart own the PVC
+    # (RWX) instead of the controller's RWO fallback.
     modelCache:
-      enabled: false
+      enabled: true
+      accessMode: ReadWriteMany
+      storageClass: freenas-nfs-ssd-csi
+      size: 100Gi
 
     priorityClasses:
       enabled: true

--- a/applications/llmkube/qwen3-35b-a3b-inferenceservice.yaml
+++ b/applications/llmkube/qwen3-35b-a3b-inferenceservice.yaml
@@ -15,7 +15,7 @@ spec:
   # ignores --n-gpu-layers. Override with the CUDA build so the 2x RTX 4060 Ti
   # on casval are actually used for inference.
   image: ghcr.io/ggml-org/llama.cpp:server-cuda13@sha256:bcaea1933502ea758ec43bb6068e82f106d9417a669dc82357c7f86aa8460b8e
-  replicas: 0
+  replicas: 1
   # Tuning targets: Qwen3.6-35B-A3B UD-Q5_K_XL (~25 GiB) on 2x RTX 4060 Ti 16 GiB.
   # Hybrid linear-attn MoE: only 10/40 layers hold a KV cache (2 KV heads), so the
   # 64k KV is ~1.25 GiB at f16 and weights+KV fit fully in VRAM; no MoE offload.


### PR DESCRIPTION
## Problem
The llmkube controller mounts a single fixed-name `llmkube-model-cache` PVC into **every** InferenceService pod. It was the controller's **RWO** fallback (chart `modelCache.enabled: false`). With `qwen35-2b` pinned to p330 and `qwen3-35b-a3b` to the `casval` burst node, the second model can never attach the volume → `FailedAttachVolume: Multi-Attach error`, pod stuck `Init` forever. (Surfaced today scaling up the 35b — see igou-openshift#261 for the casval bring-up.)

## Fix
Enable the chart's `modelCache` as **ReadWriteMany** on `freenas-nfs-ssd-csi` so both nodes mount it concurrently. All RWX-capable classes are NFS (iscsi/nvmeof are RWO block); NFS only slows **one-time pod startup** — model weights load into VRAM, so inference latency is unaffected. The chart now **owns** the PVC (RWX) instead of relying on the controller's RWO fallback.

Also bumps `qwen3-35b-a3b` `replicas: 0 → 1`.

## ⚠️ Manual migration required (not automatic)
The existing RWO `llmkube-model-cache` (controller-created, unmanaged, 100Gi NVMe-oF) must be swapped out by hand — accessMode/storageClass are immutable, and Argo won't delete an unmanaged PVC:
1. Scale both InferenceServices to 0 (frees the RWO PVC from p330).
2. Delete the RWO `llmkube-model-cache` PVC (watch for the known NVMe-oF detach wedge, #295).
3. Sync this app → Argo creates the RWX PVC.
4. Both models scale up (35b via this PR; 2b stays 1) and **re-download** into the fresh cache.

Brief 2b downtime during the swap (≈ its re-download time). Both models run concurrently afterward.

Refs #261