### PR TITLE
fix(hermes): allow east-west egress to gemma-4-e2b (fallback model)

### DIFF
--- a/applications/hermes-agent/hermes-egress-networkpolicy.yaml
+++ b/applications/hermes-agent/hermes-egress-networkpolicy.yaml
@@ -23,7 +23,8 @@ spec:
         - protocol: TCP
           port: 53
     # in-cluster LLM inference (east-west). Allowlist the specific model pods by
-    # label: qwen3-35b-a3b (intended default) and qwen35-2b (currently Ready).
+    # label: qwen3-35b-a3b (primary), qwen35-2b + gemma-4-e2b (fallback chain
+    # configured in the Hermes playbook's `hermes_config.fallback_model`).
     # Least-privilege: only these named models are reachable on 8080.
     - to:
         - namespaceSelector:
@@ -36,6 +37,7 @@ spec:
                 values:
                   - qwen3-35b-a3b
                   - qwen35-2b
+                  - gemma-4-e2b
       ports:
         - protocol: TCP
           port: 8080


### PR DESCRIPTION
## Why
The hermes-agent fallback chain (igou-ansible PR #247) now includes gemma-4-e2b. The hermes-egress NetworkPolicy is least-privilege and only allowlists qwen3-35b-a3b + qwen35-2b for east-west TCP/8080 in llmkube-system. gemma-4-e2b was silently NP-dropped — the VM's SYN went out, OVN DNAT'd to the pod, no reply ever came back, conntrack stuck `UNREPLIED`.

## Diagnosis (the rabbit hole)
- Probe pods on every node — including p330 where the VM lives — reached gemma in ~20ms. So cluster routing pod→pod is symmetric and healthy, including p330→hpg5.
- A wider probe from the VM showed **every Service with a pod on hpg5** times out (cert-manager, cnpg, gitea-mirror, gotify, intel-device-plugins, gemma). Not a hpg5/tenant issue — that's just where most non-allowlisted workloads happen to run.
- It's our own NetworkPolicy. Same policy on this branch, plus gemma-4-e2b in the values list.

## Verify after merge + Argo sync
```
oc -n hermes get networkpolicy hermes-egress -o yaml | grep -A2 'values:'
ssh igou@10.10.150.1 curl -sS -m 6 http://gemma-4-e2b.llmkube-system.svc.cluster.local:8080/v1/models
```
