### PR TITLE
feat(democratic-csi): pilot freenas-api-nvmeof on the empty cold tier

### DIFF
--- a/clusters/ocp/democratic-csi/democratic-csi-nvmeof-cold-externalsecret.yml
+++ b/clusters/ocp/democratic-csi/democratic-csi-nvmeof-cold-externalsecret.yml
@@ -16,7 +16,7 @@ spec:
       engineVersion: v2
       data:
         driver-config-file.yaml: |-
-          driver: freenas-nvmeof
+          driver: freenas-api-nvmeof
           instance_id:
           node:
             mount:
@@ -40,22 +40,10 @@ spec:
             protocol: https
             host: {{ .truenas_host }}
             port: 443
-            apiKey: {{ .truenas_api_key }}
+            apiKey: {{ .truenas_csi_api_key_ocp }}
             allowInsecure: false
             apiVersion: 2
-          sshConnection:
-            host: {{ .truenas_host }}
-            port: 22
-            username: {{ .truenas_user }}
-            privateKey: |-{{ .truenas_ssh_key | b64dec | nindent 4}}
           zfs:
-            cli:
-              sudoEnabled: true
-              paths:
-                zfs: /sbin/zfs
-                zpool: /sbin/zpool
-                sudo: /bin/sudo
-                chroot: /sbin/chroot
             datasetParentName: cold/k8s/vols
             detachedSnapshotsDatasetParentName: cold/k8sbak/vols
             zvolCompression:

--- a/components/democratic-csi/kustomization.yaml
+++ b/components/democratic-csi/kustomization.yaml
@@ -606,4 +606,4 @@ helmCharts:
     driver:
       existingConfigSecret: "democratic-csi-nvmeof-cold-config"
       config:
-        driver: freenas-nvmeof
+        driver: freenas-api-nvmeof


### PR DESCRIPTION
Stage 2 of the scoped-account migration (follow-up to #366). Flips only `democratic-csi-nvmeof-cold` to `freenas-api-nvmeof` + the `csi` service-account key — the cold tier has zero NVMe-oF volumes, so this is a zero-impact pilot of the least-proven api driver before touching `fast`/`ssd` (ssd is the cluster default StorageClass with 44 live subsystems). Validation plan: PVC create/attach/expand/delete on `freenas-nvmeof-cold-csi`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014j4ZctV7svH1yRynopCcCA