### PR TITLE
fix(jellyfin): actually state backendRef defaults; revert SSD opt-out

### DIFF
--- a/applications/jellyfin/jellyfin-httproute.yaml
+++ b/applications/jellyfin/jellyfin-httproute.yaml
@@ -4,13 +4,6 @@ kind: HTTPRoute
 metadata:
   name: jellyfin
   namespace: jellyfin
-  annotations:
-    # ArgoCD's ServerSideDiff mis-diffs this CRD (live == git per the API
-    # server's own SSA dry-run, field ownership clean, yet the controller
-    # flags OutOfSync every cycle and selfHeal loops no-op syncs). Fall back
-    # to the legacy diff for this resource; all API-server-defaulted fields
-    # are stated explicitly below so the legacy diff is exact.
-    argocd.argoproj.io/compare-options: ServerSideDiff=false
 spec:
   # group/kind/weight below are API-server defaults, stated explicitly so
   # ArgoCD's server-side-apply diff doesn't report the route as forever
@@ -30,6 +23,9 @@ spec:
       backendRefs:
         - name: jellyfin
           port: 8096
+          group: ""
+          kind: Service
+          weight: 1
       timeouts:
         # Long-lived HLS/streaming sessions — never time the request out.
         request: 0s


### PR DESCRIPTION
Root cause of the persistent HTTPRoute OutOfSync, found via the ArgoCD managed-resources API: the #371 edit for `backendRefs` **silently failed to apply** — git's target state never had `group`/`kind`/`weight` there (parentRefs did get theirs), so Argo was correctly reporting real drift against the server-defaulted live object the whole time. `kubectl diff --server-side` was misleading because dry-run re-defaults the desired object before comparing.

- Adds `group: ""` / `kind: Service` / `weight: 1` to the backendRef for real (rendered kustomize output verified to contain them).
- Reverts the #373 `ServerSideDiff=false` annotation — it was a workaround for a misdiagnosed cause; SSD was behaving correctly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JK67HF2FZFNY2vjhACoWkY