### PR TITLE
fix: archive recovered CNPG DBs to a new serverName

### DIFF
--- a/applications/forgejo/forgejo-pg-cluster.yaml
+++ b/applications/forgejo/forgejo-pg-cluster.yaml
@@ -50,3 +50,7 @@ spec:
       isWALArchiver: true
       parameters:
         barmanObjectName: forgejo-pg-backup
+        # Archive WAL to a NEW serverName so the post-recovery timeline does not
+        # collide with the pre-disaster archive we recovered from (CNPG refuses
+        # to archive into a non-empty destination for a different server).
+        serverName: forgejo-pg-r20260704

--- a/components/quay-operator/quay-pg-cluster.yaml
+++ b/components/quay-operator/quay-pg-cluster.yaml
@@ -80,3 +80,7 @@ spec:
       isWALArchiver: true
       parameters:
         barmanObjectName: quay-pg-backup
+        # Archive WAL to a NEW serverName so the post-recovery timeline does not
+        # collide with the pre-disaster archive we recovered from (CNPG refuses
+        # to archive into a non-empty destination for a different server).
+        serverName: quay-pg-r20260704

--- a/components/rhdh/rhdh-pg-cluster.yaml
+++ b/components/rhdh/rhdh-pg-cluster.yaml
@@ -56,3 +56,7 @@ spec:
       isWALArchiver: true
       parameters:
         barmanObjectName: rhdh-pg-backup
+        # Archive WAL to a NEW serverName so the post-recovery timeline does not
+        # collide with the pre-disaster archive we recovered from (CNPG refuses
+        # to archive into a non-empty destination for a different server).
+        serverName: rhdh-pg-r20260704


### PR DESCRIPTION
Recovery jobs failed with 'WAL archive check failed: Expected empty archive'. CNPG won't let a restored cluster archive into the same serverName it recovered from. Archive the post-recovery timeline to `<db>-r20260704` while still recovering from the original.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01D96MwumLzMACaBTHNTRoov