### PR TITLE
feat(hermes-agent): allow quay.io and ghcr.io egress

### DIFF
--- a/applications/hermes-agent/default-egressfirewall.yaml
+++ b/applications/hermes-agent/default-egressfirewall.yaml
@@ -321,6 +321,18 @@ spec:
       ports:
         - protocol: TCP
           port: 443
+    - type: Allow
+      to:
+        dnsName: quay.io
+      ports:
+        - protocol: TCP
+          port: 443
+    - type: Allow
+      to:
+        dnsName: ghcr.io
+      ports:
+        - protocol: TCP
+          port: 443
 
     # Python package downloads used by `uv pip install -e .[all]`.
     # pypi.org and files.pythonhosted.org currently resolve through these


### PR DESCRIPTION
## Summary

Web traffic to the container registries **quay.io** and **ghcr.io** was timing out from the Hermes namespace. The OVN-K `default` EgressFirewall in `hermes` did not have explicit allow rules for either domain, so egress to them fell through to the default `Deny 0.0.0.0/0` rule.

## Changes

Adds two `Allow` rules to `applications/hermes-agent/default-egressfirewall.yaml` for:

- `quay.io` (TCP 443)
- `ghcr.io` (TCP 443)

The new rules are placed immediately after the GitHub egress section (just before the Python/pypi block), grouping container-registry egress alongside the existing `github.com` / `codeload.github.com` entries.

## Validation

- `yamllint` clean.
- `kustomize build applications/hermes-agent/` succeeds.
- EgressFirewall CRD has no published JSON schema in kubeconform's standard set (same as every prior commit touching this file); validation relies on yamllint + kustomize + the live OVN-K webhook at apply time.