### PR TITLE
fix(jellyfin): state defaulted HTTPRoute matches explicitly

### DIFF
--- a/applications/jellyfin/jellyfin-httproute.yaml
+++ b/applications/jellyfin/jellyfin-httproute.yaml
@@ -16,7 +16,11 @@ spec:
   hostnames:
     - jellyfin.dmz.igou.systems
   rules:
-    - backendRefs:
+    - matches:
+        - path:
+            type: PathPrefix
+            value: /
+      backendRefs:
         - name: jellyfin
           port: 8096
       timeouts:


### PR DESCRIPTION
Completes the #371 SSA-defaults fix: `rules[].matches` is defaulted to `PathPrefix /` by the API server and must be stated in git.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JK67HF2FZFNY2vjhACoWkY