### PR TITLE
Allow Hermes egress to mirror.stream.centos.org

### DIFF
--- a/applications/hermes-agent/default-egressfirewall.yaml
+++ b/applications/hermes-agent/default-egressfirewall.yaml
@@ -210,6 +210,16 @@ spec:
         - protocol: TCP
           port: 443
 
+    # CentOS Stream dnf mirrors (package installs/updates during Hermes VM convergence)
+    - type: Allow
+      to:
+        dnsName: mirror.stream.centos.org
+      ports:
+        - protocol: TCP
+          port: 443
+        - protocol: TCP
+          port: 80
+
     # Optional providers: keep only the ones you actually use.
     - type: Allow
       to:


### PR DESCRIPTION
## Summary
- Add EgressFirewall allow rules for `mirror.stream.centos.org` on TCP 80 and 443 in the `hermes` namespace
- Enables dnf package installs/updates during Hermes VM convergence without temporarily opening all egress

## Test plan
- [x] `make test` passes (yamllint, kustomize build, kubeconform)
- [ ] ArgoCD syncs the updated `hermes-agent` application
- [ ] `dnf install` or `dnf update` from the Hermes VM succeeds against `mirror.stream.centos.org`


Made with [Cursor](https://cursor.com)