### PR TITLE
fix: add Claude Code endpoints to Hermes egress firewall

### DIFF
--- a/applications/hermes-agent/default-egressfirewall.yaml
+++ b/applications/hermes-agent/default-egressfirewall.yaml
@@ -379,6 +379,58 @@ spec:
       ports:
         - protocol: TCP
           port: 443
+    # Claude Code CLI (https://code.claude.com/docs/en/network-config)
+    # Anthropic publishes stable IP ranges for DNS-resolution robustness, same
+    # rationale as the GitHub CIDR rules above (OVN DNS-name egress may admit
+    # only one resolved A record). Source:
+    # https://platform.claude.com/docs/en/api/ip-addresses
+    - type: Allow
+      to:
+        cidrSelector: 160.79.104.0/23
+      ports:
+        - protocol: TCP
+          port: 443
+    - type: Allow
+      to:
+        cidrSelector: 160.79.104.0/21
+      ports:
+        - protocol: TCP
+          port: 443
+    # Claude Code account auth + Console auth
+    - type: Allow
+      to:
+        dnsName: claude.ai
+      ports:
+        - protocol: TCP
+          port: 443
+    - type: Allow
+      to:
+        dnsName: platform.claude.com
+      ports:
+        - protocol: TCP
+          port: 443
+    # Plugin executable / native installer / auto-updater downloads
+    - type: Allow
+      to:
+        dnsName: downloads.claude.ai
+      ports:
+        - protocol: TCP
+          port: 443
+    # Auto-updater on versions prior to 2.1.116
+    - type: Allow
+      to:
+        dnsName: storage.googleapis.com
+      ports:
+        - protocol: TCP
+          port: 443
+    # Claude in Chrome extension WebSocket bridge
+    - type: Allow
+      to:
+        dnsName: bridge.claudeusercontent.com
+      ports:
+        - protocol: TCP
+          port: 443
+    # Anthropic API (direct model provider)
     - type: Allow
       to:
         dnsName: api.anthropic.com


### PR DESCRIPTION
## Summary

Adds the missing Claude Code CLI networking endpoints to the `hermes` namespace OVN-K `EgressFirewall` (default) allowlist so Claude Code can authenticate, update, and run its Chrome extension bridge from inside the namespace.

## Gap analysis

| Endpoint | Already present | Added |
|---|---|---|
| `api.anthropic.com` | ✅ | — |
| `raw.githubusercontent.com` | ✅ | — |
| `claude.ai` (account auth) | ❌ | ✅ |
| `platform.claude.com` (Console auth) | ❌ | ✅ |
| `downloads.claude.ai` (plugin / installer / auto-updater) | ❌ | ✅ |
| `storage.googleapis.com` (auto-updater pre-2.1.116) | ❌ | ✅ |
| `bridge.claudeusercontent.com` (Chrome extension WS bridge) | ❌ | ✅ |
| `160.79.104.0/23` (Anthropic inbound IPv4) | ❌ | ✅ |
| `160.79.104.0/21` (Anthropic outbound IPv4) | ❌ | ✅ |

The Anthropic IP CIDR selectors use the same rationale as the existing GitHub CIDR rules — OVN DNS-name egress can admit only one resolved A record, so stable IP ranges give DNS-resolution robustness.

No existing rules were modified or removed; the default deny-all rule at the end is untouched. New rules were inserted in the "Optional providers" section, immediately before the existing `api.anthropic.com` rule, grouped under a `# Claude Code CLI` comment header, with CIDR rules first then DNS rules (matching the GitHub section pattern).

## Source docs

- https://code.claude.com/docs/en/network-config
- https://platform.claude.com/docs/en/api/ip-addresses