### PR TITLE
feat: allow igou.io and sandsoftime.igou.io in Hermes egress firewall

### DIFF
--- a/applications/hermes-agent/default-egressfirewall.yaml
+++ b/applications/hermes-agent/default-egressfirewall.yaml
@@ -546,6 +546,20 @@ spec:
         - protocol: TCP
           port: 443
 
+    # igou.io homelab sites
+    - type: Allow
+      to:
+        dnsName: igou.io
+      ports:
+        - protocol: TCP
+          port: 443
+    - type: Allow
+      to:
+        dnsName: sandsoftime.igou.io
+      ports:
+        - protocol: TCP
+          port: 443
+
     # Default deny all other IPv4 egress.
     - type: Deny
       to:


### PR DESCRIPTION
Adds two `dnsName` Allow rules (TCP 443) to the Hermes namespace EgressFirewall so the agent can reach the igou.io homelab sites:

- `igou.io`
- `sandsoftime.igou.io`

Rules are placed just before the default `Deny 0.0.0.0/0`. No change needed to the in-VM nftables backstop — it already allows all outbound 443 (the EgressFirewall is the precise control).

`make lint` and `make validate-kustomize` pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01D96MwumLzMACaBTHNTRoov