### PR TITLE
feat(openshift-virt): keep virt-handler/VMs off truenas-w1

### DIFF
--- a/components/openshift-virt/kubevirt-hyperconverged.yml
+++ b/components/openshift-virt/kubevirt-hyperconverged.yml
@@ -18,6 +18,19 @@ spec:
   # matching nodeSelector + toleration can run there.
   workloads:
     nodePlacement:
+      # Keep virt-handler (and therefore VM scheduling) OFF truenas-w1:
+      # that worker is itself a KVM guest on the TrueNAS host — nested
+      # virtualization there is unsupported/unwanted, and its disk and
+      # the cluster's CSI storage share one failure domain.
+      affinity:
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+              - matchExpressions:
+                  - key: kubernetes.io/hostname
+                    operator: NotIn
+                    values:
+                      - truenas-w1.igou.systems
       tolerations:
         - key: workload
           operator: Equal


### PR DESCRIPTION
truenas-w1.igou.systems is itself a KVM guest on the TrueNAS host — nested virtualization there is unsupported/unwanted, and its root disk shares a failure domain with the cluster's democratic-csi storage. This adds a required node-affinity (`kubernetes.io/hostname NotIn [truenas-w1.igou.systems]`) to the existing HCO `workloads.nodePlacement`, so virt-handler drains off the node, `kubevirt.io/schedulable` is withdrawn, and virt-launcher pods can never land there. Existing VMs elsewhere are unaffected (virt-handler DS rollout only).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01H3nKd6vsaYn7mPFxfUJDXN