### PR TITLE
chore: restore quay/rhdh/forgejo DBs from Barman (wave 3)

### DIFF
--- a/applications/forgejo/forgejo-pg-cluster.yaml
+++ b/applications/forgejo/forgejo-pg-cluster.yaml
@@ -17,10 +17,23 @@ spec:
     nodeSelector:
       node-role.kubernetes.io/control-plane: ""
     podAntiAffinityType: preferred # CNPG default; declared to avoid ArgoCD drift
+  # 2026-07-03 disaster recovery: restore the forgejo database from the Barman
+  # Cloud backup on RustFS (latest base 2026-07-02) instead of initdb. Revert to
+  # the initdb block below once recovered and verified.
+  #   bootstrap:
+  #     initdb:
+  #       database: forgejo
+  #       owner: forgejo
   bootstrap:
-    initdb:
-      database: forgejo
-      owner: forgejo
+    recovery:
+      source: forgejo-pg
+  externalClusters:
+    - name: forgejo-pg
+      plugin:
+        name: barman-cloud.cloudnative-pg.io
+        parameters:
+          barmanObjectName: forgejo-pg-backup
+          serverName: forgejo-pg
   storage:
     size: 10Gi
     storageClass: freenas-nvmeof-ssd-csi

--- a/clusters/ocp/values.yaml
+++ b/clusters/ocp/values.yaml
@@ -355,13 +355,13 @@ applications:
   # source:
   # path: applications/gotify
 
-  # forgejo:
-  # project: cluster-apps
-  # annotations:
-  # argocd.argoproj.io/compare-options: IgnoreExtraneous
-  # argocd.argoproj.io/sync-wave: '22'
-  # source:
-  # path: applications/forgejo
+  forgejo:
+    project: cluster-apps
+    annotations:
+      argocd.argoproj.io/compare-options: IgnoreExtraneous
+      argocd.argoproj.io/sync-wave: '22'
+    source:
+      path: applications/forgejo
 
   # gitea-mirror:
   # project: cluster-apps
@@ -371,19 +371,19 @@ applications:
   # source:
   # path: applications/gitea-mirror
 
-  # quay-operator:
-  # annotations:
-  # argocd.argoproj.io/compare-options: IgnoreExtraneous
-  # argocd.argoproj.io/sync-wave: '22'
-  # source:
-  # path: components/quay-operator
+  quay-operator:
+    annotations:
+      argocd.argoproj.io/compare-options: IgnoreExtraneous
+      argocd.argoproj.io/sync-wave: '22'
+    source:
+      path: components/quay-operator
 
-  # rhdh:
-  # annotations:
-  # argocd.argoproj.io/compare-options: IgnoreExtraneous
-  # argocd.argoproj.io/sync-wave: '22'
-  # source:
-  # path: components/rhdh
+  rhdh:
+    annotations:
+      argocd.argoproj.io/compare-options: IgnoreExtraneous
+      argocd.argoproj.io/sync-wave: '22'
+    source:
+      path: components/rhdh
 
   alertmanager-config:
     annotations:

--- a/components/quay-operator/quay-pg-cluster.yaml
+++ b/components/quay-operator/quay-pg-cluster.yaml
@@ -20,17 +20,29 @@ spec:
     nodeSelector:
       node-role.kubernetes.io/control-plane: ""
     podAntiAffinityType: preferred # CNPG default; declared to avoid ArgoCD drift
+  # 2026-07-03 disaster recovery: bootstrap by restoring the quay database from
+  # the Barman Cloud backup on RustFS (the cluster's own history), rather than
+  # initdb. CNPG opens a new timeline so continued WAL archiving to the same
+  # serverName does not collide with the restored backup. Revert to the initdb
+  # block (kept below, commented) once the DB is recovered and verified.
+  #   bootstrap:
+  #     initdb:
+  #       database: quay
+  #       owner: quay
+  #       secret:
+  #         name: quay-pg-credentials
+  #       postInitApplicationSQL:
+  #         - CREATE EXTENSION IF NOT EXISTS pg_trgm
   bootstrap:
-    initdb:
-      database: quay
-      owner: quay
-      # Owner password sourced from 1Password via ExternalSecret. Same Secret
-      # is referenced by the config-bundle template so DB_URI stays in sync.
-      secret:
-        name: quay-pg-credentials
-      # pg_trgm is required by Quay's catalog search.
-      postInitApplicationSQL:
-        - CREATE EXTENSION IF NOT EXISTS pg_trgm
+    recovery:
+      source: quay-pg
+  externalClusters:
+    - name: quay-pg
+      plugin:
+        name: barman-cloud.cloudnative-pg.io
+        parameters:
+          barmanObjectName: quay-pg-backup
+          serverName: quay-pg
   # The clair role lives on the same cluster but owns its own database (managed
   # via the Database CR in clair-database.yaml). CNPG keeps the role's password
   # in sync with the password key of quay-clair-pg-credentials.

--- a/components/rhdh/rhdh-pg-cluster.yaml
+++ b/components/rhdh/rhdh-pg-cluster.yaml
@@ -20,15 +20,25 @@ spec:
     nodeSelector:
       node-role.kubernetes.io/control-plane: ""
     podAntiAffinityType: preferred # CNPG default; declared to avoid ArgoCD drift
+  # 2026-07-03 disaster recovery: restore the backstage database from the Barman
+  # Cloud backup on RustFS (latest base 2026-07-02) instead of initdb. Revert to
+  # the initdb block below once recovered and verified.
+  #   bootstrap:
+  #     initdb:
+  #       database: backstage
+  #       owner: backstage
+  #       secret:
+  #         name: rhdh-postgres-credentials
   bootstrap:
-    initdb:
-      database: backstage
-      owner: backstage
-      # BYO credentials (managed by ESO from 1Password) so the rhdh-operator
-      # and CNPG agree on a password we control. CNPG reads `username` and
-      # `password` keys from this Secret to create the role.
-      secret:
-        name: rhdh-postgres-credentials
+    recovery:
+      source: rhdh-pg
+  externalClusters:
+    - name: rhdh-pg
+      plugin:
+        name: barman-cloud.cloudnative-pg.io
+        parameters:
+          barmanObjectName: rhdh-pg-backup
+          serverName: rhdh-pg
   storage:
     size: 10Gi
     storageClass: freenas-nvmeof-ssd-csi


### PR DESCRIPTION
Switches the three CNPG clusters from initdb to recovery-bootstrap, restoring each database from its Barman Cloud backup on RustFS (base backups from 2026-07-02, day before the disaster) and enables the quay/rhdh/forgejo apps. Original initdb blocks retained commented for post-recovery revert.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01D96MwumLzMACaBTHNTRoov