### PR TITLE
feat(hermes-agent): allow Firecrawl API egress on TCP 3002

### DIFF
--- a/applications/firecrawl/README.md
+++ b/applications/firecrawl/README.md
@@ -35,6 +35,6 @@ oc -n firecrawl run firecrawl-smoke --rm -i --restart=Never \
   http://firecrawl-api:3002/v0/health/liveness
 ```
 
-Hermes egress is intentionally not patched in this iteration. The follow-up is
-to allow the Hermes namespace to reach `firecrawl-api.firecrawl.svc.cluster.local`
-on TCP 3002 only.
+Hermes egress is patched in `applications/hermes-agent/hermes-egress-networkpolicy.yaml`
+to allow TCP 3002 to `firecrawl-api` pods only. See `applications/hermes-agent/README.md`
+for VM-side smoke-test commands.

--- a/applications/hermes-agent/README.md
+++ b/applications/hermes-agent/README.md
@@ -41,3 +41,40 @@ Expected configured values:
 SEARXNG_URL=http://searxng.searxng.svc.cluster.local:8080
 web.search_backend=searxng
 ```
+
+## Firecrawl Connectivity Test
+
+Run these commands inside the Hermes VM after egress syncs. Hermes may reach
+`firecrawl-api` on TCP 3002 only; support services (Redis, RabbitMQ, Postgres,
+Playwright) must remain unreachable.
+
+```bash
+export FIRECRAWL_URL=http://firecrawl-api.firecrawl.svc.cluster.local:3002
+
+curl -fsS "$FIRECRAWL_URL/v0/health/liveness"
+
+curl -fsS -X POST "$FIRECRAWL_URL/v2/scrape" \
+  -H 'Content-Type: application/json' \
+  -d '{"url":"https://example.com","formats":["markdown"]}' \
+  | jq -r '.data.markdown'
+
+curl -fsS -X POST "$FIRECRAWL_URL/v2/scrape" \
+  -H 'Content-Type: application/json' \
+  -d '{"url":"https://example.com","formats":["markdown"]}' \
+  | jq -e '.success == true and (.data.markdown | length) > 0'
+```
+
+Expected:
+
+- `/v0/health/liveness` returns `{"status":"ok"}`.
+- The scrape response includes markdown containing `Example Domain`.
+- The final `jq` command exits `0`.
+
+Negative checks (should fail with connection timeout or refused):
+
+```bash
+curl -fsS --connect-timeout 3 http://firecrawl-redis.firecrawl.svc.cluster.local:6379 || true
+curl -fsS --connect-timeout 3 http://firecrawl-playwright.firecrawl.svc.cluster.local:3000/health || true
+curl -fsS --connect-timeout 3 http://firecrawl-rabbitmq.firecrawl.svc.cluster.local:5672 || true
+curl -fsS --connect-timeout 3 http://firecrawl-nuq-postgres.firecrawl.svc.cluster.local:5432 || true
+```

--- a/applications/hermes-agent/hermes-egress-networkpolicy.yaml
+++ b/applications/hermes-agent/hermes-egress-networkpolicy.yaml
@@ -54,6 +54,21 @@ spec:
       ports:
         - protocol: TCP
           port: 8080
+    # in-cluster Firecrawl API (east-west). Hermes reaches the API for website
+    # extraction only; Redis, RabbitMQ, Postgres, Playwright, and worker pods
+    # remain unreachable (no egress rule and controller=api podSelector).
+    - to:
+        - namespaceSelector:
+            matchLabels:
+              kubernetes.io/metadata.name: firecrawl
+          podSelector:
+            matchLabels:
+              app.kubernetes.io/controller: api
+              app.kubernetes.io/instance: firecrawl
+              app.kubernetes.io/name: firecrawl
+      ports:
+        - protocol: TCP
+          port: 3002
     # in-cluster Quay registry (image pull)
     - to:
         - namespaceSelector:


### PR DESCRIPTION
## Summary
- Add a least-privilege east-west egress rule in `hermes-egress-networkpolicy.yaml` allowing Hermes to reach `firecrawl-api` pods on TCP 3002 only (`app.kubernetes.io/controller=api`).
- Document VM-side smoke and negative connectivity tests in `applications/hermes-agent/README.md`.
- Update the Firecrawl README to note Hermes egress is now patched.

## Test plan
- [x] `make lint`
- [x] `make validate-kustomize`
- [x] `make validate-schemas`
- [ ] ArgoCD sync `hermes-agent` application
- [ ] From Hermes VM: `curl http://firecrawl-api.firecrawl.svc.cluster.local:3002/v0/health/liveness`
- [ ] From Hermes VM: POST `/v2/scrape` for `https://example.com` and confirm markdown output
- [ ] From Hermes VM: confirm Redis/Playwright/RabbitMQ/Postgres endpoints fail (timeout/refused)


Made with [Cursor](https://cursor.com)