### PR TITLE
fix(gateway-api): state certificateRef kind/group defaults explicitly

### DIFF
--- a/clusters/ocp/gateway-api/guest-dmz-gateway.yaml
+++ b/clusters/ocp/gateway-api/guest-dmz-gateway.yaml
@@ -26,7 +26,12 @@ spec:
       tls:
         mode: Terminate
         certificateRefs:
+          # kind/group are API-server defaults, stated explicitly so ArgoCD's
+          # server-side-apply diff doesn't report the Gateway as forever
+          # OutOfSync.
           - name: gateway-guest-dmz-tls
+            kind: Secret
+            group: ""
       # Apps opt in by labelling their namespace and creating an HTTPRoute
       # with parentRefs to this Gateway. Exposure tier semantics: anything
       # routed here is reachable by every VLAN the rb5009 admits to the


### PR DESCRIPTION
Post-merge follow-up to #368: the API server defaults `kind: Secret` / `group: \"\"` on listener `certificateRefs`, which left the Gateway permanently OutOfSync under ArgoCD's server-side-apply diff (health is fine — TLS verified end-to-end at 10.10.152.3 with the *.dmz.igou.systems LE cert). Stating the defaults in git resolves the diff.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JK67HF2FZFNY2vjhACoWkY