### PR TITLE
feat(gateway-api): guest-dmz tier Gateway (#367 phase 1)

### DIFF
--- a/clusters/ocp/gateway-api/README.md
+++ b/clusters/ocp/gateway-api/README.md
@@ -1,0 +1,60 @@
+# gateway-api
+
+Shared per-tier Gateway API infrastructure — design and rationale in
+[igou-openshift#367](https://github.com/igou-io/igou-openshift/issues/367).
+One Gateway per MetalLB exposure tier replaces per-app TLS proxy
+deployments (the jellyfin Hummingbird nginx pattern from #365): apps
+onboard with a single HTTPRoute in their own namespace.
+
+## Components
+
+| Resource | Purpose |
+| --- | --- |
+| `GatewayClass openshift-default` | Binds to `openshift.io/gateway-controller/v1`; on first reconcile the Ingress Operator installs the managed OSSM 3 / Istio control plane in `openshift-ingress` |
+| `Gateway guest-dmz` | Tier entry point. Managed Envoy Deployment + LoadBalancer Service, pinned to `10.10.152.3` in the MetalLB `guest-dmz` pool via `spec.infrastructure.annotations` |
+| `Certificate gateway-guest-dmz-tls` | Wildcard `*.dmz.igou.systems` via the `cluster-acme` ClusterIssuer (LE production, Cloudflare DNS-01). Envoy hot-reloads the renewed secret via SDS — no restart choreography |
+
+## Onboarding an app onto the guest-dmz tier
+
+1. Label the app namespace: `gateway-access/guest-dmz: "true"`.
+2. Create an HTTPRoute with `parentRefs` → `guest-dmz` /
+   `namespace: openshift-ingress`, hostname `<app>.dmz.igou.systems`, and the
+   backend Service. For long-lived streams set
+   `rules[].timeouts.request: 0s`. Websocket upgrades require the backend
+   Service port to have an `http`-prefixed name.
+3. rb5009 (igou-inventory): add a static DNS record
+   `<app>.dmz.igou.systems -> 10.10.152.3` and, if a new VLAN needs access,
+   a per-VLAN pinhole to `10.10.152.3 tcp/443`.
+
+## Constraints (verified against the OCP 4.21 docs — see #367)
+
+- Gateways are only reconciled in `openshift-ingress`; listener
+  certificates must live there too (or need ReferenceGrants).
+- The generated Service is `externalTrafficPolicy: Cluster` with no
+  supported override: apps see node IPs (XFF carries the node, not the
+  client), and the VIP is BGP-advertised from all nodes (ECMP).
+- Listeners are Terminate/Passthrough only — no TLS re-encrypt to
+  backends.
+- Anything routed onto a tier Gateway is reachable by every VLAN admitted
+  to that tier's VIP — per-app L4 firewall granularity does not exist on
+  a shared VIP. Apps needing different exposure belong on a different
+  tier's Gateway.
+- Raw Istio APIs are unsupported; only Gateway API configuration.
+- Pre-flight (verified clean 2026-07-02): no OSSM v2.x Subscription may
+  exist on the cluster (`GatewayAPIOSSMConflict`), and the Gateway API
+  CRDs must remain the operator-managed bundle (community CRDs trigger an
+  upgrade admin-gate).
+
+## DNS on bare metal
+
+The operator creates a `DNSRecord` CR per listener hostname but only
+publishes via cloud DNS providers. On this cluster DNS is self-managed on
+the rb5009 — the `DNSRecord` CRs stay unpublished; verify they do not
+drive the `ingress` ClusterOperator Degraded.
+
+## Adding another tier
+
+Copy the Gateway + Certificate pair with the tier's pool name and a free
+pinned VIP from that tier's `IPAddressPool` (see
+`clusters/ocp/metallb/`), and matching rb5009 DNS/pinholes in
+igou-inventory.

--- a/clusters/ocp/gateway-api/gatewayclass.yaml
+++ b/clusters/ocp/gateway-api/gatewayclass.yaml
@@ -1,0 +1,13 @@
+---
+apiVersion: gateway.networking.k8s.io/v1
+kind: GatewayClass
+metadata:
+  name: openshift-default
+  annotations:
+    argocd.argoproj.io/sync-wave: '0'
+spec:
+  # The only controllerName the Ingress Operator reconciles. Creating this
+  # resource makes the operator install and manage a lightweight OSSM 3 /
+  # Istio control plane (istiod-openshift-gateway) in openshift-ingress —
+  # first-party since OCP 4.19, no OSSM subscription involved.
+  controllerName: openshift.io/gateway-controller/v1

--- a/clusters/ocp/gateway-api/guest-dmz-certificate.yaml
+++ b/clusters/ocp/gateway-api/guest-dmz-certificate.yaml
@@ -1,0 +1,27 @@
+---
+apiVersion: cert-manager.io/v1
+kind: Certificate
+metadata:
+  name: gateway-guest-dmz-tls
+  # Must live in the Gateway's namespace (openshift-ingress) so the listener
+  # certificateRef needs no ReferenceGrant.
+  namespace: openshift-ingress
+  annotations:
+    argocd.argoproj.io/sync-wave: '0'
+spec:
+  secretName: gateway-guest-dmz-tls
+  duration: 2160h0m0s # 90d
+  renewBefore: 360h0m0s # 15d
+  subject:
+    organizations:
+      - Igou
+  privateKey:
+    size: 4096
+    algorithm: RSA
+    encoding: PKCS1
+    rotationPolicy: Always
+  dnsNames:
+    - '*.dmz.igou.systems'
+  issuerRef:
+    kind: ClusterIssuer
+    name: cluster-acme

--- a/clusters/ocp/gateway-api/guest-dmz-gateway.yaml
+++ b/clusters/ocp/gateway-api/guest-dmz-gateway.yaml
@@ -1,0 +1,39 @@
+---
+apiVersion: gateway.networking.k8s.io/v1
+kind: Gateway
+metadata:
+  name: guest-dmz
+  # Hard constraint of the OpenShift implementation: Gateways are only
+  # reconciled in openshift-ingress.
+  namespace: openshift-ingress
+  annotations:
+    argocd.argoproj.io/sync-wave: '1'
+spec:
+  gatewayClassName: openshift-default
+  infrastructure:
+    # Copied by the gateway controller onto the generated LoadBalancer
+    # Service. The VIP is a contract with rb5009 (igou-inventory): static
+    # DNS records and per-VLAN tcp/443 pinholes target 10.10.152.3 — do not
+    # change it without updating both repos.
+    annotations:
+      metallb.universe.tf/address-pool: guest-dmz
+      metallb.universe.tf/loadBalancerIPs: 10.10.152.3
+  listeners:
+    - name: https
+      hostname: '*.dmz.igou.systems'
+      port: 443
+      protocol: HTTPS
+      tls:
+        mode: Terminate
+        certificateRefs:
+          - name: gateway-guest-dmz-tls
+      # Apps opt in by labelling their namespace and creating an HTTPRoute
+      # with parentRefs to this Gateway. Exposure tier semantics: anything
+      # routed here is reachable by every VLAN the rb5009 admits to the
+      # guest-dmz tier VIP.
+      allowedRoutes:
+        namespaces:
+          from: Selector
+          selector:
+            matchLabels:
+              gateway-access/guest-dmz: 'true'

--- a/clusters/ocp/gateway-api/kustomization.yaml
+++ b/clusters/ocp/gateway-api/kustomization.yaml
@@ -1,0 +1,6 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - gatewayclass.yaml
+  - guest-dmz-certificate.yaml
+  - guest-dmz-gateway.yaml

--- a/clusters/ocp/values.yaml
+++ b/clusters/ocp/values.yaml
@@ -82,6 +82,19 @@ applications:
     source:
       path: clusters/ocp/metallb
 
+  # Shared per-tier Gateway API entry points (issue #367). Creating the
+  # GatewayClass makes the Ingress Operator install the managed OSSM3/Istio
+  # control plane in openshift-ingress. After MetalLB (VIP pools) and
+  # cert-manager-config (cluster-acme issuer).
+  gateway-api:
+    annotations:
+      argocd.argoproj.io/compare-options: IgnoreExtraneous
+      argocd.argoproj.io/sync-wave: '10'
+    destination:
+      namespace: openshift-ingress
+    source:
+      path: clusters/ocp/gateway-api
+
   user-workload-monitoring:
     annotations:
       argocd.argoproj.io/compare-options: IgnoreExtraneous


### PR DESCRIPTION
Phase 1 of #367 — the shared gateway infrastructure only. No app routing changes: jellyfin keeps serving through its Hummingbird nginx proxy at `10.10.152.2`; its HTTPRoute migration comes after the validation checklist below.

## What

New `gateway-api` app (sync-wave 10, after MetalLB and cert-manager-config) at `clusters/ocp/gateway-api/`:

- **GatewayClass `openshift-default`** — `controllerName: openshift.io/gateway-controller/v1`. ⚠️ On first reconcile the Ingress Operator installs the managed OSSM3/Istio control plane (`istiod-openshift-gateway`) in `openshift-ingress` — this PR turns that machinery on cluster-wide.
- **Gateway `guest-dmz`** (in `openshift-ingress` — hard constraint of the implementation) — one HTTPS listener, wildcard hostname `*.dmz.igou.systems`, MetalLB `guest-dmz` pool with pinned VIP **`10.10.152.3`** via `spec.infrastructure.annotations`. Routes attach from namespaces labelled `gateway-access/guest-dmz: "true"`.
- **Certificate `gateway-guest-dmz-tls`** — wildcard `*.dmz.igou.systems`, `cluster-acme` (LE prod, DNS-01), issued into `openshift-ingress` so the listener ref needs no ReferenceGrant. Envoy hot-reloads renewals via SDS.
- README documenting onboarding steps, tier semantics, and the verified constraints from #367.

Design decision from the issue's open questions: **wildcard listener + wildcard cert** (zero-touch onboarding — a new app needs only an HTTPRoute + one rb5009 DNS record pointing at the tier VIP — or a single `*.dmz.igou.systems` wildcard record covers the whole tier). Note for the later jellyfin migration: its gateway hostname becomes `jellyfin.dmz.igou.systems`; keeping the existing `jellyfin.igou.systems` name would need a dedicated per-host listener + cert on the Gateway instead.

## Verified

- `make lint` and `kustomize build` pass; all three manifests pass **server-side dry-run** against the live 4.21 API.
- Pre-flight per #367: no OSSM v2.x Subscription on the cluster; Gateway API CRDs are the operator-shipped v1.3.0 bundle; no pre-existing GatewayClass.

## Post-merge validation (gates the jellyfin migration — checklist from #367)

- [ ] GatewayClass Accepted; managed istiod + Envoy deployment appear in `openshift-ingress`; `router-default` undisturbed
- [ ] Generated Service carries the MetalLB annotations; VIP `10.10.152.3` assigned and BGP-advertised
- [ ] Unpublished `DNSRecord` CRs don't drive the `ingress` ClusterOperator Degraded (bare metal / self-DNS)
- [ ] Cert issued; TLS handshake OK against the VIP with an `/etc/hosts` or test DNS entry
- [ ] ECMP/latency check from VLAN9 + a routed VLAN (ETP Cluster advertises from all nodes — #68 methodology)
- [ ] Long-lived stream + websocket through a test HTTPRoute

No igou-inventory changes in this phase — DNS records and pinholes move to `10.10.152.3` only when an app actually migrates.

Refs #367.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JK67HF2FZFNY2vjhACoWkY
