### PR TITLE
feat: add squid proxy application

### DIFF
--- a/applications/squid-proxy/kustomization.yaml
+++ b/applications/squid-proxy/kustomization.yaml
@@ -1,0 +1,88 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+namespace: squid-proxy
+resources:
+  - squid-proxy-namespace.yaml
+configMapGenerator:
+  - name: squid-proxy-config
+    files:
+      - squid.conf
+generatorOptions:
+  disableNameSuffixHash: true
+helmCharts:
+- name: app-template
+  namespace: squid-proxy
+  version: 4.6.2
+  releaseName: squid-proxy
+  repo: oci://ghcr.io/bjw-s-labs/helm
+  valuesFile: values-dummy.yaml
+  valuesInline:
+    controllers:
+      squid-proxy:
+        type: deployment
+        replicas: 1
+        strategy: RollingUpdate
+        pod:
+          securityContext:
+            seccompProfile:
+              type: RuntimeDefault
+        containers:
+          app:
+            image:
+              repository: ubuntu/squid
+              tag: "6.9-24.04_beta"
+              pullPolicy: IfNotPresent
+            # Run squid directly (foreground, no init script) so OpenShift's
+            # arbitrary non-root UID doesn't hit root-only setup steps.
+            command: ["/usr/sbin/squid"]
+            args: ["-N", "-f", "/etc/squid/squid.conf"]
+            env: {}
+            probes:
+              liveness:
+                enabled: true
+                type: TCP
+                spec:
+                  initialDelaySeconds: 10
+                  periodSeconds: 15
+              readiness:
+                enabled: true
+                type: TCP
+                spec:
+                  initialDelaySeconds: 10
+                  periodSeconds: 15
+              startup:
+                enabled: true
+                type: TCP
+                spec:
+                  failureThreshold: 30
+                  periodSeconds: 5
+            resources: {}
+            securityContext:
+              allowPrivilegeEscalation: false
+              runAsNonRoot: true
+              capabilities:
+                drop:
+                  - ALL
+    persistence:
+      squid-config:
+        type: configMap
+        name: squid-proxy-config
+        globalMounts:
+          - path: /etc/squid/squid.conf
+            subPath: squid.conf
+            readOnly: true
+      spool:
+        type: emptyDir
+        globalMounts:
+          - path: /var/spool/squid
+    service:
+      app:
+        controller: squid-proxy
+        ports:
+          proxy:
+            port: 3128
+            targetPort: 3128
+            protocol: TCP
+    serviceAccount:
+      squid-proxy:
+        enabled: true

--- a/applications/squid-proxy/squid-proxy-namespace.yaml
+++ b/applications/squid-proxy/squid-proxy-namespace.yaml
@@ -1,0 +1,5 @@
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: squid-proxy

--- a/applications/squid-proxy/squid.conf
+++ b/applications/squid-proxy/squid.conf
@@ -1,0 +1,41 @@
+# Squid forward proxy — cluster-internal only, no disk cache
+
+http_port 3128
+
+# Standard port ACLs
+acl SSL_ports port 443
+acl Safe_ports port 80
+acl Safe_ports port 443
+acl Safe_ports port 1025-65535
+acl CONNECT method CONNECT
+
+# RFC 1918 private networks + IPv6 ULA/link-local
+acl localnet src 10.0.0.0/8
+acl localnet src 172.16.0.0/12
+acl localnet src 192.168.0.0/16
+acl localnet src fc00::/7
+acl localnet src fe80::/10
+
+# Clamp CONNECT to SSL ports only (prevents CONNECT tunneling to arbitrary ports)
+http_access deny CONNECT !SSL_ports
+
+# Deny requests to non-standard ports
+http_access deny !Safe_ports
+
+# Allow cluster-internal sources; deny everything else
+http_access allow localnet
+http_access deny all
+
+# Container-friendly logging: access log to stdout, cache log to stderr
+access_log stdio:/dev/stdout
+cache_log stdio:/dev/stderr
+
+# No disk cache — forward proxy only
+cache_dir null /var/spool/squid
+
+# Runtime write locations (emptyDir mount)
+coredump_dir /var/spool/squid
+pid_filename /var/spool/squid/squid.pid
+
+# Prefer IPv4 for DNS lookups
+dns_v4_first on

--- a/applications/squid-proxy/values-dummy.yaml
+++ b/applications/squid-proxy/values-dummy.yaml
@@ -1,0 +1,4 @@
+---
+# Intentionally empty — required by kustomize helmCharts to point at a values file.
+# All values are inlined in kustomization.yaml under valuesInline.
+foo: bar

--- a/clusters/ocp/values.yaml
+++ b/clusters/ocp/values.yaml
@@ -338,6 +338,14 @@ applications:
     source:
       path: applications/gotify
 
+  squid-proxy:
+    project: cluster-apps
+    annotations:
+      argocd.argoproj.io/compare-options: IgnoreExtraneous
+      argocd.argoproj.io/sync-wave: '20'
+    source:
+      path: applications/squid-proxy
+
   forgejo:
     project: cluster-apps
     annotations:


### PR DESCRIPTION
## Summary

- Adds `applications/squid-proxy/` with a Squid 6.x forward proxy deployed via the bjw-s `app-template` Helm chart (v4.6.2)
- Registers the application in `clusters/ocp/values.yaml` at sync-wave `'20'` (user app tier, alongside gotify, jellyfin, etc.)
- No Route/Ingress — the proxy is cluster-internal only, reachable as `squid-proxy.squid-proxy.svc.cluster.local:3128`

## Design choices

### Chart
No well-maintained vendor Helm chart for Squid exists, so the bjw-s `app-template` pattern is used, matching the convention of ntfy, searxng, and other apps in this repo.

### Image
`ubuntu/squid:6.9-24.04_beta` — the official Canonical image. The tag format is Renovate-compatible; Docker Hub was unreachable from the devcontainer at authoring time so a digest pin could not be acquired. **Renovate should add the digest on first scan.**

### Non-root / restricted-v2 SCC
The ubuntu/squid image entrypoint script runs root-owned init steps, which would fail under OpenShift's arbitrary-UID assignment. The command is overridden to invoke `/usr/sbin/squid -N -f /etc/squid/squid.conf` directly, bypassing the init script entirely. Squid detects it is not running as root and skips the `setuid` step. All required security context fields are set for restricted-v2 compliance:

```yaml
securityContext:
  allowPrivilegeEscalation: false
  runAsNonRoot: true
  capabilities:
    drop: [ALL]
pod.securityContext:
  seccompProfile:
    type: RuntimeDefault
```

### squid.conf (ConfigMap)
The config is committed as `applications/squid-proxy/squid.conf` and loaded via a `configMapGenerator` (stable name via `disableNameSuffixHash: true`), mounted read-only at `/etc/squid/squid.conf`. Key settings:

| Setting | Value | Reason |
|---------|-------|--------|
| `http_port` | `3128` | Standard Squid port, >1024 so non-root is fine |
| `acl localnet` | RFC 1918 + IPv6 ULA/link-local | Allow all in-cluster CIDRs |
| `http_access deny CONNECT !SSL_ports` | Clamp CONNECT to 443 | Prevent tunneling to arbitrary ports |
| `cache_dir null /var/spool/squid` | No disk caching | Stateless forward proxy, no PVC needed |
| `access_log stdio:/dev/stdout` | Stdout | Container-friendly; aggregated by cluster logging |
| `pid_filename` / `coredump_dir` | `/var/spool/squid` | emptyDir mount — writable by arbitrary UID |
| `dns_v4_first on` | IPv4-first DNS | Avoids IPv6 resolution ordering issues |

### Volumes
- **`spool` (emptyDir)** at `/var/spool/squid` — squid writes its PID file and coredump dir here; ephemeral is fine since there's no disk cache
- **`squid-config` (configMap)** — the conf file, mounted via `subPath: squid.conf` so it doesn't shadow the rest of `/etc/squid/`

### No PVC
Disk caching is disabled (`cache_dir null`), so no persistent storage is needed. If disk caching is desired later, add a PVC at `/var/spool/squid` with `strategy: Recreate` and change `cache_dir` to a `ufs` or `aufs` scheme.

## Using the proxy from within the cluster

Set the `http_proxy` / `https_proxy` environment variables in any pod:

```yaml
env:
  - name: http_proxy
    value: http://squid-proxy.squid-proxy.svc.cluster.local:3128
  - name: https_proxy
    value: http://squid-proxy.squid-proxy.svc.cluster.local:3128
  - name: no_proxy
    value: .cluster.local,.svc,10.0.0.0/8,172.16.0.0/12,192.168.0.0/16
```

## Test plan

- [ ] ArgoCD syncs `squid-proxy` namespace and Deployment without errors
- [ ] Pod comes up Running (not CrashLoopBackOff) — check `oc logs -n squid-proxy` for squid startup messages
- [ ] TCP probe succeeds: `oc exec -n <any-ns> <pod> -- curl -v --proxy http://squid-proxy.squid-proxy.svc.cluster.local:3128 https://example.com`
- [ ] Verify non-cluster source is denied: CONNECT to a non-443 port returns `403 Forbidden`
- [ ] Digest-pin the image once Renovate processes the PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)