### PR TITLE
feat(jellyfin): TLS entry point via Hummingbird nginx proxy

### DIFF
--- a/applications/jellyfin/README.md
+++ b/applications/jellyfin/README.md
@@ -22,10 +22,21 @@ enforces placement on this node.
 
 ## Networking — MetalLB LoadBalancer (BGP, no Route/Ingress)
 
-Jellyfin is **not** exposed via an OpenShift Route or Ingress. The chart's
-Service is set to `type: LoadBalancer` and MetalLB hands it an address from
-the `guest-dmz` pool, reachable directly at `10.10.152.1:8096` on the LAN.
-This keeps media traffic off the ingress controller.
+Jellyfin is **not** exposed via an OpenShift Route or Ingress. This keeps
+media traffic off the ingress controller (and off the server-VLAN ingress
+VIP). Two MetalLB LoadBalancer VIPs from the `guest-dmz` pool are pinned via
+the `metallb.universe.tf/loadBalancerIPs` annotation:
+
+| VIP | Service | Purpose |
+| --- | --- | --- |
+| `10.10.152.2:443` | `jellyfin-proxy` | TLS entry point for LAN clients — `https://jellyfin.igou.systems` |
+| `10.10.152.1:8096` | `jellyfin` (chart) | Direct HTTP, reachable only from the admin-ish VLANs (9/10/25/70) |
+
+Both VIPs are contracts with the MikroTik config in `igou-inventory`
+(`host_vars/rb5009.igou.systems.yml`): the static DNS record
+`jellyfin.igou.systems -> 10.10.152.2` and per-VLAN firewall pinholes
+(VLAN35/IoT for the NVIDIA Shield, VLAN20/users for phones) allow exactly
+`10.10.152.2` tcp/443 — do not change these IPs without updating both repos.
 
 > History: jellyfin previously rode a Multus + macvlan secondary interface
 > on VLAN 45 (`10.10.45.221`). That was migrated to MetalLB in commit
@@ -34,18 +45,35 @@ This keeps media traffic off the ingress controller.
 
 ### Components
 
-1. **LoadBalancer Service** — created by the chart (`service.type:
-   LoadBalancer`, port `8096`). Pool selection is via the Service
-   annotation `metallb.universe.tf/address-pool: guest-dmz`.
+1. **TLS proxy (`jellyfin-proxy`)** — a single-replica
+   [Project Hummingbird](https://hummingbird-project.io/) nginx
+   (`quay.io/hummingbird/nginx`, distroless, non-root, read-only rootfs)
+   that terminates TLS on `8443` and proxies to the chart Service on
+   `8096`. The server block in `jellyfin-proxy-nginx.conf` is ported from
+   the nginx that fronted the old deployment on biscuit (websocket
+   upgrade, streaming timeouts, `proxy_buffering off`). The config is
+   shipped via `configMapGenerator`, so edits hash-roll the Deployment.
 
-2. **MetalLB `guest-dmz` IPAddressPool** — `10.10.152.0/24`, defined in
+2. **Certificate (`jellyfin-tls`)** — cert-manager, issued by the
+   `cluster-acme` ClusterIssuer (Let's Encrypt production, Cloudflare
+   DNS-01) for `jellyfin.igou.systems`, so clients need no custom CA.
+   **Renewal caveat:** nginx does not watch the secret; after a renewal
+   (~every 75 days) the proxy must be restarted to serve the new cert
+   (`oc -n jellyfin rollout restart deploy/jellyfin-proxy`). The blackbox
+   probe's `probe_ssl_earliest_cert_expiry` metric is the safety net.
+
+3. **LoadBalancer Services** — the proxy Service (`443 -> 8443`) and the
+   chart Service (`8096`). Pool selection is via the Service annotation
+   `metallb.universe.tf/address-pool: guest-dmz`; both use
+   `externalTrafficPolicy: Local`.
+
+4. **MetalLB `guest-dmz` IPAddressPool** — `10.10.152.0/24`, defined in
    `components/metallb/`. `autoAssign: false`, so the pool is only used by
    services that explicitly request it via the annotation above.
 
-3. **BGP advertisement** — MetalLB runs in FRR/BGP mode and advertises the
-   service IP (`10.10.152.1/32`) to the MikroTik router (`10.10.9.1`,
-   AS 64512) via the `guest-dmz` `BGPAdvertisement`. There is no L2/ARP
-   advertisement.
+5. **BGP advertisement** — MetalLB runs in FRR/BGP mode and advertises the
+   service `/32`s to the MikroTik router (`10.10.9.1`, AS 64512) via the
+   `guest-dmz` `BGPAdvertisement`. There is no L2/ARP advertisement.
 
 ### Consequences / constraints
 
@@ -58,9 +86,11 @@ This keeps media traffic off the ingress controller.
 
 ### Reaching jellyfin from the LAN
 
-DNS for the external name should point at `10.10.152.1`. The service IP is
-reachable from any LAN host that routes to the `guest-dmz` subnet via the
-MikroTik (which learns the `/32` over BGP).
+Clients use `https://jellyfin.igou.systems` (rb5009 static DNS →
+`10.10.152.2`). Which VLANs may reach it is governed by the per-VLAN
+pinhole rules on the rb5009, not by anything in this repo. The direct
+HTTP endpoint `10.10.152.1:8096` remains for the VLANs with tier-wide
+guest-dmz access (debugging, initial setup).
 
 > **Note:** the Service uses the `metallb.universe.tf/address-pool`
 > annotation, which MetalLB now logs as deprecated. It still functions;

--- a/applications/jellyfin/jellyfin-probe.yaml
+++ b/applications/jellyfin/jellyfin-probe.yaml
@@ -2,7 +2,7 @@
 apiVersion: monitoring.coreos.com/v1
 kind: Probe
 metadata:
-  name: jellyfin-biscuit
+  name: jellyfin
   labels:
     app.kubernetes.io/name: blackbox-exporter
 spec:
@@ -13,7 +13,8 @@ spec:
   targets:
     staticConfig:
       static:
-        - https://jellyfintest.biscuit.igou.systems/health
+        # Through the TLS proxy VIP — exercises the same path LAN clients use.
+        - https://jellyfin.igou.systems/health
       labels:
         tier: critical
         category: jellyfin

--- a/applications/jellyfin/jellyfin-proxy-certificate.yaml
+++ b/applications/jellyfin/jellyfin-proxy-certificate.yaml
@@ -1,0 +1,25 @@
+---
+apiVersion: cert-manager.io/v1
+kind: Certificate
+metadata:
+  name: jellyfin-tls
+  namespace: jellyfin
+  annotations:
+    argocd.argoproj.io/sync-options: SkipDryRunOnMissingResource=true
+spec:
+  secretName: jellyfin-tls
+  duration: 2160h0m0s # 90d
+  renewBefore: 360h0m0s # 15d
+  subject:
+    organizations:
+      - Igou
+  privateKey:
+    size: 4096
+    algorithm: RSA
+    encoding: PKCS1
+    rotationPolicy: Always
+  dnsNames:
+    - jellyfin.igou.systems
+  issuerRef:
+    kind: ClusterIssuer
+    name: cluster-acme

--- a/applications/jellyfin/jellyfin-proxy-deployment.yaml
+++ b/applications/jellyfin/jellyfin-proxy-deployment.yaml
@@ -1,0 +1,76 @@
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: jellyfin-proxy
+  namespace: jellyfin
+  labels:
+    app.kubernetes.io/name: jellyfin-proxy
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: jellyfin-proxy
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: jellyfin-proxy
+    spec:
+      securityContext:
+        seccompProfile:
+          type: RuntimeDefault
+      containers:
+        - name: nginx
+          image: quay.io/hummingbird/nginx:1.30.3@sha256:d4fe4078bbaac0e9bd18fe53ec0e4cb8d80895ed19994fca2134eed3ecc09287
+          ports:
+            - name: https
+              containerPort: 8443
+              protocol: TCP
+          securityContext:
+            allowPrivilegeEscalation: false
+            runAsNonRoot: true
+            readOnlyRootFilesystem: true
+            capabilities:
+              drop:
+                - ALL
+          readinessProbe:
+            httpGet:
+              path: /nginx-health
+              port: https
+              scheme: HTTPS
+          livenessProbe:
+            httpGet:
+              path: /nginx-health
+              port: https
+              scheme: HTTPS
+          resources:
+            requests:
+              cpu: 50m
+              memory: 64Mi
+            limits:
+              memory: 256Mi
+          volumeMounts:
+            - name: nginx-conf
+              mountPath: /etc/nginx/conf.d
+              readOnly: true
+            - name: tls
+              mountPath: /etc/nginx/tls
+              readOnly: true
+            # Writable paths required with readOnlyRootFilesystem: the image
+            # keeps its PID file in /tmp and proxy/client temp files under
+            # /var/lib/nginx/tmp.
+            - name: tmp
+              mountPath: /tmp
+            - name: nginx-tmp
+              mountPath: /var/lib/nginx/tmp
+      volumes:
+        - name: nginx-conf
+          configMap:
+            name: jellyfin-proxy-nginx
+        - name: tls
+          secret:
+            secretName: jellyfin-tls
+        - name: tmp
+          emptyDir: {}
+        - name: nginx-tmp
+          emptyDir: {}

--- a/applications/jellyfin/jellyfin-proxy-nginx.conf
+++ b/applications/jellyfin/jellyfin-proxy-nginx.conf
@@ -1,0 +1,44 @@
+# TLS front for jellyfin, ported from the nginx server block that fronted
+# the old deployment on biscuit. Mounted as the whole /etc/nginx/conf.d
+# directory, so the image's default :8080 welcome-page server is dropped.
+server {
+    listen 8443 ssl;
+    http2 on;
+    server_name jellyfin.igou.systems;
+
+    ssl_certificate     /etc/nginx/tls/tls.crt;
+    ssl_certificate_key /etc/nginx/tls/tls.key;
+
+    # Streaming timeouts
+    send_timeout 100m;
+    proxy_read_timeout 86400s;
+    proxy_send_timeout 86400s;
+
+    # Allow large uploads (e.g. image uploads)
+    client_max_body_size 100M;
+
+    # Probed by kubelet; answered locally so proxy health does not flap
+    # with jellyfin restarts.
+    location = /nginx-health {
+        access_log off;
+        return 200;
+    }
+
+    location / {
+        proxy_pass http://jellyfin:8096;
+        proxy_http_version 1.1;
+        proxy_set_header Upgrade $http_upgrade;
+        proxy_set_header Connection "upgrade";
+        proxy_set_header Host $host;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto $scheme;
+        proxy_set_header X-Forwarded-Host $host;
+        # The Service maps 443 -> 8443, so the port clients see is 443,
+        # not $server_port.
+        proxy_set_header X-Forwarded-Port 443;
+
+        # Disable buffering for smooth streaming
+        proxy_buffering off;
+    }
+}

--- a/applications/jellyfin/jellyfin-proxy-service.yaml
+++ b/applications/jellyfin/jellyfin-proxy-service.yaml
@@ -1,0 +1,25 @@
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: jellyfin-proxy
+  namespace: jellyfin
+  labels:
+    app.kubernetes.io/name: jellyfin-proxy
+  annotations:
+    metallb.universe.tf/address-pool: guest-dmz
+    # Pinned: this VIP is a contract with rb5009 (static DNS record for
+    # jellyfin.igou.systems and the per-VLAN firewall pinholes).
+    metallb.universe.tf/loadBalancerIPs: 10.10.152.2
+spec:
+  type: LoadBalancer
+  # Preserve the client source IP and advertise the VIP only from the node
+  # hosting the proxy pod (same rationale as the jellyfin Service).
+  externalTrafficPolicy: Local
+  selector:
+    app.kubernetes.io/name: jellyfin-proxy
+  ports:
+    - name: https
+      port: 443
+      targetPort: 8443
+      protocol: TCP

--- a/applications/jellyfin/kustomization.yaml
+++ b/applications/jellyfin/kustomization.yaml
@@ -7,6 +7,14 @@ resources:
   - jellyfin-media-nfs-pvc.yaml
   - jellyfin-config-pvc.yaml
   - jellyfin-probe.yaml
+  - jellyfin-proxy-certificate.yaml
+  - jellyfin-proxy-deployment.yaml
+  - jellyfin-proxy-service.yaml
+configMapGenerator:
+  # Name-suffix hash makes config edits roll the proxy Deployment.
+  - name: jellyfin-proxy-nginx
+    files:
+      - jellyfin.conf=jellyfin-proxy-nginx.conf
 helmCharts:
 - name: jellyfin
   namespace: jellyfin
@@ -54,6 +62,10 @@ helmCharts:
       externalTrafficPolicy: Local
       annotations:
         metallb.universe.tf/address-pool: guest-dmz
+        # Pinned so the VIP survives Service recreation; LAN clients reach
+        # jellyfin over TLS via the jellyfin-proxy VIP (10.10.152.2:443),
+        # this direct HTTP endpoint stays for the admin VLANs.
+        metallb.universe.tf/loadBalancerIPs: 10.10.152.1
     ingress:
       enabled: false
     persistence:


### PR DESCRIPTION
Adds an in-cluster TLS front for jellyfin ahead of the DNS cutover from biscuit, so LAN clients (NVIDIA Shield first) get `https://jellyfin.igou.systems` with a publicly trusted cert and media traffic stays off the ingress controller.

## What

- **`jellyfin-tls` Certificate** — `cluster-acme` ClusterIssuer (LE production, Cloudflare DNS-01), SAN `jellyfin.igou.systems`.
- **`jellyfin-proxy` Deployment** — Project Hummingbird nginx (`quay.io/hummingbird/nginx:1.30.3`, digest-pinned, distroless, non-root, read-only rootfs + the two emptyDirs the image documents). Server block ported from the biscuit nginx config (websocket upgrade, streaming timeouts, `proxy_buffering off`), shipped via `configMapGenerator` so config edits hash-roll the pod. Local `/nginx-health` endpoint for kubelet probes so proxy health doesn't flap with jellyfin restarts.
- **`jellyfin-proxy` Service** — LoadBalancer `443 -> 8443`, guest-dmz pool, pinned to `10.10.152.2`, `externalTrafficPolicy: Local`.
- **Chart service** — pinned to `10.10.152.1` (was implicit first-free).
- **Blackbox probe** — repointed from `https://jellyfintest.biscuit.igou.systems/health` (dead since the Multus→MetalLB migration; upstream `10.10.45.221` no longer exists, currently 502/failing) to `https://jellyfin.igou.systems/health`, which exercises the same path clients use.
- README networking section rewritten accordingly.

## Verified

- `make lint` and `kustomize build --enable-helm` pass.
- Smoke-tested the rendered Deployment on the cluster in a scratch namespace (self-signed cert): image runs under restricted SCC, TLS terminates, `/health` and `/System/Info/Public` proxy through to the live jellyfin pod. Cleaned up after.

## Notes / ordering

- Companion PR in igou-inventory adds the `jellyfin.igou.systems -> 10.10.152.2` static DNS record and VLAN35/VLAN20 pinholes; the repointed probe stays red until that lands on the rb5009.
- The old `jellyfin-biscuit` Probe object is renamed to `jellyfin` — if the app isn't pruning, delete the old Probe once synced.
- nginx doesn't watch the TLS secret: after cert-manager renews (~75d), `oc -n jellyfin rollout restart deploy/jellyfin-proxy`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JK67HF2FZFNY2vjhACoWkY