### PR TITLE
chore: restore hermes-agent scaffolding (wave 3)

### DIFF
--- a/clusters/ocp/values.yaml
+++ b/clusters/ocp/values.yaml
@@ -295,18 +295,18 @@ applications:
     source:
       path: clusters/ocp/cloudnative-pg
 
+  hermes-agent:
+    project: cluster-apps
+    annotations:
+      argocd.argoproj.io/compare-options: IgnoreExtraneous
+      argocd.argoproj.io/sync-wave: '20'
+    source:
+      path: applications/hermes-agent
+
   # ── TEMPORARILY DISABLED 2026-07-03 (cluster rebuild), staged restore ──
   # These apps stay deferred in this wave. Uncomment (restore original block)
   # as each wave brings them back. ArgoCD ignores comments, so the flattened
   # indentation here is cosmetic. See the 2026-07-03 incident.
-  # hermes-agent:
-  # project: cluster-apps
-  # annotations:
-  # argocd.argoproj.io/compare-options: IgnoreExtraneous
-  # argocd.argoproj.io/sync-wave: '20'
-  # source:
-  # path: applications/hermes-agent
-
   # firecrawl:
   # project: cluster-apps
   # annotations:


### PR DESCRIPTION
Re-enables the hermes-agent Application (namespace, blank hermes-state PVC, egress firewall, network policies, VM-hardening VAP). VM provisioned out-of-band via ansible; state restored from the verified 2026-07-03 backup.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01D96MwumLzMACaBTHNTRoov