### PR TITLE
fix(nmstate): set maxUnavailable on single-node mapping policies

### DIFF
--- a/clusters/ocp/nmstate/mapping-casval-nodenetworkconfigurationpolicy.yaml
+++ b/clusters/ocp/nmstate/mapping-casval-nodenetworkconfigurationpolicy.yaml
@@ -7,6 +7,7 @@ metadata:
     argocd.argoproj.io/sync-options: SkipDryRunOnMissingResource=true
     argocd.argoproj.io/sync-wave: '3'
 spec:
+  maxUnavailable: 2
   nodeSelector:
     kubernetes.io/hostname: casval.igou.systems
   desiredState:

--- a/clusters/ocp/nmstate/mapping-hpg5-nodenetworkconfigurationpolicy.yaml
+++ b/clusters/ocp/nmstate/mapping-hpg5-nodenetworkconfigurationpolicy.yaml
@@ -7,6 +7,7 @@ metadata:
     argocd.argoproj.io/sync-options: SkipDryRunOnMissingResource=true
     argocd.argoproj.io/sync-wave: '3'
 spec:
+  maxUnavailable: 2
   nodeSelector:
     kubernetes.io/hostname: hpg5.igou.systems
   desiredState:

--- a/clusters/ocp/nmstate/mapping-nodenetworkconfigurationpolicy.yaml
+++ b/clusters/ocp/nmstate/mapping-nodenetworkconfigurationpolicy.yaml
@@ -6,6 +6,7 @@ metadata:
     argocd.argoproj.io/sync-options: SkipDryRunOnMissingResource=true
     argocd.argoproj.io/sync-wave: '3'
 spec:
+  maxUnavailable: 2
   desiredState:
     ovn:
       bridge-mappings:


### PR DESCRIPTION
## Summary
- Adds explicit `maxUnavailable: 2` to the three single-node `mapping` NodeNetworkConfigurationPolicies (`mapping`, `mapping-hpg5`, `mapping-casval`).
- Prevents a recurring kubernetes-nmstate deadlock where these policies wedge in `Progressing` / enactments stuck `Pending` with `MaxUnavailableLimitReached`.

## Root cause
Each `mapping` NNCP targets exactly one node, so the default `maxUnavailable` of `"50%"` resolves to `1` (`ceil(0.5 × 1)`, floored at `MinMaxunavailable = 1`). kubernetes-nmstate increments a per-policy `unavailableNodeCount` before applying and decrements it via a `defer`. If the handler is interrupted between the two (control-plane reboot, pod eviction, OOM — guaranteed eventually on a single control-plane node), the count leaks to `1` and never clears. With the limit also `1`, `count(1) >= max(1)` parks the enactment in `Pending`/`MaxUnavailableLimitReached` indefinitely (observed: `mapping` stuck ~20 days). The validating webhook then refuses spec edits because the policy is "still in progress".

## Fix
Setting an explicit integer `maxUnavailable: 2` gives each single-node policy headroom, so a leaked count of `1` can no longer block re-apply. A percentage cannot fix this (`100%` of 1 node is still `1` → must be an absolute integer ≥ 2).

The live cluster was already remediated out-of-band (status counter reset + policies re-applied); all three NNCPs are `Available`/`Ignored(NoMatchingNode)`. This PR brings the Git source into sync so ArgoCD won't drift.

## Test plan
- [x] `make lint` (yamllint) passes
- [x] `kustomize build clusters/ocp/nmstate/` renders `maxUnavailable: 2` on all three policies
- [x] Applied to cluster: `mapping` recovered from stuck `Progressing` → `Available / SuccessfullyConfigured`
- [ ] CI (validate workflow) green on PR

Made with [Cursor](https://cursor.com)