### PR TITLE
chore: restore wave 1 (stateless operators, CAPI, CNV, tenants)

### DIFF
--- a/clusters/ocp/values.yaml
+++ b/clusters/ocp/values.yaml
@@ -52,23 +52,19 @@ applications:
     source:
       path: clusters/ocp/nmstate
 
-  # ── TEMPORARILY DISABLED 2026-07-03 (cluster rebuild) ─────────────────────
-  # Deferred to relieve single-node resource congestion while the reinstalled
-  # cluster converges and workers rejoin. Uncomment to restore; each block is
-  # unchanged. See igou-inventory#120 / the 2026-07-03 incident.
-  # openshift-nfd:
-  # annotations:
-  # argocd.argoproj.io/compare-options: IgnoreExtraneous
-  # argocd.argoproj.io/sync-wave: '5'
-  # source:
-  # path: components/openshift-nfd
+  openshift-nfd:
+    annotations:
+      argocd.argoproj.io/compare-options: IgnoreExtraneous
+      argocd.argoproj.io/sync-wave: '5'
+    source:
+      path: components/openshift-nfd
 
-  # nvidia-gpu-operator:
-  # annotations:
-  # argocd.argoproj.io/compare-options: IgnoreExtraneous
-  # argocd.argoproj.io/sync-wave: '6'
-  # source:
-  # path: components/nvidia-gpu-operator
+  nvidia-gpu-operator:
+    annotations:
+      argocd.argoproj.io/compare-options: IgnoreExtraneous
+      argocd.argoproj.io/sync-wave: '6'
+    source:
+      path: components/nvidia-gpu-operator
 
   udn:
     annotations:
@@ -99,12 +95,12 @@ applications:
     source:
       path: clusters/ocp/gateway-api
 
-  # user-workload-monitoring:
-  # annotations:
-  # argocd.argoproj.io/compare-options: IgnoreExtraneous
-  # argocd.argoproj.io/sync-wave: '6'
-  # source:
-  # path: components/user-workload-monitoring
+  user-workload-monitoring:
+    annotations:
+      argocd.argoproj.io/compare-options: IgnoreExtraneous
+      argocd.argoproj.io/sync-wave: '6'
+    source:
+      path: components/user-workload-monitoring
 
   cert-manager-config:
     annotations:
@@ -163,55 +159,59 @@ applications:
     source:
       path: clusters/ocp/apiserver
 
-  # cluster-api-operator:
-  # annotations:
-  # argocd.argoproj.io/compare-options: IgnoreExtraneous
-  # argocd.argoproj.io/sync-wave: '10'
-  # destination:
-  # namespace: capi-operator-system
-  # source:
-  # path: components/cluster-api-operator
+  cluster-api-operator:
+    annotations:
+      argocd.argoproj.io/compare-options: IgnoreExtraneous
+      argocd.argoproj.io/sync-wave: '10'
+    destination:
+      namespace: capi-operator-system
+    source:
+      path: components/cluster-api-operator
 
-  # cluster-api:
-  # annotations:
-  # argocd.argoproj.io/compare-options: IgnoreExtraneous
-  # argocd.argoproj.io/sync-wave: '11'
-  # destination:
-  # namespace: openshift-cluster-api
-  # source:
-  # path: clusters/ocp/cluster-api
-  # # Metal3/CAPM3 patches BMH spec fields when it claims the host (online,
-  # # consumerRef, image, userData, customDeploy, preprovisioning*). Leave
-  # # those to the controllers so ArgoCD doesn't fight them back to the
-  # # minimal manifest checked into git.
-  # ignoreDifferences:
-  # - group: metal3.io
-  # kind: BareMetalHost
-  # jsonPointers:
-  # - /spec/online
-  # - /spec/consumerRef
-  # - /spec/image
-  # - /spec/userData
-  # - /spec/customDeploy
-  # - /spec/preprovisioningNetworkDataName
-  # - /spec/networkData
-  # # The cluster-autoscaler owns replicas for autoscaler-managed
-  # # MachineSets — leave it to the autoscaler so ArgoCD doesn't revert
-  # # scale-ups to 0 and trigger a delete/recreate loop.
-  # - group: cluster.x-k8s.io
-  # kind: MachineSet
-  # jsonPointers:
-  # - /spec/replicas
+  cluster-api:
+    annotations:
+      argocd.argoproj.io/compare-options: IgnoreExtraneous
+      argocd.argoproj.io/sync-wave: '11'
+    destination:
+      namespace: openshift-cluster-api
+    source:
+      path: clusters/ocp/cluster-api
+    # Metal3/CAPM3 patches BMH spec fields when it claims the host (online,
+    # consumerRef, image, userData, customDeploy, preprovisioning*). Leave
+    # those to the controllers so ArgoCD doesn't fight them back to the
+    # minimal manifest checked into git.
+    ignoreDifferences:
+      - group: metal3.io
+        kind: BareMetalHost
+        jsonPointers:
+          - /spec/online
+          - /spec/consumerRef
+          - /spec/image
+          - /spec/userData
+          - /spec/customDeploy
+          - /spec/preprovisioningNetworkDataName
+          - /spec/networkData
+      # The cluster-autoscaler owns replicas for autoscaler-managed
+      # MachineSets — leave it to the autoscaler so ArgoCD doesn't revert
+      # scale-ups to 0 and trigger a delete/recreate loop.
+      - group: cluster.x-k8s.io
+        kind: MachineSet
+        jsonPointers:
+          - /spec/replicas
 
-  # cluster-api-autoscaler:
-  # annotations:
-  # argocd.argoproj.io/compare-options: IgnoreExtraneous
-  # argocd.argoproj.io/sync-wave: '12'
-  # destination:
-  # namespace: cluster-api-autoscaler-system
-  # source:
-  # path: components/cluster-api-autoscaler
+  cluster-api-autoscaler:
+    annotations:
+      argocd.argoproj.io/compare-options: IgnoreExtraneous
+      argocd.argoproj.io/sync-wave: '12'
+    destination:
+      namespace: cluster-api-autoscaler-system
+    source:
+      path: components/cluster-api-autoscaler
 
+  # ── TEMPORARILY DISABLED 2026-07-03 (cluster rebuild), staged restore ──
+  # These apps stay deferred in this wave. Uncomment (restore original block)
+  # as each wave brings them back. ArgoCD ignores comments, so the flattened
+  # indentation here is cosmetic. See the 2026-07-03 incident.
   # loki-operator:
   # annotations:
   # argocd.argoproj.io/compare-options: IgnoreExtraneous
@@ -226,43 +226,43 @@ applications:
   # source:
   # path: components/openshift-logging
 
-  # openshift-pipelines:
-  # annotations:
-  # argocd.argoproj.io/compare-options: IgnoreExtraneous
-  # argocd.argoproj.io/sync-wave: '10'
-  # source:
-  # path: components/openshift-pipelines
+  openshift-pipelines:
+    annotations:
+      argocd.argoproj.io/compare-options: IgnoreExtraneous
+      argocd.argoproj.io/sync-wave: '10'
+    source:
+      path: components/openshift-pipelines
 
-  # remote-tenants:
-  # annotations:
-  # argocd.argoproj.io/compare-options: IgnoreExtraneous
-  # argocd.argoproj.io/sync-wave: '20'
-  # source:
-  # path: clusters/ocp/remote-tenants
+  remote-tenants:
+    annotations:
+      argocd.argoproj.io/compare-options: IgnoreExtraneous
+      argocd.argoproj.io/sync-wave: '20'
+    source:
+      path: clusters/ocp/remote-tenants
 
-  # pac-tenants:
-  # annotations:
-  # argocd.argoproj.io/compare-options: IgnoreExtraneous
-  # argocd.argoproj.io/sync-wave: '20'
-  # source:
-  # path: clusters/ocp/pac-tenants
-  # # OpenShift's image-registry-pull-secrets controller injects the
-  # # auto-generated `<sa>-dockercfg-*` entry into the operator-owned
-  # # `pipeline` SA's imagePullSecrets/secrets. SSA prevents us from
-  # # overwriting it, but ArgoCD's diff still flags it as OutOfSync.
-  # # Defer those fields to that controller via field-manager scoping.
-  # ignoreDifferences:
-  # - group: ""
-  # kind: ServiceAccount
-  # managedFieldsManagers:
-  # - openshift.io/image-registry-pull-secrets_service-account-controller
+  pac-tenants:
+    annotations:
+      argocd.argoproj.io/compare-options: IgnoreExtraneous
+      argocd.argoproj.io/sync-wave: '20'
+    source:
+      path: clusters/ocp/pac-tenants
+    # OpenShift's image-registry-pull-secrets controller injects the
+    # auto-generated `<sa>-dockercfg-*` entry into the operator-owned
+    # `pipeline` SA's imagePullSecrets/secrets. SSA prevents us from
+    # overwriting it, but ArgoCD's diff still flags it as OutOfSync.
+    # Defer those fields to that controller via field-manager scoping.
+    ignoreDifferences:
+      - group: ""
+        kind: ServiceAccount
+        managedFieldsManagers:
+          - openshift.io/image-registry-pull-secrets_service-account-controller
 
-  # intel-device-plugins-operator:
-  # annotations:
-  # argocd.argoproj.io/compare-options: IgnoreExtraneous
-  # argocd.argoproj.io/sync-wave: '10'
-  # source:
-  # path: components/intel-device-plugins-operator
+  intel-device-plugins-operator:
+    annotations:
+      argocd.argoproj.io/compare-options: IgnoreExtraneous
+      argocd.argoproj.io/sync-wave: '10'
+    source:
+      path: components/intel-device-plugins-operator
 
   # grafana:
   # annotations:
@@ -271,24 +271,24 @@ applications:
   # source:
   # path: components/grafana
 
-  # tailscale-operator:
-  # annotations:
-  # argocd.argoproj.io/compare-options: IgnoreExtraneous
-  # argocd.argoproj.io/sync-wave: '10'
-  # destination:
-  # namespace: tailscale
-  # source:
-  # path: components/tailscale-operator
-  # # The operator rewrites the igou-io-node-exporter egress Service's
-  # # spec.externalName from the git placeholder to its proxy FQDN. Defer that
-  # # field to the operator so the app doesn't sit permanently OutOfSync.
-  # ignoreDifferences:
-  # - group: ""
-  # kind: Service
-  # name: igou-io-node-exporter
-  # namespace: tailscale
-  # jsonPointers:
-  # - /spec/externalName
+  tailscale-operator:
+    annotations:
+      argocd.argoproj.io/compare-options: IgnoreExtraneous
+      argocd.argoproj.io/sync-wave: '10'
+    destination:
+      namespace: tailscale
+    source:
+      path: components/tailscale-operator
+    # The operator rewrites the igou-io-node-exporter egress Service's
+    # spec.externalName from the git placeholder to its proxy FQDN. Defer that
+    # field to the operator so the app doesn't sit permanently OutOfSync.
+    ignoreDifferences:
+      - group: ""
+        kind: Service
+        name: igou-io-node-exporter
+        namespace: tailscale
+        jsonPointers:
+          - /spec/externalName
 
   cloudnative-pg:
     annotations:
@@ -404,11 +404,11 @@ applications:
   # source:
   # path: clusters/ocp/ansible-automation-platform
 
-  # molecule:
-  # annotations:
-  # argocd.argoproj.io/sync-wave: '39'
-  # source:
-  # path: components/molecule
+  molecule:
+    annotations:
+      argocd.argoproj.io/sync-wave: '39'
+    source:
+      path: components/molecule
 
   service-accounts:
     annotations:
@@ -417,9 +417,9 @@ applications:
     source:
       path: clusters/ocp/service-accounts
 
-  # openshift-virt:
-  # annotations:
-  # argocd.argoproj.io/compare-options: IgnoreExtraneous
-  # argocd.argoproj.io/sync-wave: '50'
-  # source:
-  # path: components/openshift-virt
+  openshift-virt:
+    annotations:
+      argocd.argoproj.io/compare-options: IgnoreExtraneous
+      argocd.argoproj.io/sync-wave: '50'
+    source:
+      path: components/openshift-virt


### PR DESCRIPTION
First restore wave after the 2026-07-03 rebuild — all 3 nodes are Ready. Re-enables the no-data apps (operators, CAPI, CNV operator, tenants, pipelines, tailscale, observability-adjacent). Observability, databases, user apps, and KubeVirt VMs stay deferred pending per-app PV/data restore in later waves.

Rebuilt from the pre-defer original so active blocks keep correct indentation; deferred apps are commented (ArgoCD ignores comments).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01D96MwumLzMACaBTHNTRoov