### PR TITLE
fix(nmstate): ignore-healthcheck on mapping-casval to unblock app-of-apps sync

### DIFF
--- a/clusters/ocp/nmstate/mapping-casval-nodenetworkconfigurationpolicy.yaml
+++ b/clusters/ocp/nmstate/mapping-casval-nodenetworkconfigurationpolicy.yaml
@@ -4,6 +4,7 @@ kind: NodeNetworkConfigurationPolicy
 metadata:
   name: mapping-casval
   annotations:
+    argocd.argoproj.io/ignore-healthcheck: 'true'
     argocd.argoproj.io/sync-options: SkipDryRunOnMissingResource=true
     argocd.argoproj.io/sync-wave: '3'
 spec:


### PR DESCRIPTION
## Summary
- Adds `argocd.argoproj.io/ignore-healthcheck: "true"` to the `mapping-casval` NodeNetworkConfigurationPolicy.
- Unblocks the `root-applications` app-of-apps, whose sync had been parked indefinitely on the `nmstate` child Application's health.

## Root cause
`mapping-casval` targets the `casval` burst worker, which is scaled to 0 at rest, so the policy reports `Suspended` ("NoMatchingNode"). ArgoCD's built-in NNCP health check maps `NoMatchingNode -> Suspended`, which rolled the `nmstate` Application up to `Suspended`. `root-applications` gates sync-wave progression on each child Application reaching `Healthy`, so its sync parked at `waiting for healthy state of argoproj.io/Application/nmstate` and never advanced past wave 5 — leaving later-wave apps (e.g. `searxng`) uncreated and `root-applications` `OutOfSync`. (This gate was effectively shut for ~20 days, originally behind the `mapping` enactment deadlock fixed in #340.)

## Fix
`ignore-healthcheck` removes this intentionally-inert policy from the `nmstate` app's aggregated health, so `nmstate` reports `Healthy`, the wave gate clears, and the app-of-apps syncs to completion. The `nmstate` sub-app's own sync already completed and has no later wave, so the documented `ignore-healthcheck` sync caveat (argoproj/argo-cd#22940) does not apply here.

## Verification (applied live)
- `nmstate` app health: `Suspended` -> `Healthy`
- `root-applications`: sync `Running`/parked -> `Succeeded` ("successfully synced (all tasks run)"), health `Healthy`, sync `Synced`
- `searxng` Application: previously `Missing`/non-existent -> created, `Synced` + `Healthy`
- All ArgoCD applications: `Synced` + `Healthy`

## Test plan
- [x] yamllint passes
- [ ] CI (validate workflow) green on PR

Made with [Cursor](https://cursor.com)