### PR TITLE
feat(democratic-csi): complete NVMe-oF cutover to freenas-api-nvmeof

### DIFF
--- a/clusters/ocp/democratic-csi/democratic-csi-nvmeof-fast-externalsecret.yml
+++ b/clusters/ocp/democratic-csi/democratic-csi-nvmeof-fast-externalsecret.yml
@@ -16,7 +16,7 @@ spec:
       engineVersion: v2
       data:
         driver-config-file.yaml: |-
-          driver: freenas-nvmeof
+          driver: freenas-api-nvmeof
           instance_id:
           node:
             mount:
@@ -40,22 +40,10 @@ spec:
             protocol: https
             host: {{ .truenas_host }}
             port: 443
-            apiKey: {{ .truenas_api_key }}
+            apiKey: {{ .truenas_csi_api_key_ocp }}
             allowInsecure: false
             apiVersion: 2
-          sshConnection:
-            host: {{ .truenas_host }}
-            port: 22
-            username: {{ .truenas_user }}
-            privateKey: |-{{ .truenas_ssh_key | b64dec | nindent 4}}
           zfs:
-            cli:
-              sudoEnabled: true
-              paths:
-                zfs: /sbin/zfs
-                zpool: /sbin/zpool
-                sudo: /bin/sudo
-                chroot: /sbin/chroot
             datasetParentName: fast/k8s/vols
             detachedSnapshotsDatasetParentName: fast/k8sbak/vols
             zvolCompression:

--- a/clusters/ocp/democratic-csi/democratic-csi-nvmeof-ssd-externalsecret.yml
+++ b/clusters/ocp/democratic-csi/democratic-csi-nvmeof-ssd-externalsecret.yml
@@ -16,7 +16,7 @@ spec:
       engineVersion: v2
       data:
         driver-config-file.yaml: |-
-          driver: freenas-nvmeof
+          driver: freenas-api-nvmeof
           instance_id:
           node:
             mount:
@@ -40,22 +40,10 @@ spec:
             protocol: https
             host: {{ .truenas_host }}
             port: 443
-            apiKey: {{ .truenas_api_key }}
+            apiKey: {{ .truenas_csi_api_key_ocp }}
             allowInsecure: false
             apiVersion: 2
-          sshConnection:
-            host: {{ .truenas_host }}
-            port: 22
-            username: {{ .truenas_user }}
-            privateKey: |-{{ .truenas_ssh_key | b64dec | nindent 4}}
           zfs:
-            cli:
-              sudoEnabled: true
-              paths:
-                zfs: /sbin/zfs
-                zpool: /sbin/zpool
-                sudo: /bin/sudo
-                chroot: /sbin/chroot
             datasetParentName: ssd/k8s/vols
             detachedSnapshotsDatasetParentName: ssd/k8sbak/vols
             zvolCompression:

--- a/components/democratic-csi/kustomization.yaml
+++ b/components/democratic-csi/kustomization.yaml
@@ -474,7 +474,7 @@ helmCharts:
     driver:
       existingConfigSecret: "democratic-csi-nvmeof-fast-config"
       config:
-        driver: freenas-nvmeof
+        driver: freenas-api-nvmeof
 # ---- NVMe-oF - ssd pool ----
 - name: democratic-csi
   namespace: democratic-csi
@@ -542,7 +542,7 @@ helmCharts:
     driver:
       existingConfigSecret: "democratic-csi-nvmeof-ssd-config"
       config:
-        driver: freenas-nvmeof
+        driver: freenas-api-nvmeof
 # ---- NVMe-oF - cold pool ----
 - name: democratic-csi
   namespace: democratic-csi


### PR DESCRIPTION
Final stage of the scoped-account migration (#366, #377): flips `nvmeof-fast` and `nvmeof-ssd` (default SC) to `freenas-api-nvmeof` with the `csi` service-account key. After this, all nine democratic-csi instances on ocp run pure-API with zero SSH. Validation: PVC lifecycle across all nine StorageClasses.

Note: the earlier cold-tier pilot stall was environmental (cold pool resilver + romm extraction saturating middleware — zvol creates >60s globally); with romm paused, creates are ~2s. See session notes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014j4ZctV7svH1yRynopCcCA