### PR TITLE
Add internal SearXNG search service

### DIFF
--- a/applications/searxng/kustomization.yaml
+++ b/applications/searxng/kustomization.yaml
@@ -1,0 +1,89 @@
+---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+namespace: searxng
+resources:
+  - searxng-namespace.yaml
+  - searxng-networkpolicy.yaml
+  - searxng-secrets-externalsecret.yaml
+configMapGenerator:
+  - name: searxng-config
+    files:
+      - settings.yml
+generatorOptions:
+  disableNameSuffixHash: true
+helmCharts:
+  - name: app-template
+    namespace: searxng
+    version: 4.6.2
+    releaseName: searxng
+    repo: oci://ghcr.io/bjw-s-labs/helm
+    valuesFile: values-dummy.yaml
+    valuesInline:
+      defaultPodOptions:
+        automountServiceAccountToken: false
+      controllers:
+        searxng:
+          type: deployment
+          replicas: 1
+          strategy: RollingUpdate
+          pod:
+            securityContext:
+              seccompProfile:
+                type: RuntimeDefault
+          containers:
+            app:
+              image:
+                repository: docker.io/searxng/searxng
+                tag: "2026.6.24-e3126b89e@sha256:77b6ec55d5176fc47cfe91df5e182393133305358741d0c80ebbeec75ac39f99"
+                pullPolicy: IfNotPresent
+              env:
+                SEARXNG_SECRET:
+                  valueFrom:
+                    secretKeyRef:
+                      name: searxng-secrets
+                      key: secret_key
+              probes:
+                liveness:
+                  enabled: true
+                  type: HTTP
+                  path: /healthz
+                  port: 8080
+                readiness:
+                  enabled: true
+                  type: HTTP
+                  path: /healthz
+                  port: 8080
+                startup:
+                  enabled: true
+                  type: HTTP
+                  path: /healthz
+                  port: 8080
+                  spec:
+                    failureThreshold: 30
+                    periodSeconds: 10
+              resources: {}
+              securityContext:
+                allowPrivilegeEscalation: false
+                runAsNonRoot: true
+                capabilities:
+                  drop:
+                    - ALL
+      persistence:
+        config:
+          type: configMap
+          name: searxng-config
+          globalMounts:
+            - path: /etc/searxng/settings.yml
+              subPath: settings.yml
+              readOnly: true
+      service:
+        app:
+          controller: searxng
+          ports:
+            http:
+              port: 8080
+              targetPort: 8080
+      serviceAccount:
+        searxng:
+          enabled: true

--- a/applications/searxng/searxng-namespace.yaml
+++ b/applications/searxng/searxng-namespace.yaml
@@ -1,0 +1,5 @@
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: searxng

--- a/applications/searxng/searxng-networkpolicy.yaml
+++ b/applications/searxng/searxng-networkpolicy.yaml
@@ -1,0 +1,43 @@
+---
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: searxng
+  namespace: searxng
+spec:
+  podSelector:
+    matchLabels:
+      app.kubernetes.io/instance: searxng
+      app.kubernetes.io/name: searxng
+  policyTypes:
+    - Ingress
+    - Egress
+  ingress:
+    - from:
+        - namespaceSelector:
+            matchLabels:
+              kubernetes.io/metadata.name: hermes
+      ports:
+        - protocol: TCP
+          port: 8080
+  egress:
+    - to:
+        - namespaceSelector:
+            matchLabels:
+              kubernetes.io/metadata.name: openshift-dns
+      ports:
+        - protocol: UDP
+          port: 5353
+        - protocol: TCP
+          port: 5353
+        - protocol: UDP
+          port: 53
+        - protocol: TCP
+          port: 53
+    - to:
+        - ipBlock:
+            cidr: 0.0.0.0/0
+            except:
+              - 10.0.0.0/8
+              - 172.16.0.0/12
+              - 192.168.0.0/16

--- a/applications/searxng/searxng-secrets-externalsecret.yaml
+++ b/applications/searxng/searxng-secrets-externalsecret.yaml
@@ -1,0 +1,22 @@
+---
+apiVersion: external-secrets.io/v1
+kind: ExternalSecret
+metadata:
+  name: searxng-secrets
+  namespace: searxng
+spec:
+  refreshInterval: 24h
+  secretStoreRef:
+    kind: ClusterSecretStore
+    name: onepassword-sdk-ocp-pull
+  target:
+    name: searxng-secrets
+    creationPolicy: Owner
+    deletionPolicy: Retain
+  dataFrom:
+    - extract:
+        key: searxng-secrets
+        conversionStrategy: Default
+        decodingStrategy: None
+        metadataPolicy: None
+        nullBytePolicy: Ignore

--- a/applications/searxng/settings.yml
+++ b/applications/searxng/settings.yml
@@ -1,0 +1,16 @@
+---
+use_default_settings: true
+
+general:
+  instance_name: SearXNG
+
+search:
+  formats:
+    - html
+    - json
+
+server:
+  # Overridden at runtime by the SEARXNG_SECRET environment variable.
+  secret_key: ultrasecretkey
+  limiter: false
+  image_proxy: true

--- a/applications/searxng/values-dummy.yaml
+++ b/applications/searxng/values-dummy.yaml
@@ -1,0 +1,3 @@
+---
+# Intentionally empty - required by kustomize helmCharts to point at a values file.
+# All values are inlined in kustomization.yaml under valuesInline.

--- a/clusters/ocp/values.yaml
+++ b/clusters/ocp/values.yaml
@@ -290,6 +290,14 @@ applications:
     source:
       path: applications/hermes-agent
 
+  searxng:
+    project: cluster-apps
+    annotations:
+      argocd.argoproj.io/compare-options: IgnoreExtraneous
+      argocd.argoproj.io/sync-wave: '20'
+    source:
+      path: applications/searxng
+
   jellyfin:
     project: cluster-apps
     annotations:


### PR DESCRIPTION
## Summary
- add an internal ClusterIP SearXNG app using the app-template Helm pattern
- externalize server secret_key through the searxng-secrets 1Password item
- register the app in the OCP app-of-apps at sync wave 20
- add a scoped NetworkPolicy allowing Hermes to reach SearXNG on 8080

## Not changed
- Hermes EgressFirewall
- Hermes VM config, which remains Ansible/AAP-owned
- Firecrawl

## Validation
- make lint
- make lint-helm
- make validate-kustomize
- make validate-schemas
- make test