### PR TITLE
fix(jellyfin): disable ServerSideDiff for the HTTPRoute

### DIFF
--- a/applications/jellyfin/jellyfin-httproute.yaml
+++ b/applications/jellyfin/jellyfin-httproute.yaml
@@ -4,6 +4,13 @@ kind: HTTPRoute
 metadata:
   name: jellyfin
   namespace: jellyfin
+  annotations:
+    # ArgoCD's ServerSideDiff mis-diffs this CRD (live == git per the API
+    # server's own SSA dry-run, field ownership clean, yet the controller
+    # flags OutOfSync every cycle and selfHeal loops no-op syncs). Fall back
+    # to the legacy diff for this resource; all API-server-defaulted fields
+    # are stated explicitly below so the legacy diff is exact.
+    argocd.argoproj.io/compare-options: ServerSideDiff=false
 spec:
   # group/kind/weight below are API-server defaults, stated explicitly so
   # ArgoCD's server-side-apply diff doesn't report the route as forever


### PR DESCRIPTION
Follow-up to #370/#371/#372: even with every API-server-defaulted field stated in git (verified: `kubectl diff --server-side` is empty and field ownership is clean), ArgoCD's ServerSideDiff still flags the HTTPRoute OutOfSync each cycle, so selfHeal loops no-op syncs (~40 sync operations). Per-resource `argocd.argoproj.io/compare-options: ServerSideDiff=false` falls back to the legacy diff, which is exact here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JK67HF2FZFNY2vjhACoWkY