### PR TITLE
feat(democratic-csi): cut NFS+iSCSI over to freenas-api-* with scoped service account

### DIFF
--- a/clusters/ocp/democratic-csi/democratic-csi-iscsi-cold-externalsecret.yml
+++ b/clusters/ocp/democratic-csi/democratic-csi-iscsi-cold-externalsecret.yml
@@ -16,7 +16,7 @@ spec:
       engineVersion: v2
       data:
         driver-config-file.yaml: |-
-          driver: freenas-iscsi
+          driver: freenas-api-iscsi
           instance_id:
           node:
             mount:
@@ -40,22 +40,10 @@ spec:
             protocol: https
             host: {{ .truenas_host }}
             port: 443
-            apiKey: {{ .truenas_api_key }}
+            apiKey: {{ .truenas_csi_api_key_ocp }}
             allowInsecure: false
             apiVersion: 2
-          sshConnection:
-            host: {{ .truenas_host }}
-            port: 22
-            username: {{ .truenas_user }}
-            privateKey: |-{{ .truenas_ssh_key | b64dec | nindent 4}}
           zfs:
-            cli:
-              sudoEnabled: true
-              paths:
-                zfs: /sbin/zfs
-                zpool: /sbin/zpool
-                sudo: /bin/sudo
-                chroot: /sbin/chroot
             datasetParentName: cold/k8s/vols
             detachedSnapshotsDatasetParentName: cold/k8sbak/vols
             zvolCompression:

--- a/clusters/ocp/democratic-csi/democratic-csi-iscsi-fast-externalsecret.yml
+++ b/clusters/ocp/democratic-csi/democratic-csi-iscsi-fast-externalsecret.yml
@@ -16,7 +16,7 @@ spec:
       engineVersion: v2
       data:
         driver-config-file.yaml: |-
-          driver: freenas-iscsi
+          driver: freenas-api-iscsi
           instance_id:
           node:
             mount:
@@ -40,22 +40,10 @@ spec:
             protocol: https
             host: {{ .truenas_host }}
             port: 443
-            apiKey: {{ .truenas_api_key }}
+            apiKey: {{ .truenas_csi_api_key_ocp }}
             allowInsecure: false
             apiVersion: 2
-          sshConnection:
-            host: {{ .truenas_host }}
-            port: 22
-            username: {{ .truenas_user }}
-            privateKey: |-{{ .truenas_ssh_key | b64dec | nindent 4}}
           zfs:
-            cli:
-              sudoEnabled: true
-              paths:
-                zfs: /sbin/zfs
-                zpool: /sbin/zpool
-                sudo: /bin/sudo
-                chroot: /sbin/chroot
             datasetParentName: fast/k8s/vols
             detachedSnapshotsDatasetParentName: fast/k8sbak/vols
             zvolCompression:

--- a/clusters/ocp/democratic-csi/democratic-csi-iscsi-ssd-externalsecret.yml
+++ b/clusters/ocp/democratic-csi/democratic-csi-iscsi-ssd-externalsecret.yml
@@ -16,7 +16,7 @@ spec:
       engineVersion: v2
       data:
         driver-config-file.yaml: |-
-          driver: freenas-iscsi
+          driver: freenas-api-iscsi
           instance_id:
           node:
             mount:
@@ -40,22 +40,10 @@ spec:
             protocol: https
             host: {{ .truenas_host }}
             port: 443
-            apiKey: {{ .truenas_api_key }}
+            apiKey: {{ .truenas_csi_api_key_ocp }}
             allowInsecure: false
             apiVersion: 2
-          sshConnection:
-            host: {{ .truenas_host }}
-            port: 22
-            username: {{ .truenas_user }}
-            privateKey: |-{{ .truenas_ssh_key | b64dec | nindent 4}}
           zfs:
-            cli:
-              sudoEnabled: true
-              paths:
-                zfs: /sbin/zfs
-                zpool: /sbin/zpool
-                sudo: /bin/sudo
-                chroot: /sbin/chroot
             datasetParentName: ssd/k8s/vols
             detachedSnapshotsDatasetParentName: ssd/k8sbak/vols
             zvolCompression:

--- a/clusters/ocp/democratic-csi/democratic-csi-nfs-cold-externalsecret.yml
+++ b/clusters/ocp/democratic-csi/democratic-csi-nfs-cold-externalsecret.yml
@@ -16,28 +16,16 @@ spec:
       engineVersion: v2
       data:
         driver-config-file.yaml: |-
-          driver: freenas-nfs
+          driver: freenas-api-nfs
           instance_id:
           httpConnection:
             protocol: https
             host: {{ .truenas_host }}
             port: 443
-            apiKey: {{ .truenas_api_key }}
+            apiKey: {{ .truenas_csi_api_key_ocp }}
             allowInsecure: false
             apiVersion: 2
-          sshConnection:
-            host: {{ .truenas_host }}
-            port: 22
-            username: {{ .truenas_user }}
-            privateKey: |-{{ .truenas_ssh_key | b64dec | nindent 4}}
           zfs:
-            cli:
-              sudoEnabled: true
-              paths:
-                zfs: /sbin/zfs
-                zpool: /sbin/zpool
-                sudo: /bin/sudo
-                chroot: /sbin/chroot
             datasetParentName: cold/k8s/vols
             detachedSnapshotsDatasetParentName: cold/k8sbak/vols
             datasetEnableQuotas: true

--- a/clusters/ocp/democratic-csi/democratic-csi-nfs-fast-externalsecret.yml
+++ b/clusters/ocp/democratic-csi/democratic-csi-nfs-fast-externalsecret.yml
@@ -16,28 +16,16 @@ spec:
       engineVersion: v2
       data:
         driver-config-file.yaml: |-
-          driver: freenas-nfs
+          driver: freenas-api-nfs
           instance_id:
           httpConnection:
             protocol: https
             host: {{ .truenas_host }}
             port: 443
-            apiKey: {{ .truenas_api_key }}
+            apiKey: {{ .truenas_csi_api_key_ocp }}
             allowInsecure: false
             apiVersion: 2
-          sshConnection:
-            host: {{ .truenas_host }}
-            port: 22
-            username: {{ .truenas_user }}
-            privateKey: |-{{ .truenas_ssh_key | b64dec | nindent 4}}
           zfs:
-            cli:
-              sudoEnabled: true
-              paths:
-                zfs: /sbin/zfs
-                zpool: /sbin/zpool
-                sudo: /bin/sudo
-                chroot: /sbin/chroot
             datasetParentName: fast/k8s/vols
             detachedSnapshotsDatasetParentName: fast/k8sbak/vols
             datasetEnableQuotas: true

--- a/clusters/ocp/democratic-csi/democratic-csi-nfs-ssd-externalsecret.yml
+++ b/clusters/ocp/democratic-csi/democratic-csi-nfs-ssd-externalsecret.yml
@@ -16,28 +16,16 @@ spec:
       engineVersion: v2
       data:
         driver-config-file.yaml: |-
-          driver: freenas-nfs
+          driver: freenas-api-nfs
           instance_id:
           httpConnection:
             protocol: https
             host: {{ .truenas_host }}
             port: 443
-            apiKey: {{ .truenas_api_key }}
+            apiKey: {{ .truenas_csi_api_key_ocp }}
             allowInsecure: false
             apiVersion: 2
-          sshConnection:
-            host: {{ .truenas_host }}
-            port: 22
-            username: {{ .truenas_user }}
-            privateKey: |-{{ .truenas_ssh_key | b64dec | nindent 4}}
           zfs:
-            cli:
-              sudoEnabled: true
-              paths:
-                zfs: /sbin/zfs
-                zpool: /sbin/zpool
-                sudo: /bin/sudo
-                chroot: /sbin/chroot
             datasetParentName: ssd/k8s/vols
             detachedSnapshotsDatasetParentName: ssd/k8sbak/vols
             datasetEnableQuotas: true

--- a/components/democratic-csi/kustomization.yaml
+++ b/components/democratic-csi/kustomization.yaml
@@ -78,7 +78,7 @@ helmCharts:
     driver:
       existingConfigSecret: "democratic-csi-iscsi-fast-config"
       config:
-        driver: freenas-iscsi
+        driver: freenas-api-iscsi
 # ---- iSCSI - ssd pool ----
 - name: democratic-csi
   namespace: democratic-csi
@@ -144,7 +144,7 @@ helmCharts:
     driver:
       existingConfigSecret: "democratic-csi-iscsi-ssd-config"
       config:
-        driver: freenas-iscsi
+        driver: freenas-api-iscsi
 # ---- iSCSI - cold pool ----
 - name: democratic-csi
   namespace: democratic-csi
@@ -206,7 +206,7 @@ helmCharts:
     driver:
       existingConfigSecret: "democratic-csi-iscsi-cold-config"
       config:
-        driver: freenas-iscsi
+        driver: freenas-api-iscsi
 # ---- NFS - fast pool ----
 - name: democratic-csi
   namespace: democratic-csi
@@ -274,7 +274,7 @@ helmCharts:
     driver:
       existingConfigSecret: "democratic-csi-nfs-fast-config"
       config:
-        driver: freenas-nfs
+        driver: freenas-api-nfs
 # ---- NFS - ssd pool ----
 - name: democratic-csi
   namespace: democratic-csi
@@ -342,7 +342,7 @@ helmCharts:
     driver:
       existingConfigSecret: "democratic-csi-nfs-ssd-config"
       config:
-        driver: freenas-nfs
+        driver: freenas-api-nfs
 # ---- NFS - cold pool ----
 - name: democratic-csi
   namespace: democratic-csi
@@ -406,7 +406,7 @@ helmCharts:
     driver:
       existingConfigSecret: "democratic-csi-nfs-cold-config"
       config:
-        driver: freenas-nfs
+        driver: freenas-api-nfs
 # ---- NVMe-oF - fast pool ----
 - name: democratic-csi
   namespace: democratic-csi


### PR DESCRIPTION
## What

Switches the six NFS/iSCSI democratic-csi instances (fast/ssd/cold) from the hybrid SSH+API drivers to the pure-API `freenas-api-nfs` / `freenas-api-iscsi`:

- **`sshConnection` and `zfs.cli` sudo config deleted** — the `NOPASSWD: ALL` SSH credential is no longer present in these cluster secrets.
- **Auth switches to the dedicated `csi` service account's key** (`{{ .truenas_csi_api_key_ocp }}`) — a `nologin` user with no sudo, created declaratively via igou-io/igou-ansible#283 + igou-io/igou-inventory#70/#73. Per-cluster keys, independently revocable.
- **PV continuity preserved**: `csiDriver` names, `namePrefix`/`nameSuffix`, and dataset parents are unchanged; both driver families share the same `democratic-csi:*` ZFS tracking properties.
- **NVMe-oF instances untouched** — staged separately (both nvmeof variants are new as of v1.9.5, `freenas-api-nvmeof` is unproven, and `freenas-nvmeof-ssd-csi` is the default StorageClass). They keep the old credential until piloted.

Note: the privilege currently includes interim `FULL_ADMIN` because TrueNAS 25.x restricts the (deprecated) REST API to FULL_ADMIN credentials only — role-scoped keys work solely over WebSocket, which democratic-csi doesn't speak yet (igou-io/igou-inventory#73 has the full analysis). Revert to the 10 scoped roles when democratic-csi ships WebSocket support.

## ⚠️ Before merging (manual 1Password step)

The ESO template references `truenas_csi_api_key_ocp`, which must exist in the `truenas` item in vault **`ocp-pull`**. The Connect token is read-only on that vault, so copy the fields manually: the new keys are staged in the `claude` vault item **`truenas-csi-api-keys`** (`truenas_csi_api_key_ocp`, `truenas_csi_api_key_rk8s`) — add both to `ocp-pull/truenas` as concealed fields with the same labels. If merged early, ESO templating fails and the existing secrets are retained (controllers keep running on the old config) — safe but no cutover.

## Validation

- `kustomize build --enable-helm` passes for `components/democratic-csi` and `clusters/ocp/democratic-csi`.
- The `csi` key verified live against TrueNAS 25.10.1 REST: dataset/nvmet/sharing queries 200.
- Post-merge plan: argocd sync, confirm controllers healthy, exercise PVC create/attach/expand/snapshot/delete on `freenas-nfs-ssd-csi` + `freenas-iscsi-ssd-csi`, confirm existing NFS PV still serves — then revoke the old `democratic` API key (id 7) and remove stale accounts.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014j4ZctV7svH1yRynopCcCA