### PR TITLE
docs: 2026-07-03 disaster-recovery post-mortem, component reviews & runbooks

### DIFF
--- a/docs/post-mortems/2026-07-03-component-reviews.md
+++ b/docs/post-mortems/2026-07-03-component-reviews.md
@@ -1,0 +1,1663 @@
+# Component Health & Functionality Reviews — post-2026-07-03 rebuild
+
+> Companion to [`2026-07-03-ocp-disaster-recovery.md`](./2026-07-03-ocp-disaster-recovery.md).
+> One section per app-of-apps component, authored by a dedicated Opus 4.8 reviewer:
+> a read-only health check of the live cluster plus a functionality review of the
+> git config, focused on whether each component correctly recovered the rebuild.
+
+## Contents
+- [alertmanager-config](#alertmanager-config)
+- [ansible-automation-platform](#ansible-automation-platform)
+- [apiserver-certs](#apiserver-certs)
+- [apiserver](#apiserver)
+- [cert-manager-config](#cert-manager-config)
+- [cloudnative-pg](#cloudnative-pg)
+- [cluster-api-autoscaler](#cluster-api-autoscaler)
+- [cluster-api-operator](#cluster-api-operator)
+- [cluster-api](#cluster-api)
+- [democratic-csi](#democratic-csi)
+- [external-secrets-operator](#external-secrets-operator)
+- [firecrawl](#firecrawl)
+- [forgejo](#forgejo)
+- [gateway-api](#gateway-api)
+- [gitea-mirror](#gitea-mirror)
+- [gotify](#gotify)
+- [grafana](#grafana)
+- [hermes-agent](#hermes-agent)
+- [image-registry](#image-registry)
+- [ingresscontroller-certs](#ingresscontroller-certs)
+- [intel-device-plugins-operator](#intel-device-plugins-operator)
+- [jellyfin](#jellyfin)
+- [kubeletconfig](#kubeletconfig)
+- [llmkube](#llmkube)
+- [loki-operator](#loki-operator)
+- [lvms-operator](#lvms-operator)
+- [machineconfigs](#machineconfigs)
+- [metallb](#metallb)
+- [molecule](#molecule)
+- [nmstate](#nmstate)
+- [nvidia-gpu-operator](#nvidia-gpu-operator)
+- [ocp-base-config](#ocp-base-config)
+- [onepassword-connect](#onepassword-connect)
+- [openshift-logging](#openshift-logging)
+- [openshift-nfd](#openshift-nfd)
+- [openshift-pipelines](#openshift-pipelines)
+- [openshift-virt](#openshift-virt)
+- [pac-tenants](#pac-tenants)
+- [quay-operator](#quay-operator)
+- [remote-tenants](#remote-tenants)
+- [rhdh](#rhdh)
+- [searxng](#searxng)
+- [service-accounts](#service-accounts)
+- [tailscale-operator](#tailscale-operator)
+- [udn](#udn)
+- [user-workload-monitoring](#user-workload-monitoring)
+
+---
+
+## alertmanager-config
+
+**Status:** degraded
+
+The component's own resources recovered cleanly from the rebuild (ArgoCD Synced/Healthy on origin/main HEAD `d81e454`, both ExternalSecrets synced, the `alertmanager-main` config Secret applied via `Replace=true`, and the running Alertmanager loaded a config byte-identical to git). However, **2 of the 3 notification sinks it fans out to are dead because their upstream dependencies were never restored post-disaster**, so alerts are actively failing to deliver.
+
+### Scope
+
+- Namespace: `openshift-monitoring`. Manages the platform `alertmanager-main` config Secret (`secretGenerator`, `disableNameSuffixHash`, `Replace=true`) plus two ExternalSecrets: `alertmanager-slack-bot-token` and `alertmanager-eda-event-stream` (ClusterSecretStore `onepassword-sdk-ocp-pull`).
+- Pod `alertmanager-main-0` 6/6 Running on hpg5, 0 restarts, StatefulSet 1/1. Secret mounts (`alertmanager-eda-event-stream/{url,token}`, `alertmanager-slack-bot-token/password`) present and wired via `cluster-monitoring-config` `alertmanagerMain.secrets` (a separate component, verified present).
+
+### Findings
+
+- **[HIGH] Default `gotify` receiver + gotify leg of critical/warning receivers are broken — NXDOMAIN.** The config's catch-all `route.receiver: gotify` and the webhook in `gotify-and-slack-critical`/`gotify-and-slack-warning` all POST to `http://alertmanager-gotify-bridge.gotify.svc:8080/gotify_webhook`. The **`gotify` namespace/service does not exist**: DNS returns NXDOMAIN and Alertmanager logs are full of `notify retry canceled after 15/16 attempts ... lookup alertmanager-gotify-bridge.gotify.svc ... no such host`. Root cause: the **`gotify` ArgoCD Application was never created** — it is defined in git (`clusters/ocp/values.yaml:346`, path `applications/gotify`, sync-wave 20) but is absent from the 44 live apps, because `root-applications` is still `OutOfSync/Progressing` and hasn't reconciled it. Not this component's own defect, but it means all push notifications and any alert without a severity label (→ default receiver) are lost.
+- **[HIGH] Critical/warning delivery degraded even to the healthy Slack sink (fanout coupling).** Because the gotify webhook and Slack live in the *same* receivers, the gotify NXDOMAIN failure makes the whole receiver fanout return error; Alertmanager retries the entire receiver (re-sending to Slack → duplicate Slack messages) and ultimately cancels the notification after ~15 attempts, so grouped critical/warning alerts are dropped. Slack is the only potentially-working sink but its reliability is dragged down by the dead gotify leg.
+- **[HIGH] `eda-github-issue` receiver failing HTTP 503.** The receiver POSTs to `https://automation.apps.ocp.igou.systems` (from the `alertmanager-eda-event-stream` secret `url`); Alertmanager logs show 13+ `unexpected status code 503` with the OpenShift router "Application is not available" page — the backing AAP/EDA event-stream Route has no endpoints. There is **no `aap`/`eda`/`automation` ArgoCD app in this cluster**, so the EDA→GitHub-issue pipeline (per the EDA Alertmanager→GitHub memory) is down; no auto-issues are being filed for firing alerts.
+- **[LOW] Transient ArgoCD ComparisonError on this app.** `alertmanager-config` shows a condition `ComparisonError: Failed to load target state ... context deadline exceeded` (repo-server manifest-gen timeout) even though it reports Synced/Healthy on the correct revision. Cosmetic/intermittent, likely repo-server load during the rebuild; monitor.
+- **[INFO] The component itself is correctly configured and drift-free.** Synced revision == origin/main HEAD; the Alertmanager-loaded config exactly matches git (Watchdog/AlertmanagerReceiversNotConfigured null-routed, the `AlertmanagerFailedToSendAlerts integration=webhook` self-referential null-route present, inhibit rules and severity fan-out intact); ExternalSecrets both `SecretSynced/Ready=True`; the `Replace=true` strategy and Connect-empty-field `password`-only pull are working as designed. It recovered its own state correctly.
+
+### Remediation
+
+1. **Restore the `gotify` application (root cause of the HIGH gotify failures).** Investigate/repair `root-applications` (OutOfSync/Progressing) so the sync-wave-20 `gotify` Application is created; then confirm `alertmanager-gotify-bridge.gotify.svc:8080` resolves and the NXDOMAIN log spam stops. Owner: gotify application / app-of-apps, not this component.
+2. **Restore the AAP/EDA event-stream endpoint** backing `https://automation.apps.ocp.igou.systems` so `eda-github-issue` stops returning 503 and the alert→GitHub-issue pipeline resumes. Confirm the Route/Service exists post-rebuild.
+3. **(Hardening) Decouple Slack from gotify** in `alertmanager.yaml`: put the gotify webhook and Slack in separate receivers (or route `continue: true` legs) so a single sink outage can't retry-storm, duplicate Slack messages, or cancel delivery to the healthy sink.
+4. **(Low)** If the `ComparisonError`/DeadlineExceeded recurs, raise the ArgoCD repo-server timeout or reconcile; currently non-blocking.
+
+No change to the `alertmanager-config` component's own manifests is required to fix the two HIGH findings — they are unrestored-dependency gaps (gotify app, AAP/EDA), not misconfiguration or drift in this component.
+
+---
+
+## ansible-automation-platform
+
+**Status: not-yet-deployed** (post-rebuild restoration in progress; queued at ArgoCD sync-wave 30, not yet reached)
+
+Git source: `clusters/ocp/ansible-automation-platform/` (app-of-apps entry `clusters/ocp/values.yaml:393`, project `cluster-apps`, sync-wave 30).
+
+### Health check (read-only, observed 2026-07-04 ~02:57–02:59 UTC)
+
+- **The ArgoCD Application `ansible-automation-platform` does not exist** (`oc get applications.argoproj.io ansible-automation-platform -n openshift-gitops` → NotFound). It appears only as a child resource of the app-of-apps `root-applications`, listed **OutOfSync / health=Missing** (`nil->obj` — needs to be created).
+- **Nothing AAP is deployed on the cluster**: no `ansible-automation-platform` namespace, no operator Subscription/CSV, no `AnsibleAutomationPlatform` CRD/CR, no pods, no PVCs, no route. The whole stack is absent.
+- **Why it isn't there yet:** `root-applications` (automated, prune+selfHeal) is mid-reconciliation after the reinstall and is (re)creating a batch of pruned lower-wave child apps **wave-by-wave, gating on health**. During the observation window it visibly progressed: at 02:57 firecrawl/searxng/jellyfin/llmkube/gotify/gitea-mirror/AAP were all Missing; by 02:59 firecrawl/searxng/jellyfin/gotify/llmkube had been created (searxng/jellyfin/gotify `Progressing` = pods starting), with the operation message `waiting for healthy state of Application/gotify and 1 more`. The sync must clear wave 19→20→22→23 (gitea-mirror still Missing) before it reaches **wave 30, where the AAP Application gets created**. Only then does AAP install (namespace w0 → operator Sub w1 → admin-password ExternalSecret w3 → AAP CR w5).
+- Dependencies for AAP are healthy/present: `external-secrets-operator`, `onepassword-connect`, `democratic-csi` apps Synced/Healthy; ClusterSecretStore `onepassword-sdk-ocp-pull` = **Ready/True**; StorageClass `freenas-nvmeof-ssd-csi` (provisioner `org.democratic-csi.nvmeof-ssd`) present. So once the wave is reached, AAP should install cleanly.
+
+### Findings
+
+- **[High] AAP deployment is transitively blocked behind unrelated lower-priority apps.** Because AAP is the highest sync-wave (30) among the currently-Missing child apps, the app-of-apps will only create it *after* firecrawl (w19), searxng/jellyfin/llmkube/gotify (w20), and gitea-mirror (w23) all reach Healthy. If any one of those wedges (image pull, crashloop, stuck Progressing), the app-of-apps sync stalls at that wave and **AAP never gets created**. AAP recovery is coupled to the health of apps it has no functional relationship to.
+- **[Medium] app-of-apps not settling — persistent OutOfSync neighbors.** `root-applications` itself is OutOfSync with several always-OutOfSync/Healthy children (forgejo, openshift-pipelines, pac-tenants, quay-operator, rhdh). selfHeal keeps re-triggering; the create-and-gate cycle should still converge, but drift in those apps should be resolved so the app-of-apps can reach a clean synced state and reliably drive wave 30.
+- **[Medium] No AAP database restore in the DR path.** The AAP CR uses the operator's *own managed PostgreSQL* (`database.postgres_storage_class: freenas-nvmeof-ssd-csi`, `postgres_data_volume_init: false`) — this is **not CloudNativePG** and was **not** part of the Barman/RustFS restore that recovered quay/rhdh/forgejo. When AAP finally deploys it comes up with a **fresh, empty controller DB**. Controller/EDA state (job templates, projects, inventories, credentials, rulebooks) must be repopulated by **AAP config-as-code** (from igou-inventory / aap-sync), which must be re-run post-deploy. Anything not captured in config-as-code (run history, manually-created objects, issued tokens) is permanently lost. Confirm config-as-code is the source of truth and re-runs; if any AAP DB state is expected to survive DR, a backup mechanism is missing.
+- **[Medium] NVMe-oF PVCs exposed to the shared-hostnqn latent bug.** AAP's postgres (and redis) PVCs land on `freenas-nvmeof-ssd-csi`. The known cluster-wide defect (all 3 nodes share the same nvme `hostnqn`/`hostid`, nqn …466937ab…) causes intermittent NVMe-oF volume-attach failures — so AAP's first postgres attach (and any future node reschedule) is at risk of intermittent failure until the hostnqn uniqueness bug is fixed.
+- **[Low] `installPlanApproval: Automatic` on channel `stable-2.7`.** Operator auto-upgrades within the channel unattended. Acceptable, but worth being aware of on a freshly reinstalled OCP 4.21.9.
+- **[Low / verify] admin password secret key.** The AAP CR sets `admin_password_secret: aap-admin-password`; the ExternalSecret uses `dataFrom: extract` of the 1Password item `aap-admin-password`. The operator expects a `password` key — this worked pre-disaster and the secret store is Ready, so likely fine; verify the 1Password item exposes a `password` field once the ExternalSecret materializes.
+
+### Config assessment (git)
+
+The component definition itself is **correct and unchanged** — nothing in git needs fixing to get AAP running. `hub.disabled: true` / `eda.disabled: false` matches the known EDA-only design (Alertmanager→GitHub issue pipeline); Route + Edge TLS on `automation.apps.ocp.igou.systems`; admin password sourced from 1Password via ExternalSecret (DR-safe, re-hydrates automatically); correct intra-app sync-wave ordering (ns 0 → sub 1 → ES 3 → CR 5) with `SkipDryRunOnMissingResource=true` so the CR applies before its CRD exists. This is a *deployment-ordering / restoration-progress* gap, not a manifest defect.
+
+### Remediation
+
+1. **Let the app-of-apps converge, but watch the gating apps.** Monitor firecrawl (w19), searxng/jellyfin/llmkube/gotify (w20), gitea-mirror (w23) to Healthy; if any wedges, fix/prune it so the sync advances to wave 30. To unblock AAP immediately without waiting on those, an operator could manually sync/create just the AAP Application (out of band) — but the standing fix is to get the earlier waves healthy.
+2. **Resolve the persistent OutOfSync neighbors** (forgejo, openshift-pipelines, pac-tenants, quay-operator, rhdh) so `root-applications` settles and reliably drives later waves.
+3. **After AAP comes up, re-run AAP config-as-code** (aap-sync from igou-inventory) to repopulate the fresh controller/EDA DB, then verify job templates, EDA rulebook activations (Alertmanager→issue pipeline), and credentials are present. Confirm whether an AAP DB backup is expected as part of DR; if so, add one (it is not covered by the CNPG/Barman restore).
+4. **Track the shared nvme hostnqn fix** — AAP postgres on NVMe-oF will be intermittently attach-flaky until nodes get unique hostnqn/hostid.
+5. Re-verify AAP once deployed: operator CSV Succeeded, AAP CR `.status` Successful, postgres/redis PVCs Bound, pods Running, and the `automation.apps.ocp.igou.systems` route serving with a valid Edge cert.
+
+---
+
+## apiserver-certs
+
+**Status: healthy**
+
+Component that requests the external API serving certificate for `api.ocp.igou.systems` via cert-manager (ACME/Let's Encrypt). It fully recovered the 2026-07-03 rebuild: the certificate was automatically re-issued during reinstall and the live API endpoint is serving it.
+
+### Scope
+- Git source: `clusters/ocp/apiserver-certs/` — a single `cert-manager.io/v1` `Certificate` (`api-certificate`) in namespace `openshift-config`, wired into the app-of-apps at sync-wave 9 (`clusters/ocp/values.yaml`).
+- Produces secret `acme-api` (`kubernetes.io/tls`), consumed by the sibling `apiserver` component (`clusters/ocp/apiserver/cluster-apiserver.yaml`) which patches `APIServer/cluster` `spec.servingCerts.namedCertificates` → `acme-api`.
+
+### Health check (live)
+- **ArgoCD app `apiserver-certs`: Synced / Healthy** (revision d81e454); single managed resource `Certificate/api-certificate` Synced+Healthy. Sibling app `apiserver` also Synced/Healthy.
+- **Certificate `api-certificate`: Ready=True** — "Certificate is up to date and has not expired"; issued ~7h42m ago (during the rebuild), `notAfter 2026-10-01`, `renewalTime 2026-09-16`.
+- **CertificateRequest `api-certificate-1`: Ready/Approved**; ACME **Order `api-certificate-1-...`: valid**. **ClusterIssuer `cluster-acme`: Ready=True** (ACME account registered).
+- **Secret `acme-api`** present with `tls.crt`/`tls.key`; chain is a genuine Let's Encrypt cert (`O=Let's Encrypt, CN=YR2`).
+- **Live functional proof:** `openssl s_client` to `api.ocp.igou.systems:6443` serves `CN=api.ocp.igou.systems`, Let's Encrypt issuer, `notBefore Jul 3 18:40:50 2026` — i.e. the freshly re-issued cert is actually on the wire, not just stored.
+- **`kube-apiserver` ClusterOperator:** Degraded=False, Available=True, Progressing=False (revision 8). No crashloops/pending/PVC concerns (component owns no pods/workloads/PVCs/routes).
+
+### Findings
+- **[INFO] Disaster recovery complete, no manual restore needed.** Both the `Certificate` CR and its consumer `APIServer/cluster` patch are declarative in git, so GitOps recreated them and cert-manager re-ran the ACME flow automatically after reinstall. Nothing about this component required hand-restoration.
+- **[LOW] Latent sync-wave ordering chicken-and-egg.** The consumer `apiserver` patch (references secret `acme-api`) is sync-wave 3, but `apiserver-certs` that creates `acme-api` is sync-wave 9. On a cold install the `APIServer/cluster` object names a serving cert whose secret does not yet exist. OpenShift tolerates this (falls back to the default serving cert until the secret appears), so it self-heals — and did here (cert is live) — but the ordering is inverted relative to the dependency.
+- **[LOW/INFO] Issuance depends on the full ACME path staying healthy.** Recovery required a brand-new ACME order (new order observed, valid). Repeated reinstall loops could in principle hit Let's Encrypt rate limits or stall on the DNS/HTTP-01 solver; not observed this time. Renewal is unattended (renewBefore 15d) so no action needed, but this is the component's only real fragility.
+- **[INFO] Cert hygiene is good; one superfluous usage.** RSA-4096, `rotationPolicy: Always`, 90d duration / 15d renewBefore. `usages` lists both `server auth` and `client auth`; only `server auth` is needed for an API serving cert — `client auth` is harmless but unnecessary.
+
+### Remediation
+- No corrective action required — component is healthy, functional, and correctly recovered.
+- Optional hardening: consider raising the `apiserver-certs` sync-wave to precede the consumer `apiserver` component (or accept the documented self-healing behavior), and drop `client auth` from `usages` in `api-cert.yaml`. Both are cosmetic.
+
+---
+
+## apiserver
+
+**Status:** healthy
+
+The `apiserver` component (`clusters/ocp/apiserver`) manages a single cluster-scoped resource: the OpenShift `APIServer/cluster` config CR. Its job is to (a) select the etcd encryption provider and (b) wire a named ACME serving certificate onto the kube-apiserver for `api.ocp.igou.systems`. It fully recovered the rebuild and is verified functional end-to-end.
+
+### Findings
+
+- **[INFO] ArgoCD app Synced + Healthy, zero drift.** `apiserver` app is `Synced`/`Healthy` at revision `d81e454`, source `clusters/ocp/apiserver` (targetRevision HEAD). The live `APIServer/cluster` spec matches git byte-for-byte (`encryption.type: identity`; one `namedCertificate` for `api.ocp.igou.systems` → secret `acme-api`). Only field present live-but-not-in-git is `audit.profile: Default`, which is the API-server default injected by the apiserver-config operator — not real drift, and ArgoCD does not flag it.
+
+- **[INFO] Named ACME serving cert is actually wired, not merely present (functional verification).** The live endpoint `api.ocp.igou.systems:6443` serves `CN=api.ocp.igou.systems` issued by **Let's Encrypt (O=Let's Encrypt, CN=YR2)**, `notBefore Jul 3 18:40:50 2026`, `notAfter Oct 1 18:40:49 2026`. This is the same cert stored in secret `openshift-config/acme-api` (`kubernetes.io/tls`, 2 keys) — confirming the `servingCerts.namedCertificates` override took effect on the running kube-apiserver, not just that the CR was applied. This is the meaningful "functional not just running" check and it passes.
+
+- **[INFO] Post-disaster recovery confirmed.** The serving cert secret is ~7h old and the cert `notBefore` is `Jul 3 18:40`, i.e. re-issued *during* the rebuild window. The supporting `apiserver-certs` app is `Synced`/`Healthy`; its `Certificate openshift-config/api-certificate` (issuer `ClusterIssuer/cluster-acme`, secretName `acme-api`) reports `Ready=True — Certificate is up to date and has not expired`. So the cert-manager → ACME → named-cert chain re-established itself cleanly after the reinstall; no manual restore was needed for this component and none is outstanding.
+
+- **[INFO] kube-apiserver operator fully rolled out.** `clusteroperator/kube-apiserver` = `Available=True, Progressing=False, Degraded=False` (v4.21.9, kube 1.34.6); `NodeInstallerProgressing=False`, single control-plane node at revision 8. The named-cert change is baked into the current rollout, not pending.
+
+- **[LOW — security hardening] etcd encryption at rest is disabled (`encryption.type: identity`).** `identity` is a no-op provider: Secrets, ConfigMaps, ServiceAccount tokens, and OAuth tokens are stored **unencrypted** in etcd. This matches the OpenShift out-of-the-box default (it is *not* a rebuild regression and is exactly what git declares), but it is a deliberate, explicit choice here and leaves data-at-rest unprotected. Given the single-node control plane on MS-01, anyone with disk/etcd-snapshot/backup access to that node can read all cluster secrets in cleartext. Consider switching to `aescbc` (or `aesgcm`) if the threat model includes node-disk / backup exposure.
+
+### Remediation
+
+- No corrective action required for availability — component is healthy, in-sync, and functionally verified.
+- (Optional hardening, non-urgent) To enable etcd encryption at rest, set `spec.encryption.type: aescbc` (or `aesgcm`) in `clusters/ocp/apiserver/cluster-apiserver.yaml` and let ArgoCD roll it out. Note this triggers a kube-apiserver + etcd re-encryption rollout and should be done in a maintenance window; verify a fresh etcd/Barman-adjacent backup exists first.
+- (Watch item) The ACME serving cert expires `2026-10-01`. Renewal is automated via cert-manager (`api-certificate` Ready), but since the API endpoint's TLS depends on it, confirm cert-manager + the `cluster-acme` ClusterIssuer stay healthy ahead of that date — the same rebuild that just re-issued this cert proves the path works.
+
+---
+
+## cert-manager-config
+
+**Status:** healthy
+
+Declarative component (`clusters/ocp/cert-manager-config`) containing a single `ClusterIssuer` (`cluster-acme`) — a Let's Encrypt **production** ACME issuer using a Cloudflare **DNS-01** solver for the `igou.systems` / `ocp.igou.systems` zones. It fully recovered the rebuild with zero manual intervention and is proven functional end-to-end.
+
+### Health check (live cluster)
+
+- **ArgoCD app:** `cert-manager-config` — **Synced / Healthy**, project `cluster-config`. Synced revision `d81e454` **== origin/main HEAD** (no drift). `spec.source.path` = `clusters/ocp/cert-manager-config`.
+- **ClusterIssuer `cluster-acme`:** `Ready=True`, reason `ACMEAccountRegistered` ("The ACME account was registered with the ACME server"), age 7h40m (registered fresh right after reinstall). Live spec matches git exactly (server, email, `dns-token/credential` solver ref, zones) — no manual drift.
+- **cert-manager pods** (`cert-manager` ns): controller, cainjector, webhook all `1/1 Running` (a few restarts during the post-reinstall bring-up; stable now).
+- **dns-token secret** (Cloudflare API token): present, delivered by an **ExternalSecret** (`onepassword-sdk-ocp-pull` ClusterSecretStore → 1Password), `SecretSynced / Ready=True`; contains the `credential` key that the ClusterIssuer references. (NB: this ExternalSecret is owned by the *cert-manager-operator* app, not this component.)
+- **acme-private-key secret:** present (regenerated fresh on reinstall).
+- **End-to-end issuance PROVEN — 3 real LE production certs issued via `cluster-acme` post-rebuild, all `Ready=True`:**
+  - `openshift-config/api-certificate` → `api.ocp.igou.systems`
+  - `openshift-ingress/apps-certificate` → `*.apps.ocp.igou.systems`
+  - `openshift-ingress/gateway-guest-dmz-tls` → `*.dmz.igou.systems`
+  - All Orders in `valid` state, no stuck Challenges; `notAfter 2026-10-01`, `renewalTime 2026-09-16` (proper LE 90-day + 2/3 renewal).
+- **Controller logs:** no ACME rate-limit / DNS-solver / auth errors. Only benign optimistic-lock re-queues on unrelated CAPI self-signed certs.
+
+### Findings
+
+1. **[Low / advisory] No staging issuer — DR rate-limit exposure.** Only the LE **production** endpoint is defined (`acme-v02.api.letsencrypt.org`); there is no `letsencrypt-staging` ClusterIssuer. This incident's failure mode was a *reinstall loop*. Each agent-based reinstall re-registers a new ACME account and re-requests the same 3 certs. If a rebuild loop recurs (or multiple rebuilds land in one week), LE production limits — new-account, failed-validation, and 5 duplicate-certs/week — could throttle certificate issuance and leave the API/ingress on the default self-signed certs. It worked cleanly this time, but a staging issuer would de-risk future DR/testing.
+2. **[Info / Low] Implicit cross-app dependency for the functional path.** The ClusterIssuer (this app, sync-wave 1) is only *registerable* on its own; actual issuance depends on `dns-token`, delivered by the **cert-manager-operator** app (sync-wave 2) via ESO + 1Password Connect. Since the DNS token is consumed only at challenge-solve time (not at account registration), the wave ordering is harmless and it recovered fine — but the end-to-end issuance path is gated on operator + ESO + 1Password Connect all being healthy. Worth documenting in the DR runbook so a future issuance failure isn't misattributed to this component.
+3. **[Info] Redundant dnsZone entry.** `solvers[0].selector.dnsZones` lists both `igou.systems` and `ocp.igou.systems`; the latter is a subdomain of the former and cert-manager matches zones by subdomain, so it is redundant (harmless). `*.dmz.igou.systems` correctly matches via the `igou.systems` entry.
+4. **[Info] ACME account key regenerated, not restored — by design.** `acme-private-key` was freshly generated on reinstall rather than restored from backup; correct behavior (ACME accounts are cheap/stateless). The prior LE account is orphaned but harmless — no restore was or is needed for this component.
+
+### Remediation
+
+- **(Low, optional)** Add a `letsencrypt-staging` ClusterIssuer to the component for DR/test issuance so rebuild loops don't consume LE production quota; use it to validate the DNS-01 path before switching to production.
+- **(Info)** Document the issuance dependency chain (cert-manager-config → dns-token ExternalSecret from cert-manager-operator → ESO/1Password Connect) in the DR runbook.
+- **(Info, cosmetic)** Drop the redundant `ocp.igou.systems` entry from `dnsZones` (no functional impact).
+- **No corrective action required for recovery** — the component is fully declarative, self-healed on reinstall, and is verified functional end-to-end.
+
+---
+
+## cloudnative-pg
+
+**Status: healthy**
+
+The CloudNativePG operator and its Barman Cloud backup plugin (the two things this component actually ships) came back cleanly after the reinstall and are not merely running — they are actively performing the post-disaster PITR restores of the dependent databases. ArgoCD app `cloudnative-pg` is **Synced / Healthy**, last operation **Succeeded** (revision `d81e454`).
+
+### What this component is
+Git source `clusters/ocp/cloudnative-pg` = namespace `cloudnative-pg` + two remote-referenced components:
+- `components/cloudnative-pg` — OperatorGroup (spec `{}` = AllNamespaces), Subscription (`certified-operators`, channel `stable-v1`, `installPlanApproval: Automatic`), a `cnpg-metrics` Service and a ServiceMonitor.
+- `components/cloudnative-pg-barman-plugin` — the first-party `plugin-barman-cloud` v0.12.0 (the supported replacement for the deprecated in-tree `barmanObjectStore`), namespace-retargeted from upstream `cnpg-system` to `cloudnative-pg`, with the upstream `runAsUser/runAsGroup: 10001` stripped so OpenShift restricted-v2 SCC can inject a compliant UID.
+
+The actual Postgres `Cluster` CRs live in the consuming components (`quay-enterprise/quay-pg`, `rhdh/rhdh-pg`, `forgejo/forgejo-pg`) — reviewed here only insofar as they prove the operator is functional.
+
+### Live cluster state (read-only)
+- **Operator**: CSV `cloudnative-pg.v1.30.0` = `Succeeded`; Subscription `AtLatestKnown`; `cnpg-controller-manager` Deployment 1/1 Running.
+- **Barman plugin**: `barman-cloud` Deployment 1/1 Running (`plugin-barman-cloud:v0.12.0`); both cert-manager Certificates `barman-cloud-server` / `barman-cloud-client` = Ready (mTLS gRPC discovery intact after the namespace retarget).
+- **Metrics wiring correct**: `cnpg-metrics` Service has a live endpoint (`10.128.0.41:8080`); controller pod carries `app.kubernetes.io/name=cloudnative-pg` and exposes a `metrics` port; ServiceMonitor selector matches.
+- **Operator is doing real work**: `rhdh-pg` and `forgejo-pg` = "Cluster in healthy state", READY 1/1 (Barman restores already completed). `quay-pg` is mid-restore (`Setting up primary`) via the `quay-pg-1-full-recovery` job, actively replaying WAL from `s3://cnpg-backups/quay-pg` (LSN advancing ~240 MB / 10 s; sidecar logging continuous "Restored WAL file" — progressing, not stuck).
+- No errors in current operator logs; no PVCs owned by this namespace (operator is stateless).
+
+### Findings
+
+- **[INFO] quay-pg restore still in progress (~1h WAL replay), not a component defect.** The operator + Barman plugin are functioning correctly; quay simply has a large WAL chain to replay to reach end-of-WAL. It is advancing steadily and should reach primary on its own. Belongs to the `quay` component's review; noted here as positive proof the plugin's WAL-restore path works. Monitor; do not intervene.
+- **[LOW] Both operator pods restarted during the DR bootstrap window, now stable.** `cnpg-controller-manager` (7 restarts) and `barman-cloud` (3 restarts) each last terminated `exitCode 1 / Error` at ~2026-07-03T19:43:37Z — the reinstall/bootstrap churn while the API server / webhooks were still stabilizing. Both have been continuously Running for ~7h since. No action needed; expected DR noise.
+- **[LOW] `installPlanApproval: Automatic` let the operator minor-bump to v1.30.0.** The barman-plugin kustomization header still documents "live: 1.29.1", and CNPG in fact auto-upgraded 1.29.x → 1.30.0 (unattended). Fine for a homelab, but an unpinned operator upgrade landing in the middle of a disaster recovery is a latent risk (a bad CSV could stall all three DBs at once). Consider `Manual` approval, or at least pin/track the channel, for change control.
+- **[LOW/doc-drift] Stale version comment.** `components/cloudnative-pg-barman-plugin/kustomization.yaml` says "CNPG ... live: 1.29.1"; actual is 1.30.0. Cosmetic; update when convenient.
+- **[SECURITY — OK] No gaps found.** OperatorGroup `{}` = AllNamespaces is intentional and required (operator must watch `quay-enterprise`/`rhdh`/`forgejo`). No secrets in git. The SCC-compliance patch (strip `runAsUser/runAsGroup`, keep `runAsNonRoot` + drop-ALL caps + `readOnlyRootFilesystem`) is the correct, minimal change. Backups target `s3://cnpg-backups/*` on RustFS with a 30d retention policy — credentials sourced out-of-band (ExternalSecret in the DB namespaces), not in this component.
+
+### Cross-reference (not owned here)
+The DR incident's latent **shared NVMe `hostnqn`/`hostid` across all 3 nodes** can cause intermittent `democratic-csi.nvmeof-ssd` volume-attach failures. CNPG DBs are the heaviest PVC consumers on that SC (quay-pg attached fine this cycle), so a future CNPG pod reschedule could surface the bug as a failed primary attach. Track under the storage/CSI remediation, not this component.
+
+### Remediation
+1. **No action required for the operator/plugin** — healthy and functional.
+2. **Let `quay-pg` finish** its WAL replay; verify it transitions to `Cluster in healthy state` READY 1/1 and that Quay app reconnects. Only investigate if it plateaus (LSN stops advancing) or the recovery job errors.
+3. **(Optional, low)** Switch the Subscription to `installPlanApproval: Manual` (or pin the CSV) to prevent unattended operator upgrades during future recoveries; refresh the stale "1.29.1" comment in the barman-plugin kustomization.
+4. **(Track elsewhere)** Fix the shared-`hostnqn` NVMe uniqueness bug so CNPG PVC attaches stay reliable.
+
+---
+
+## cluster-api-autoscaler
+
+**Status:** healthy (functional today; one MEDIUM latent drift risk from the rebuild)
+
+Upstream `registry.k8s.io/autoscaling/cluster-autoscaler:v1.34.0` (digest-pinned) run standalone with `--cloud-provider=clusterapi`, deployed by GitOps (ArgoCD app `cluster-api-autoscaler`, sync-wave 12, project `cluster-config`). It auto-discovers the CAPI `casval-worker` MachineSet (min 0 / max 1) in `openshift-cluster-api` and drives scale-from-zero of the casval burst GPU node.
+
+### Health check (read-only)
+
+- **ArgoCD app:** `Synced` + `Healthy` (revision `d81e454`). No drift.
+- **Namespace / workload:** `cluster-api-autoscaler-system` Active. Deployment `1/1` ready (`desired=1 ready=1 avail=1`), pod `Running`, **0 restarts**, up ~3.5h (since the rebuild), scheduled on the control-plane node `ocp.igou.systems` per its nodeSelector/tolerations. No PVCs (stateless — nothing to restore).
+- **Leader election:** Lease `cluster-api-autoscaler` held in **kube-system** (holder = current pod, renewing). Note: despite `--leader-elect-resource-namespace=cluster-api-autoscaler-system`, this build parks the lease in kube-system; the RBAC comment already anticipated this and grants it, so it works. The namespace-local `leases` Role is effectively unused.
+- **Runtime behavior (logs + status CM):** Node group `MachineSet/openshift-cluster-api/casval-worker (min 0, max 1, replicas 0)` discovered every loop; main loop runs (`No unschedulable pods` → `scale up not needed`, `no scale down candidates`). `cluster-autoscaler-status` ConfigMap in kube-system reports `autoscalerStatus: Running`, clusterWide health `Healthy` (3/3 nodes ready), node group `casval-worker` `Healthy` cloudProviderTarget 0 — proves the kube-system RBAC and write path work.
+- **Benign noise (not defects):** `Failed to check cloud provider has instance for hpg5.igou.systems / ocp.igou.systems / truenas-w1: machine not found` — expected, those are agent-installed (non-CAPI) nodes. Also client-side API throttling delays + verbose `--v=4` make the loop ~6.4s and the log chatty.
+
+### Functionality review (git vs live)
+
+- **Recovered the rebuild cleanly.** Component is 100% declarative and holds no state, so GitOps redeployed it with no manual restore — the correct outcome. RBAC, SA, namespace, and the hardened deployment (`runAsNonRoot`, drop ALL caps, `readOnlyRootFilesystem`, seccomp RuntimeDefault, no privilege escalation, `system-cluster-critical`) are all intact and correct. Discovery works because the whole CAPI stack is internally self-consistent on the cluster name `ocp-hb42r`.
+
+- **[MEDIUM] Post-disaster `infrastructureName` drift — documented invariant now violated; scale-up unverified since rebuild.** The reinstall regenerated the OpenShift infra name to **`ocp-m97rd`** (`oc get infrastructure cluster`), but the autoscaler's discovery arg `--node-group-auto-discovery=clusterapi:namespace=openshift-cluster-api,clusterName=ocp-hb42r` — and the whole CAPI stack it depends on (Cluster, MachineSet `cluster.x-k8s.io/cluster-name` label, `cluster-api-cluster-config` ConfigMap) — are still pinned to the **old `ocp-hb42r`**. The repo's own docs state clusterName "**must equal `infrastructure.status.infrastructureName`… Update on reprovision**"; this was not done. It does not break the autoscaler *today* (everything is self-consistent, so discovery + status all work), but: (a) the actual scale-up/provision path has **not been exercised since the disaster** — MachineSet is at 0 and BMH `casval` is `available`/offline; and (b) this is a cross-component coupling trap — the autoscaler hard-codes `ocp-hb42r` in its Deployment args, so if the `cluster-api` component is later corrected to `ocp-m97rd` without updating this arg in lockstep, discovery silently returns zero node groups. Root cause lives in the `cluster-api` component; this component carries a coupled copy.
+
+- **[LOW] Scale-from-zero end-to-end unproven post-rebuild.** The CAPI `Cluster ocp-hb42r` is `Available=False` (`RemoteConnectionProbe` failed, `ControlPlaneAvailable=Unknown`) — the expected "phantom/externally-managed" state for this BYO pattern (control plane is agent-installed, not CAPI-managed; `InfrastructureReady=True`, `Paused=False`, so MachineSet reconciliation is not blocked). The BMH target survived and is `available`. However the MachineSet's own annotation warns of the known first-scale GPU limitation (kubernetes/autoscaler#5278): scale-*from*-zero for `nvidia.com/gpu` pods won't work until casval has been manually scaled to 1 once. Since casval has never come up since the reinstall, a one-shot bootstrap + a real burst-pod scale test is needed before treating autoscaling as operational.
+
+- **[LOW] No metrics scrape.** Container exposes metrics on port 8085 but there is no `Service`/`ServiceMonitor` in the namespace, so Prometheus is not collecting autoscaler metrics — no alerting/visibility on scale events, failed scale-ups, or unschedulable-pod backlog.
+
+### Remediation
+
+1. **Reconcile the CAPI cluster name to the live infra name `ocp-m97rd` (repo-wide, atomic).** Update `clusters/ocp/cluster-api/cluster-config-configmap.yaml` (the single source of truth) **and** the autoscaler's `--node-group-auto-discovery=…clusterName=…` arg in `components/cluster-api-autoscaler/cluster-autoscaler-deployment.yaml` in the same change, then let ArgoCD resync. (Owner: coordinate with the `cluster-api` component review.) If instead a decision is made to keep `ocp-hb42r` permanently, update the comments/README so the "must equal infrastructureName" invariant is no longer misleading.
+2. **Prove scale-from-zero once.** Manually scale `casval-worker` to 1 (bootstraps the GPU capacity per #5278), confirm the node joins with the burst taint/labels, then scale back and drive a real Pending burst pod to confirm the autoscaler scales up and back down. Read-only for this review — flag to the operator.
+3. **(LOW) Add a `Service` + `ServiceMonitor`** (or PodMonitor) for port 8085 so scale activity and errors are observable in Prometheus.
+4. **(Optional cleanup)** Lower `--v=4`→`--v=2` to cut log noise; the unused namespace-local `leases` Role can stay (harmless) since the lease actually lands in kube-system.
+
+---
+
+## cluster-api-operator
+
+**Status: healthy** (operator + providers fully recovered; one Medium functional gap in the downstream CAPI machine-management path that is latent, not this component's file scope)
+
+### Scope
+`components/cluster-api-operator` installs the upstream (kubernetes-sigs) **cluster-api-operator** Helm chart (v0.27.0) plus three provider CRs, the SCC/PSA plumbing, and RBAC that OpenShift's built-in CAPI stack would normally supply. It is the *sole* CAPI implementation on this cluster — OpenShift's native `cluster-capi-operator` is not running (`openshift-cluster-api` has **no deployments**, only the csr-approver/node-cleanup cronjobs). The actual machine objects (BareMetalHost, `casval-worker` MachineSet, Metal3MachineTemplate, BMC ExternalSecret) live in the sibling **`cluster-api`** ArgoCD app (`clusters/ocp/cluster-api/`), which is also Synced/Healthy.
+
+### Health check (read-only)
+- **ArgoCD app** `cluster-api-operator`: **Synced / Healthy**, rev `d81e454`, `automated.selfHeal: true`.
+- **Operator**: `capi-operator-system/capi-operator-cluster-api-operator` 1/1, 0 restarts, on control-plane (`ocp.igou.systems`), 3h30m.
+- **Providers — all Ready=True, ProviderInstalled, PreflightChecksPassed:**
+  - CoreProvider `cluster-api` **v1.12.7** → `capi-system/capi-controller-manager` 1/1
+  - InfrastructureProvider `metal3` **v1.12.4** → `capm3-system/capm3-controller-manager` 1/1
+  - IPAMProvider `metal3` **v1.12.4** → `capm3-system/ipam-controller-manager` 1/1
+- **Namespaces** capi-operator-system / capi-system / capm3-system Active with `pod-security…/enforce: privileged` labels present; SCC `nonroot-v2` RoleBindings implicitly validated by the fact the UID-65532 controller pods are Running.
+- **IPAM CRD SSA patch verified live**: `ipaddressclaims`/`ipaddresses.ipam.cluster.x-k8s.io` expose exactly `v1alpha1(served, not-stored)` + `v1beta1(served, stored)` — the OCP-4.21-payload shape the `providers.yaml` patch targets. No `v1beta2` storage version, so no CVO↔capi-operator SSA conflict. Working as designed.
+- **No Warning events** in any of the three namespaces; **no CrashLoopBackOff / Pending**; no PVCs or Routes owned by this component (none expected).
+
+### Findings
+
+**[Medium] Downstream CAPI workload-cluster connection is broken — `ocp-hb42r-kubeconfig` secret missing post-reinstall.**
+The `Cluster/ocp-hb42r` (in `openshift-cluster-api`) is `Available=False`:
+- `RemoteConnectionProbe=False (ProbeFailed)`, `ControlPlaneAvailable=Unknown (InternalError)`.
+- `capi-controller-manager` logs a hard failure every ~30s: `Connect failed … error getting kubeconfig secret: Secret "ocp-hb42r-kubeconfig" not found`.
+
+Root cause: the cluster-cache kubeconfig Secret is normally minted by OpenShift's native `cluster-capi-operator` during bootstrap, but that operator is intentionally absent here, and no GitOps object recreates it. On reinstall the cluster infra-id regenerated (`ocp-hb42r`), so any previously-minted secret no longer matches. This component's own `capi-workload-cluster-access-rbac.yaml` grants the `default`/openshift-cluster-api SA node read/patch precisely so a token in that secret works — but the secret it depends on does not exist. Impact: `Metal3Cluster/ocp-hb42r` is Ready and `InfrastructureReady=True`, but if `casval-worker` (currently `replicas: 0`, the intended burst-GPU scale-from-zero path) is scaled up, the resulting Machine can provision the BareMetalHost yet fail to associate its `nodeRef`/reach `Running` because the CAPI cluster-cache cannot reach the workload apiserver, and autoscaler accounting would be off. No active workload is impaired today (0 replicas), so this is latent — but the scale-from-zero recovery path is unproven after the rebuild. Note: this may also have been a pre-existing cosmetic `Available=False` before the disaster; the missing secret is nonetheless real.
+
+**[Low] IPAM CRD patch is version-pinned to the OCP 4.21 release payload and must be hand-regenerated on any CAPI-core bump.** The two RFC-6902 patches in `providers.yaml` embed byte-identical CRD schema bodies from the 4.21 release image so CVO and capi-operator get shared SSA ownership. Correct today (cluster is 4.21.9, CAPI v1.12.7), but this is fragile maintenance debt: bumping `CoreProvider.spec.version` without re-extracting the manifest would reintroduce the storage-version conflict. Documented in-file; flagging as an upgrade-time trap.
+
+**[Info] No auto-prune on the ArgoCD app** (`syncPolicy.automated` has `selfHeal: true`, no `prune`). Drift is self-healed but resources removed from git are not garbage-collected. Consistent with the rest of the repo; not a defect.
+
+**[Info] Recovery quality:** the operator layer itself recovered the rebuild cleanly and completely — chart version, all three provider versions, SCC/PSA/RBAC, and the IPAM CRD reconciliation are all in their intended state with no manual drift. Everything this component *directly* owns is GitOps-reproducible and healthy.
+
+### Remediation
+1. **(Medium)** Restore/create the `ocp-hb42r-kubeconfig` cluster-cache Secret in `openshift-cluster-api` (kubeconfig for the local apiserver, tokened by the `default` SA that `capi-workload-cluster-access-rbac.yaml` already authorizes) so `RemoteConnectionProbe`/`ControlPlaneAvailable` clear and Machine node-association works. Because the infra-id (`ocp-hb42r`) is installer-generated and changes on every reinstall, prefer a reproducible generator over a hand-created secret — e.g. add it to the `cluster-api` app (`clusters/ocp/cluster-api/`) rendered from the live infra-id, or a small post-install Ansible step — so this doesn't have to be rediscovered after the next rebuild. Validate by scaling `casval-worker` 0→1 and confirming the Machine reaches `Running` with a `nodeRef`.
+2. **(Low)** Add a comment/checklist tying `CoreProvider.spec.version` bumps to re-extracting the IPAM CRD patch from the matching OCP release image (already partly noted in-file); consider a CI check that diffs the embedded schema against the payload.
+3. **(Info)** Track that this cluster relies solely on the community capi-operator (native `cluster-capi-operator` disabled) — this is the reason the kubeconfig secret is not auto-minted and should be captured in the DR runbook.
+
+---
+
+## cluster-api
+
+**Status: degraded** — ArgoCD `Synced`/`Healthy` and all operators/providers/CronJobs are running, but the burst-worker provisioning path did **not** recover from the 2026-07-03 reinstall. The cluster still carries the pre-disaster infrastructure name and the documented one-time bootstrap steps were never re-applied. Currently benign only because the MachineSet is at `replicas: 0` and the BMH is `online: false`; the first attempt to burst-scale `casval` will fail.
+
+Git source: `clusters/ocp/cluster-api` (cluster-specific objects; the operator/providers live in `components/cluster-api-operator`).
+
+### What is healthy
+- ArgoCD app `cluster-api`: `Synced` + `Healthy` (rev d81e454, project cluster-config).
+- Providers all `READY=True`: core-provider `v1.12.7` (capi-system), metal3 infra `v1.12.4` (capm3-system), metal3 ipam `v1.12.4`. Controllers `capi-controller-manager`, `capm3-controller-manager`, `ipam-controller-manager`, and `capi-operator-cluster-api-operator` all `1/1 Running`.
+- `capi-csr-approver` and `capi-node-cleanup` CronJobs firing every minute; latest jobs `Complete`, pods scheduled on the control-plane node.
+- `casval-bmc-secret` ExternalSecret `Ready=True` (SecretSynced, 3 keys) — 1Password path recovered fine.
+- Dormant burst config intact and correct: BMH `casval` `available`/`online:false`, MachineSet `casval-worker` `replicas:0` with autoscaler 0→1 bounds and capacity/label hints. `Metal3Cluster` `Ready=true`.
+
+### Findings
+
+1. **[CRITICAL] Stale cluster name — post-disaster restore gap.** `cluster-config-configmap.yaml` still pins `clusterName: ocp-hb42r` (git and live agree, hence ArgoCD is "Synced"), but the reinstalled cluster's `infrastructure.status.infrastructureName` is now **`ocp-m97rd`**. The README and the ConfigMap comment state this value *must* equal `infrastructure.status.infrastructureName` and *must be updated on reprovision*. `git log` confirms the ConfigMap was untouched during recovery (last edit is the original creation commit). Every CAPI object (`Cluster`, `Metal3Cluster`, `MachineSet` cluster-name label/`spec.clusterName`, and the expected `<cluster-name>-kubeconfig` secret) is keyed to the wrong name. This is latent drift that ArgoCD cannot detect.
+
+2. **[HIGH] `worker-user-data-managed` bootstrap secret missing.** README step 1 (one-time-per-cluster, not GitOps-automated) requires copying this secret from `openshift-machine-api` into `openshift-cluster-api`; CAPM3 consumes it for the Ignition bootstrap referenced by both the MachineSet and the Metal3MachineTemplate. It is **NotFound** in `openshift-cluster-api` (the source copy still exists in `openshift-machine-api`, 2 keys). Without it a burst worker cannot be provisioned.
+
+3. **[HIGH] Workload kubeconfig secret missing + `ControlPlaneInitialized=False`.** README step 2 (create the `<cluster-name>-kubeconfig` secret carrying the `cluster.x-k8s.io/cluster-name` label, then patch `ControlPlaneInitialized=True` for the external-control-plane pattern) was not re-run. No kubeconfig/user-data secret exists in the namespace, and the `Cluster` shows `Available=False`, `ControlPlaneInitialized=False (NotInitialized — Waiting for the first control plane machine…)`, `RemoteConnectionProbe=False`. In this external-control-plane design the initialized condition must be patched manually; until then CAPI treats the control plane as uninitialized, which gates worker Machine provisioning and remote-cluster caching.
+
+4. **[LOW/observation] Bootstrap remains manual and undocumented in recovery runbooks.** All three gaps above stem from steps the README itself flags as "not yet automated in GitOps." The disaster-recovery playbook did not include them, so they were silently skipped. Consider promoting them into the GitOps bootstrap Ansible (or at minimum the DR runbook) so a reinstall reconstitutes the burst path automatically.
+
+### Remediation
+1. Update `clusters/ocp/cluster-api/cluster-config-configmap.yaml` `clusterName` from `ocp-hb42r` to `ocp-m97rd`, commit, and let ArgoCD re-sync so the kustomize `replacements` propagate the new name into `Cluster`, `Metal3Cluster`, and the `MachineSet` (name/label/`spec.clusterName`). Verify against `oc get infrastructure cluster -o jsonpath='{.status.infrastructureName}'`.
+2. Re-run README step 1: copy `worker-user-data-managed` from `openshift-machine-api` into `openshift-cluster-api`.
+3. Re-run README step 2 against the corrected name `ocp-m97rd`: create the `ocp-m97rd-kubeconfig` secret (with the `cluster.x-k8s.io/cluster-name` label) and patch `ControlPlaneInitialized=True` on the `Cluster` status.
+4. Validate the burst path end-to-end (scale MachineSet 0→1 or exercise the autoscaler once) before relying on it, then return to scale-to-zero.
+5. Fold steps 1–3 into the GitOps/DR bootstrap automation so a future reinstall recovers the burst worker without manual intervention.
+
+---
+
+## democratic-csi
+
+**Status: healthy** (fully recovered the rebuild and is the storage backbone of the DR restore) — **with one CRITICAL latent node-level risk (shared NVMe hostnqn) that threatens this component's default storage class.**
+
+democratic-csi is the cluster's primary dynamic-provisioning CSI stack, fronting the TrueNAS box (`truenas.igou.systems`) over three transports (iSCSI, NFS, NVMe-oF) × three ZFS pools (fast, ssd, cold) = **9 driver releases**. `freenas-nvmeof-ssd-csi` is the **cluster-default StorageClass** and hosts essentially every restored stateful workload.
+
+### Health check (read-only, cluster state)
+
+- **ArgoCD app** `democratic-csi` (project `cluster-config`): **Synced / Healthy**, revision `d81e454`. 169 managed resources, **0 OutOfSync / 0 unhealthy**. No drift.
+- **Controllers:** all 9 Deployments `…-config-controller` are `1/1` Available (6/6 containers each).
+- **Node plugins:** all 9 DaemonSets `…-config-node` are `3/3` Ready across all three nodes (ocp/10.10.9.10, hpg5, truenas-w1).
+- **StorageClasses:** all 9 `freenas-*-csi` present; **`freenas-nvmeof-ssd-csi` marked `(default)`**. **CSIDrivers:** all 9 `org.democratic-csi.*` registered. **VolumeSnapshotClasses:** 6 present (fast+ssd tiers; cold tiers intentionally have none).
+- **ExternalSecrets:** all 9 `…-config` `SecretSynced / Ready=True` via ClusterSecretStore `onepassword-sdk-ocp-pull` (1Password item `truenas`). Decoded `nvmeof-ssd` config is fully templated (`host: truenas.igou.systems`, `apiKey` present, `datasetParentName: ssd/k8s/vols`) — secret plumbing survived the rebuild.
+- **Functional proof (not merely running):** controller `Probe` → TrueNAS returns `ready:true` in steady state. **16 PVCs bound** on freenas SCs (14 on nvmeof-ssd, 2 on nvmeof-fast), **all VolumeAttachments `attached=True`**, **no unbound/Pending PVCs cluster-wide**, and **no `FailedAttachVolume` / `FailedMount` / Multi-Attach events**. The DR-restored stateful workloads are all live on this storage: `quay-pg-1-full-recovery` 2/2, `rhdh-pg-1` 2/2, `forgejo-pg-1` 2/2, and the `hermes` VM (30Gi root+state) 2/2 — plus the 6 CNV golden OS images and user-workload Prometheus/Thanos.
+
+### Findings
+
+- **[CRITICAL — latent, not-yet-firing] All 3 nodes share one NVMe `hostnqn` AND `hostid` (`466937ab-67bf-4315-971b-bc110d55ce28`).** Verified by SSH on all nodes. NVMe-oF requires a unique host identifier per initiator; the TrueNAS target gates namespace visibility / ANA / reservations by hostnqn, so three "identical" hosts against the same subsystems can cross-expose RWO namespaces or produce intermittent attach/reservation failures — exactly the incident's stated symptom. This is *the* default StorageClass and carries every restored database, so blast radius is maximal. **Not a fault in this component's git** (hostnqn is node/OS-level), but it is the single biggest threat to democratic-csi's correctness. It has not manifested as an outage yet (all attachments currently healthy), which is luck, not safety.
+- **[MEDIUM] Controller pods flap under transient TrueNAS API latency.** Every controller shows 10–13 restarts; container `lastState` = `Error` (csi-driver exit 15, sidecars 255) correlated with `Liveness probe failed: grpc` warnings ~80–85 min ago and controller logs showing `TrueNAS api is unavailable: timeout of 5000ms exceeded` plus a `CreateVolume … timeout of 60000ms`. The 5s gRPC liveness probe restarts the driver whenever TrueNAS is briefly slow, cascading restarts across all 9 releases at once. Self-heals (all 6/6 now) but is disruptive during any real TrueNAS slowdown and masks genuine failures. Consider raising liveness `timeoutSeconds`/`failureThreshold`.
+- **[LOW] Driver image pinned to the `next` development channel** (`ghcr.io/…/democratic-csi:next@sha256:0f308ae…`) rather than a tagged stable release. It is digest-pinned (reproducible) and tracked by a Renovate customManager, but `next` is democratic-csi's dev stream — acceptable as the price of NVMe-oF support, worth revisiting once NVMe-oF lands in a stable tag.
+- **[INFO] No post-disaster restore was required for democratic-csi itself, and none is missing.** The component is effectively stateless: its config lives in 1Password (re-hydrated by ESO) and the actual volume data lives on TrueNAS ZFS (`ssd/k8s/vols`, etc.), which was never touched by the MS-01 wipe. GitOps re-sync + ESO fully reconstituted it; all volumes re-bound and re-attached against pre-existing ZFS zvols. Clean recovery.
+- **[INFO — no gap] Security/RBAC is correctly scoped.** Privileged SCC is bound only to the per-release `…-node-sa` ServiceAccounts (node plugins legitimately need host mount + nvme/iscsi tooling); controllers use `hostNetwork: true` for target connectivity. TLS to TrueNAS is `allowInsecure: false`, apiVersion 2, via a scoped `csi` API key (per prior scoped-account work). No over-broad grants observed. iSCSI/NFS tiers are provisioned and running but currently carry 0 PVCs (idle tiering options).
+
+### Remediation
+
+1. **(Critical) Assign a unique `/etc/nvme/hostnqn` + `/etc/nvme/hostid` to each node** and reconnect NVMe-oF. Fix belongs in node provisioning (MachineConfig/ignition or the igou-ansible node role), not this component — generate with `nvme gen-hostnqn` / a fresh UUID per host so the three initiators are distinct on the TrueNAS target. Track/coordinate with the cluster-wide hostnqn remediation noted in the reinstall record. Until fixed, treat every nvmeof RWO attach as at risk of cross-node exposure.
+2. **(Medium) Loosen the controller gRPC liveness probe** (higher `timeoutSeconds`/`failureThreshold`, or point liveness at the local socket rather than a path that round-trips to TrueNAS) via the helm `valuesInline`, so transient TrueNAS API latency stops restarting all 9 controllers. Optionally investigate the underlying TrueNAS API slowness (5s/60s timeouts) separately.
+3. **(Low) Move off the `next` image channel to a stable digest** once democratic-csi ships NVMe-oF in a released tag; keep the Renovate customManager.
+4. **(Verify)** No action needed on data restore — confirm ongoing health by watching that `quay/rhdh/forgejo` CNPG and the hermes PVCs stay `attached=True`; a sudden Multi-Attach event would be the first sign the shared-hostnqn risk has fired.
+
+---
+
+## external-secrets-operator
+
+**Status:** degraded — operator fully recovered and the read/pull path is 100% functional, but the secret **write-back (PushSecret) path is broken** on two of three ClusterSecretStores.
+
+Git source: `clusters/ocp/external-secrets-operator` (Helm chart `external-secrets` v2.6.0, app image pinned by digest `v2.2.0@sha256:876e627…`). Deployed via ArgoCD app `external-secrets-operator` (project `cluster-config`, sync-wave 0).
+
+### Health check (read-only, live cluster)
+
+- **ArgoCD app:** `Synced` + `Healthy`; `status.sync.revision` = `d81e454…` = current `origin/main` HEAD (no drift, no conditions/warnings).
+- **Namespace:** `external-secrets-operator` Active (8h, matches post-rebuild age).
+- **Deployments:** all 3 at `1/1` Ready — `external-secrets`, `external-secrets-cert-controller`, `external-secrets-webhook` (all pods Running, 0 restarts, 7h24m). This is a Helm-based install, not OLM (no Subscription/CSV — expected).
+- **CRDs:** full ESO CRD set installed (externalsecrets, clustersecretstores, pushsecrets, clusterexternalsecrets, generators, etc.).
+- **ClusterSecretStores (CRs owned by this component):** all 3 `Valid` / `Ready=True` / advertised `ReadWrite` — `onepassword-sdk-ocp-pull`, `onepassword-sdk-ocp-push`, `onepassword-sdk-claude`. All point at Connect `http://onepassword-connect.onepassword-connect.svc:8080` and auth via the shared `onepassword-connect-token` secret.
+- **Consumers:** all ~28 `ExternalSecret`s cluster-wide are `SecretSynced=True` (cert-manager, democratic-csi, quay, rhdh, forgejo, tailscale, openshift-config htpasswd, monitoring, etc.) — the pull path that the rest of the rebuild depended on is fully working.
+- **Bootstrap token:** `onepassword-connect-token` secret present in-ns.
+
+### Findings
+
+**[Medium] Secret write-back path is non-functional — Connect token lacks vault-update (403).**
+All 6 `PushSecret`s in the `service-accounts` namespace are in `Errored` state, and the ESO controller is logging ~12 reconcile 403s per 10 min (ongoing, not a startup blip):
+- `onepassword-sdk-ocp-push` → vault `dtd2bci…` (ocp-push): `403 Authorization: token does not have permission to perform update on vault`
+- `onepassword-sdk-claude` → vault `iggugny…` (claude): same 403.
+
+Root cause is the 1Password **Connect access token** (shared `onepassword-connect-token`) being scoped read-only on the `ocp-push` and `claude` vaults. Note ESO's store validation only probes reachability, so both stores still report `ReadWrite`/`Valid` while every actual write fails — the health signal is misleading. The PushSecret objects themselves live in the `service-accounts` component, but the broken capability is on stores this component owns. Read/pull is unaffected. Cannot definitively confirm whether this regressed during the rebuild or pre-existed, but it is broken *now*.
+
+**[Low / DR-resilience] Bootstrap `onepassword-connect-token` is out-of-band, not in GitOps.**
+The secret is created manually (`oc -n external-secrets-operator create secret generic onepassword-connect-token …`, managed-by `kubectl-client-side-apply`, no ArgoCD tracking-id, no ownerRefs, no labels) per `docs/superpowers/plans/2026-06-07-1password-connect-migration.md`. This is the intended ESO chicken-and-egg bootstrap and it *was* correctly re-applied during recovery, so ESO came back. But it is a single manual step with no GitOps safety net: if missed on a future rebuild, **every** ExternalSecret cluster-wide fails. It should be an explicit, checklisted DR-runbook step (which the migration doc provides).
+
+**[Low / security] Single shared token spans read + write across all vaults.**
+One `onepassword-connect-token` backs the pull, push, and claude stores. If the 403 is fixed by granting the shared token write on `ocp-push`/`claude`, the read-only `ocp-pull` store's token also becomes write-capable — a least-privilege gap. Prefer separate read-only vs write-scoped Connect tokens/secrets per store class.
+
+**[Info] Benign startup transients (already self-resolved).** Webhook logged `invalid certs. retrying…` / `ca cert not yet ready` only at boot (7h ago); none in the last 15 min, the `externalsecret-validate` ValidatingWebhookConfiguration now has a populated caBundle, and the webhook is `1/1`. Normal cert-controller startup race — no action.
+
+**[Info] Operator pinned to control-plane node only.** `valuesInline.global.nodeSelector: control-plane` + master/control-plane tolerations. Appropriate for this single-control-plane cluster, but means ESO shares fate with the MS-01 master (acceptable given the topology).
+
+### Remediation
+
+1. **Restore the push/write capability (Medium):** In 1Password, grant the Connect integration/token backing `onepassword-connect-token` **write (update)** access to the `ocp-push` (`dtd2bci…`) and `claude` (`iggugny…`) vaults, then re-apply the `onepassword-connect-token` secret in `external-secrets-operator`. The 6 `service-accounts` PushSecrets should flip to `SecretSynced` on next reconcile (or force with an annotation touch). Verify: `oc get pushsecret -A` shows no `Errored` and controller logs stop emitting `status 403`.
+2. **Codify the bootstrap step (Low):** Ensure the manual `onepassword-connect-token` creation is a first-class step in the cluster DR runbook (it currently lives only in the migration plan doc), and consider whether it can be seeded from a break-glass source rather than hand-typed.
+3. **Least-privilege tokens (Low):** Split into a read-only Connect token for `onepassword-sdk-ocp-pull` and a separate write-scoped token for the push/claude stores.
+4. No action needed on the ArgoCD app, deployments, CRDs, webhook certs, or the pull path — all healthy and drift-free.
+
+---
+
+## firecrawl
+
+**Status: not-yet-deployed** (correctly defined in git and registered in the app-of-apps, but blocked from being created by a stuck upstream app-of-apps sync — this is a rollout/ordering problem, not a firecrawl defect)
+
+Firecrawl is an internal-only web scraping/crawling backend for the Hermes agent. It is a multi-workload `app-template` (bjw-s) Helm deployment: `api`, `worker`, `extract-worker`, `nuq-worker` (Node), plus support services `playwright`, `redis`, `rabbitmq`, and a persistent `nuq-postgres`. Source: `applications/firecrawl` (registered in `clusters/ocp/values.yaml` at sync-wave 19).
+
+### Findings
+
+- **[CRITICAL] The firecrawl ArgoCD Application does not exist; nothing is running.** `oc get applications.argoproj.io firecrawl -n openshift-gitops` → NotFound, and namespace `firecrawl` does not exist (no Deployments/PVCs/pods/secrets). In the `root-applications` app-of-apps resource tree, `Application/firecrawl` shows `OutOfSync / Missing`.
+
+- **[CRITICAL] Root cause is an upstream app-of-apps deadlock, external to firecrawl.** `root-applications` is `OutOfSync / Progressing` with auto-sync (selfHeal+prune) enabled. An in-flight sync **operation has been Running/retrying since 01:42Z (~73 min, retryCount ≥4)** and is gated on child-app health (message cycles: "waiting for healthy state of Application/quay-operator", then "…/machineconfigs" — i.e. it restarts wave-walking each retry and never completes). Because the operation never reaches a clean finish, the newly-added wave-19 firecrawl Application is never created. The same stall is holding back six sibling apps (`ansible-automation-platform`, `gitea-mirror`, `gotify`, `jellyfin`, `llmkube`, `searxng` — all Missing).
+
+- **[CRITICAL] The stuck operation is targeting a stale revision that predates firecrawl.** The running op's target is `056256c` (PR #386, "restore hermes-agent scaffolding") — but firecrawl was only added at HEAD `d81e454` (PR #389). So even if the current op eventually succeeds, it will not create firecrawl; a *fresh* sync to `d81e454` is required. The app's compare revision is already `d81e454` (hence the OutOfSync/Missing diff), but no new sync can start while the old operation is stuck. The actual health blocker is **quay-operator** (its CNPG `quay-pg` Cluster and `QuayRegistry/igou-registry` are Missing — the `quay-operator` namespace has no CNPG cluster and only the operator pod). This is a DR-restore-in-progress artifact (wave-3 apps were re-enabled incrementally in #386→#389).
+
+- **[INFO/positive] The firecrawl git config is DR-safe and does not require any post-disaster restore.** Secrets come from a self-contained ESO `Password` generator (`firecrawl-secrets` → `firecrawl-secret`) — no 1Password/Barman dependency, so a fresh random secret is generated on deploy and shared consistently by redis/rabbitmq/nuq-postgres at first boot. The `passwords.generators.external-secrets.io` CRD is present and ESO is Synced/Healthy. `nuq-postgres` is only a transient queue DB, so the fresh 10Gi PVC (no backup/restore) is the correct design — no data-loss concern.
+
+- **[LOW] Once created, PVC binding depends on democratic-csi NVMe-oF, which carries the cluster-wide latent bug.** `firecrawl-nuq-postgres` (RWO 10Gi) uses `freenas-nvmeof-ssd-csi` (present, default, democratic-csi Synced/Healthy). The shared-hostnqn/hostid defect noted in the incident could cause intermittent volume-attach failures for this PVC until fixed. No fsGroup is set on nuq-postgres; rely on OpenShift restricted SCC to assign one for the `/var/lib/postgresql/data` mount.
+
+- **[LOW] Runtime search dependency is also down.** Config sets `SEARXNG_ENDPOINT=http://searxng.searxng.svc…`, but the `searxng` namespace/app is also not deployed (same stall). The core scrape/crawl path (api+worker+extract-worker+nuq-worker+playwright) does not need searxng, so this only degrades search-backed features once firecrawl comes up.
+
+- **[INFO] Security posture is good.** `automountServiceAccountToken: false`, seccomp RuntimeDefault, `runAsNonRoot`, `allowPrivilegeEscalation: false`, `drop: [ALL]` on all containers; images pinned by digest; no Route (internal ClusterIP only); Hermes egress restricted to TCP 3002 via `hermes-agent` NetworkPolicy (hermes-agent app is Synced/Healthy). The upstream `nuq-prefetch-worker` is intentionally `enabled: false` (documented).
+
+### Remediation (advisory — reviewer is read-only)
+
+1. **Unblock the app-of-apps rollout** (this is the only thing preventing firecrawl from deploying). Terminate the wedged `root-applications` sync operation so a fresh sync against HEAD `d81e454` can start, and resolve the wave-22 `quay-operator` health gate (bring up its CNPG `quay-pg` Cluster + `QuayRegistry`). Firecrawl is wave 19, so a clean re-sync should create it before it re-reaches quay.
+2. **Consider decoupling low-priority apps from the quay gate.** quay-operator being unhealthy is currently blocking unrelated apps (firecrawl, searxng, jellyfin, llmkube, gotify, gitea-mirror, AAP). Making these independently syncable (or ordering quay after them) would prevent one operator's slow restore from starving the rest.
+3. **After firecrawl syncs, run the README smoke test** (`/v0/health/liveness` via `TEST_API_KEY`) and confirm the `firecrawl-nuq-postgres` PVC bound cleanly (watch for NVMe-oF attach flakiness tied to the shared-hostnqn bug). Bring up `searxng` to restore search-backed crawl features.
+
+---
+
+## forgejo
+
+**Status: broken** — every pod is Running/Healthy and the CNPG database restore technically succeeded, but the live service is a **fresh empty instance**: the 356 restored repos are orphaned in the wrong database and the git repository filesystem was never restored. From a user/DR standpoint the component does not fulfil its function and there is active data-loss risk.
+
+Source path: `applications/forgejo` · ArgoCD app `forgejo` (project `cluster-apps`, sync-wave 22) · namespace `forgejo` · route `https://forgejo.apps.ocp.igou.systems`.
+
+### Health check (read-only, live cluster)
+- **ArgoCD app**: `OutOfSync` / `Healthy`. The only OutOfSync resource is `Cluster/forgejo-pg` (itself Healthy). `operationState: Succeeded ("successfully synced")`; `automated.selfHeal: true`; no `ignoreDifferences` configured.
+- **Pods**: `forgejo-6cc8b8565b-7lz8r` 1/1 Running (on `truenas-w1`), `forgejo-pg-1` 2/2 Running (pinned to control-plane per anti-multiattach affinity). No restarts, no crashloops, no Pending.
+- **PVCs**: `forgejo-pg-1` (10Gi) and `forgejo-shared-storage` (100Gi) both Bound on `freenas-nvmeof-ssd-csi` (RWO).
+- **CNPG cluster** `forgejo-pg`: 1/1 ready, "Cluster in healthy state"; conditions `Ready`, `ContinuousArchiving=Success`, `LastBackupSucceeded=True`. `ScheduledBackup forgejo-pg-daily` produced a completed Backup; WAL/backup archiving to the new `serverName forgejo-pg-r20260704` (correct post-DR timeline-collision avoidance).
+- **ExternalSecrets**: `cnpg-s3-credentials` and `forgejo-secrets` both `SecretSynced` / Ready. Route (edge/Redirect) + services present.
+
+### Findings
+
+**[CRITICAL] Database restore landed in the wrong DB — forgejo is serving an empty instance.**
+The recovery block in `forgejo-pg-cluster.yaml` specifies only `bootstrap.recovery.source: forgejo-pg` and omits `database`/`owner`. CNPG defaulted them to `app`/`app`, so on physical recovery it created a **new empty `app` database + `app` role** and generated the `forgejo-pg-app` secret pointing at `dbname=app, user=app`. The Forgejo Helm release consumes exactly that secret (`GITEA__database__{HOST,NAME,USER,PASSWD}` from `forgejo-pg-app`), so Forgejo connected to the empty `app` DB, ran its own migrations, and created a fresh admin.
+- `app` DB: 128 tables, **users=1** (`igou_admin`, created post-disaster), **repos=0**, actions=0.
+- `forgejo` DB (the real restored data, orphaned/unused): 128 tables, **users=6** (`igou_admin, starred, djdanielsson, Throckmortra, xvorenda, igou-io`), **repos=356**, last action `2026-07-02 21:20` (right before the disaster).
+Pre-disaster the DB was named `forgejo`/`forgejo` (per the commented-out `initdb` block in the same file); the recovery block should have set `database: forgejo, owner: forgejo` so the `-app` secret pointed at the recovered DB.
+
+**[CRITICAL] Git repository filesystem was NOT restored and has no backup mechanism.**
+`forgejo-shared-storage` (100Gi) is a freshly provisioned empty volume: `/data/git/repositories` has **0 repos** and `df` shows **204K used of 98G**. Forgejo stores bare git repos (commits/blobs/refs) on this PVC — the CNPG Barman backups cover only Postgres metadata, **not** the on-disk git objects, and no Velero/CSI-snapshot/tar-to-S3 backup is configured for this PVC anywhere in the manifests. Consequence: even after fixing the DB pointer (Finding 1), all 356 repos would appear but be empty/broken. Unless the pre-disaster `forgejo-shared-storage` zvol still exists on TrueNAS (democratic-csi names zvols by PVC-UUID, so a name search is inconclusive — needs a lookup by the old PVC UUID) or the repos are mirrored elsewhere, this is unrecoverable data loss. The DR record mentions only the DB restore; the repo filesystem restore appears to have been missed.
+
+**[HIGH] Empty Forgejo breaks Pipelines-as-Code tenants (downstream blast radius).**
+`clusters/ocp/pac-tenants/values.yaml` registers PaC tenants against repos hosted in Forgejo (e.g. `https://forgejo.apps.ocp.igou.systems/igou-io/igou-ansible`). With an empty instance those repos 404, so tenant clones/webhooks/pipelines are broken until Forgejo data is recovered.
+
+**[LOW→MED] Perpetual OutOfSync; recovery manifest not reverted.**
+`bootstrap` is immutable, so the operator-defaulted `database: app`/`owner: app` will diff against git forever, and with no `ignoreDifferences` on `/spec/bootstrap` the app can never reach Synced (selfHeal churns cosmetically, masking real drift). The manifest also still has `bootstrap.recovery` active pointing at the OLD archive `serverName forgejo-pg` — its own comment instructs reverting to the `initdb`/normal running spec once recovery is verified; that revert is pending. If `forgejo-pg-1` is ever lost, it would recover from the stale pre-disaster archive rather than the current `forgejo-pg-r20260704` timeline.
+
+**[INFO] Security posture is otherwise sound** — admin `passwordMode: initialOnlyRequireReset`, route edge TLS + redirect, `webhook.ALLOWED_HOST_LIST: private`, git memory caps, `nonroot-v2` SCC bound to the `forgejo` SA. No security gap found.
+
+### Remediation (priority order)
+1. **Repoint the DB (CRITICAL).** Bootstrap is immutable, so re-run recovery with `bootstrap.recovery: { source: forgejo-pg, database: forgejo, owner: forgejo }` — recreate the CNPG cluster from the same Barman backup so the operator-generated `forgejo-pg-app` secret points at the restored `forgejo` database (the current empty `app` DB is disposable). Verify `forgejo-pg-app.dbname=forgejo` and `users=6/repos=356` after.
+2. **Recover the git repo filesystem (CRITICAL).** Before doing anything destructive, locate a source for the bare repos: (a) check TrueNAS for the orphaned pre-disaster `forgejo-shared-storage` zvol (by the old PVC UUID) and clone/restore it into the new PVC's zvol; (b) check the `gitea-mirror` app (wave 23) and any external GitHub mirrors as alternate sources; then rehydrate `/data/git/repositories`. If nothing is found, treat the 356 repos as lost and rebuild from upstream mirrors.
+3. **Add a filesystem backup for `forgejo-shared-storage`** (Velero + CSI snapshot, or periodic tar-to-S3) so DB-only backups don't recur as a single point of loss.
+4. **After verification, revert `forgejo-pg-cluster.yaml`** to the plain `initdb`/running spec per its own comment (or add `ignoreDifferences` on `/spec/bootstrap`) to clear the perpetual OutOfSync and prevent an accidental replay from the stale archive.
+5. **Revalidate PaC tenants** (`igou-io/igou-ansible` etc.) once repos are back.
+
+---
+
+## gateway-api
+
+**Status: healthy** (component fully recovered the rebuild) — but the guest-dmz tier is **not yet serving any application**: zero HTTPRoutes are attached because its documented consumer (jellyfin) was not restored. Root cause of that gap is outside this component.
+
+Reviewed git revision: `origin/main` @ `d81e454` (git path `clusters/ocp/gateway-api`). ArgoCD app `gateway-api` is **Synced + Healthy**, synced to `d81e454` (targetRevision HEAD) — no drift.
+
+### Scope
+The component owns exactly three resources (per `kustomization.yaml`): `GatewayClass openshift-default`, `Gateway guest-dmz` (ns `openshift-ingress`), and cert-manager `Certificate gateway-guest-dmz-tls`. It does **not** own any HTTPRoute — apps onboard their own.
+
+### Findings
+
+**[OK] Full infrastructure recovery, verified live.**
+- `GatewayClass openshift-default` → controller `openshift.io/gateway-controller/v1`, `Accepted=True` (7h40m).
+- `Gateway guest-dmz` → `Programmed=True`, `Accepted=True`, address `10.10.152.3` (the contracted rb5009 VIP). Listener `https` conditions all clean (`ResolvedRefs=True`, `Conflicted=False`).
+- Managed control plane + data plane both Running in `openshift-ingress`: `istiod-openshift-gateway` (restartCount 1, benign — no lastState, not a crashloop) and Envoy `guest-dmz-openshift-default-*` (1/1).
+- LoadBalancer Service `guest-dmz-openshift-default` has `EXTERNAL-IP 10.10.152.3` (MetalLB honored the `spec.infrastructure.annotations` pin), ports 443 + 15021, `externalTrafficPolicy: Cluster` (as documented).
+- `ingress` ClusterOperator: `Available=True, Progressing=False, Degraded=False`. The per-listener `DNSRecord guest-dmz-...-wildcard` exists and, as the README predicted for bare metal, stays unpublished without degrading the operator.
+
+**[OK] TLS restored correctly — end-to-end verified.** `Certificate` READY, backing `Secret gateway-guest-dmz-tls` present. Live probe of `https://10.10.152.3:443` (SNI `*.dmz.igou.systems`) returns the **real production Let's Encrypt wildcard** `CN=*.dmz.igou.systems` (issuer LE, freshly reissued **notBefore Jul 3 2026**, notAfter Oct 1 2026, renewalTime Sep 16) and Envoy answers HTTP 404 (correct: no route attached). So TLS termination on the VIP is genuinely functional, not merely "pods Running." `cluster-acme` ClusterIssuer is READY. Cert was correctly regenerated during the rebuild — no stale/expired secret.
+
+**[MEDIUM] The guest-dmz Gateway currently routes nothing — DMZ tier is not functional end-to-end.** Listener `attachedRoutes: 0`; **zero HTTPRoutes cluster-wide**; **zero namespaces** carry the `gateway-access/guest-dmz=true` label. The documented live consumer `jellyfin.dmz.igou.systems` (jellyfin-cutover memory) is down: the `jellyfin` namespace does not exist and the `jellyfin` ArgoCD Application is **missing from `openshift-gitops`**, even though it is declared in the app-of-apps (`clusters/ocp/values.yaml` → `applications.jellyfin`, project `cluster-apps`, sync-wave 20, path `applications/jellyfin`, which includes a valid `jellyfin-httproute.yaml` with correct `parentRefs` to `guest-dmz`). **This is a jellyfin / app-of-apps restore gap, not a gateway-api defect** — but it means the whole reason this Gateway exists is unserved. Flag for the jellyfin/app-of-apps owner.
+
+**[INFO] Pre-flight constraints from README still hold post-rebuild.** Gateway API CRDs are the operator-managed bundle (`bundle-version v1.3.0`, `channel standard`) — not community CRDs, so no upgrade admin-gate. A `servicemeshoperator3` Subscription exists in `openshift-operators` (OSSM **v3**, stable) — this does **not** trigger `GatewayAPIOSSMConflict`, which fires only on OSSM **v2.x**; the managed `istiod-openshift-gateway` is healthy alongside it.
+
+**[INFO / by-design] Shared-VIP exposure.** The wildcard cert + single VIP mean every VLAN admitted to the guest-dmz tier reaches anything routed here; per-app L4 isolation is impossible on this shared Gateway (documented tradeoff). No security regression from the rebuild — just noting the standing posture as more apps onboard.
+
+### Remediation
+1. **(Owner: jellyfin/app-of-apps, not gateway-api)** Restore the consumer app so the tier actually serves: investigate why the `jellyfin` ArgoCD Application isn't materializing from `clusters/ocp/values.yaml` (sync-wave 20 / project `cluster-apps`) — check the `applications` app-of-apps/ApplicationSet health and any pruned/failed generation, then let it sync (creates the `jellyfin` ns with the `gateway-access/guest-dmz=true` label + the HTTPRoute). After sync, confirm `Gateway guest-dmz` listener `attachedRoutes` becomes ≥1 and `curl https://jellyfin.dmz.igou.systems` returns 200 through the VIP.
+2. **No action needed on gateway-api itself.** All three owned resources are correctly restored, Synced to HEAD, and live-verified. Optional post-restore smoke test once a route is attached: re-run the VIP curl expecting the app response instead of 404.
+3. **Monitor** cert auto-renewal at ~Sep 16 (Envoy SDS hot-reload, no restart) — no action now.
+
+---
+
+## gitea-mirror
+
+**Status:** not-yet-deployed (queued in the post-disaster app-of-apps restore; config in git is intact and valid, but the child Application has not been created yet, so there is no data-recovery step wired for it)
+
+`gitea-mirror` is a GitHub→Forgejo repo-mirroring web app (image `ghcr.io/raylabshq/gitea-mirror:v3.15.6`, digest-pinned) deployed via the bjw-s `app-template` Helm chart. Source: `applications/gitea-mirror` (wired into `clusters/ocp/values.yaml:362`, project `cluster-apps`, sync-wave `23`).
+
+### Health check (read-only, cluster = ocp)
+
+- **ArgoCD Application `gitea-mirror` does not exist yet.** `oc get application gitea-mirror -n openshift-gitops` → NotFound. In `root-applications.status.resources` it shows `OutOfSync / Missing`.
+- **Root cause = still queued, not failed.** `root-applications` (auto-sync, self-heal) is mid-DR-restore and re-running a wave-ordered sync (revision `d81e454`, started 02:56:21Z). The current syncResult has only reached the low waves (currently blocking on `democratic-csi`, hookPhase `Running`). A whole batch of higher-/file-wave apps is still `Missing`: `gitea-mirror`, `gotify`, `jellyfin`, `searxng`, `firecrawl`, `llmkube`, `ansible-automation-platform`. gitea-mirror is wave 23, so it is created near the end. No defect specific to gitea-mirror.
+- **Nothing exists in-cluster:** no `gitea-mirror` namespace, no `gitea-mirror-config` PVC, no pods, no route. Nothing to be CrashLooping/Pending yet.
+- **Downstream dependencies are ready**, so it should sync cleanly once reached: mirror target `forgejo` pod + `forgejo-pg` are Running and the route `forgejo.apps.ocp.igou.systems` is up; `ClusterSecretStore onepassword-sdk-ocp-pull` is `Ready=True`; default StorageClass `freenas-nvmeof-ssd-csi` present and `democratic-csi` app Synced/Healthy; `blackbox-exporter` svc exists (for the Probe CR).
+
+### Functionality review (git config)
+
+Config is correct and complete and was **never removed during DR** (only PR #250 ever touched the values.yaml block; the app dir is intact). Image is digest-pinned; securityContext is restricted-v2 compliant (`runAsNonRoot`, drop ALL, no privilege escalation, seccomp RuntimeDefault); `BETTER_AUTH_URL`/route host are consistent (`gitea-mirror.apps.ocp.igou.systems`); GitHub creds come from ExternalSecret `gitea-mirror-secrets` (envFrom). Findings:
+
+- **[MEDIUM] No post-disaster restore for its state; it will come up empty and need manual first-run setup.** All app state — the better-auth admin account, GitHub/Forgejo connection, encrypted tokens, and mirror job history — lives in a **SQLite file DB** (`DATABASE_URL: file:/app/data/gitea-mirror.db`) on the 40Gi RWO PVC `gitea-mirror-config`. This is *not* a CloudNativePG database, so it was **not** part of the Barman/RustFS DB restore (quay/rhdh/forgejo) or the hermes tar restore. When the app finally deploys it gets a **fresh empty PVC** → boots into first-run setup with no admin user and no Forgejo target. It will **not** auto-resume mirroring. GITHUB_TOKEN/BETTER_AUTH_SECRET/ENCRYPTION_SECRET are injected from 1Password, and `AUTO_IMPORT_REPOS=true` + `SCHEDULE_ENABLED` are set, so once an admin logs in and re-pastes the Forgejo PAT (by design this PAT is UI-entered, not wired to k8s), it can re-import. But a human step is required — this is the real DR gap for this component.
+- **[MEDIUM] Pre-disaster data likely survives as an orphaned zvol on TrueNAS (optional recovery path).** The default SC uses `org.democratic-csi.nvmeof-ssd` with `reclaimPolicy: Delete`. Because etcd was wiped rather than the PV gracefully deleted, the CSI driver never received a delete call, so the old `gitea-mirror-config` zvol was almost certainly **orphaned** on TrueNAS, not reclaimed. The old SQLite DB (with the working config) may still be recoverable via a manual static-PV import — otherwise GitOps will provision a fresh empty volume and the old one becomes dead storage. Low urgency since the data is re-derivable, but worth a look before accepting a clean-slate setup, and it adds to the cold/orphan cleanup backlog.
+- **[HIGH — cross-cutting latent bug, affects this app's volume] Shared NVMe hostnqn/hostid across all 3 nodes.** gitea-mirror's PVC lands on the NVMe-oF default SC. The incident's known latent defect (all nodes share the same `hostnqn ...466937ab...`) causes intermittent volume-attach failures over NVMe-oF. Once gitea-mirror is scheduled, watch for stuck `ContainerCreating`/attach errors on `gitea-mirror-config`; this is not gitea-mirror's fault but will manifest on its RWO volume.
+- **[LOW] Destructive cleanup is enabled against freshly-restored Forgejo.** `CLEANUP_DELETE_IF_NOT_IN_GITHUB: "true"`, `CLEANUP_ORPHANED_REPO_ACTION: archive`, `CLEANUP_DRY_RUN: "false"`. On the first scheduled run (`0 4 * * *`) it will archive Forgejo repos absent from GitHub. Archive (not delete) is relatively safe, but it runs automatically against the just-restored Forgejo — confirm the Forgejo DB restore matches GitHub before the first schedule fires, or start with `CLEANUP_DRY_RUN: "true"`.
+- **[LOW] `resources: {}`** — no CPU/memory requests or limits → BestEffort QoS; first to be evicted under pressure on a recovering cluster. Add a small burstable request.
+- **[LOW] Verify the 1Password item `gitea-mirror` is populated** (fields GITHUB_TOKEN, BETTER_AUTH_SECRET, ENCRYPTION_SECRET). The pod requires the `gitea-mirror-secrets` envFrom secret to start; couldn't confirm the item's contents here (op is Connect-mode). The store is Ready and it worked pre-disaster, so this is just a pre-flight check.
+- **[COSMETIC] Probe CR is named `gitea-mirror-biscuit`** — stale "biscuit" host legacy; the target URL is correctly `...apps.ocp.igou.systems/api/health`, so it functions.
+
+### Remediation
+
+1. **None required to unblock it** — it is queued behind the wave-ordered DR sync. Let `root-applications` finish (it is currently blocked on `democratic-csi` reaching Healthy, then works up to wave 23). If it stalls, unblocking the earlier waves (democratic-csi / quay) lets it proceed. Do not hand-create the Application.
+2. **After it deploys, do first-run setup** (expected, not a bug): open `https://gitea-mirror.apps.ocp.igou.systems`, create the admin account, re-paste the Forgejo PAT (stashed as 1Password item `gitea-mirror-forgejo-pat`), confirm the GitHub token connects, then trigger/allow the auto-import to re-mirror.
+3. **Before the first 04:00 schedule**, verify the restored Forgejo repo set matches GitHub (or temporarily set `CLEANUP_DRY_RUN: "true"`) so the cleanup pass doesn't archive legitimately-restored repos.
+4. **Optional data recovery:** check TrueNAS for the orphaned pre-disaster `gitea-mirror-config` zvol; if present and preferred over a clean setup, statically import it as the PV. Otherwise delete it as part of orphan cleanup.
+5. **Watch the volume attach** on first schedule for the shared-hostnqn NVMe-oF issue; track under the cluster-wide hostnqn remediation.
+6. **Nice-to-have:** add a small `resources.requests` block.
+
+---
+
+## gotify
+
+**Status: broken** (defined in git, not re-deployed after the rebuild; causing a live alert-delivery outage)
+
+Scope note: since the cluster reinstall, the Gotify *server* no longer runs on OCP — it lives on the public VPS `gotify.igou.io`. The only in-cluster piece is the `alertmanager-gotify-bridge` (druggeri/alertmanager_gotify_bridge v2.3.2), which receives Alertmanager webhooks and forwards them to `https://gotify.igou.io/message`. That bridge is currently **not deployed**.
+
+### Findings
+
+- **[CRITICAL] The `gotify` child Application was never (re)created — component is absent from the cluster.**
+  - `oc get applications.argoproj.io gotify -n openshift-gitops` → `NotFound`.
+  - In `root-applications` (the app-of-apps) the child shows `Application/gotify sync=OutOfSync health=Missing`.
+  - Namespace `gotify` does not exist; no Deployment, Service, ServiceAccount, ExternalSecret, or Secret exist.
+
+- **[CRITICAL] Alertmanager Gotify delivery is DOWN right now.** `alertmanager-main-0` is Running and `components/alertmanager-config/alertmanager.yaml` sets the **default** receiver to `gotify` plus `gotify-and-slack-critical` / `gotify-and-slack-warning`, all pointing at `http://alertmanager-gotify-bridge.gotify.svc:8080/gotify_webhook`. That Service does not exist, so every push notification to Gotify (including the Watchdog dead-man's-switch) is failing. Slack fan-out for critical/warning receivers is unaffected; info/Watchdog-to-Gotify visibility is lost.
+
+- **[HIGH — root cause, external to gotify] The parent app-of-apps sync is stalled and never reached gotify.** `root-applications` is `OutOfSync | Progressing`, operation "waiting for healthy state of argoproj.io/Application/quay-operator", which is itself "waiting for healthy state of postgresql.cnpg.io/Cluster/quay-pg" (the Barman-restored Quay DB not yet Healthy). The same stall left a batch of workload apps Missing: firecrawl(19), gotify(20), jellyfin(20), llmkube(20), searxng(20), gitea-mirror(23), ansible-automation-platform(30). Note the ordering anomaly: gotify is sync-wave 20 yet quay-operator (wave 22) got created while gotify did not — so simply waiting on quay-pg may not auto-heal gotify; a targeted sync is likely required.
+
+- **[INFO] gotify's own git config is correct and needs no data restore.** The bridge is stateless — the server/PVC/route/admin-secret were intentionally removed (comment in `applications/gotify/kustomization.yaml`), so there is **nothing to restore from backup** for this component; it should converge cleanly once synced. Config is sound: image digest-pinned (`...@sha256:2424...`), hardened securityContext (runAsNonRoot, drop ALL caps, `allowPrivilegeEscalation: false`, seccomp RuntimeDefault), and the documented `MESSAGE_ANNOTATION: summary` + `DISPATCH_ERRORS`/`EXTENDED_DETAILS` workarounds for the v2.3.2 HTTP-400 bug.
+
+- **[INFO] Secret backing verified present.** ExternalSecret `gotify-bridge-token` uses ClusterSecretStore `onepassword-sdk-ocp-pull` (vault `ocp-pull`). The 1Password item `gotify-bridge-token` exists in that vault and has a `token` field, matching the Deployment's `secretKeyRef{name: gotify-bridge-token, key: token}`. So ESO resolution should succeed as soon as the app deploys.
+
+- **[LOW] No resource requests/limits** on the bridge container (`resources: {}`). Minor; the bridge is lightweight.
+
+### Remediation
+1. Get the parent app-of-apps to converge: bring `quay-pg` CNPG cluster to Healthy so `root-applications` can finish, **or** don't block gotify on Quay — trigger a targeted `argocd app sync gotify` / sync `root-applications` (with the anomalous wave ordering, gotify likely needs an explicit sync rather than passively waiting on the quay-operator wave).
+2. After it deploys, verify: `gotify` namespace + `alertmanager-gotify-bridge` Deployment Ready, Service `alertmanager-gotify-bridge.gotify.svc:8080` exists, ExternalSecret `gotify-bridge-token` → Secret `gotify-bridge-token` (key `token`) SecretSynced, and Alertmanager stops logging webhook failures (send a test alert / confirm the Watchdog reaches gotify.igou.io).
+3. (Optional) add modest CPU/memory requests+limits to the bridge container.
+
+---
+
+## grafana
+
+**Status:** healthy
+
+Grafana instance for the `ocp` hub cluster, deployed via the community Grafana Operator (channel `v5`), fronted by an OpenShift OAuth-proxy sidecar, with the in-cluster Thanos Querier as the default (and only) datasource. It fully recovered the 2026-07-03 rebuild with no manual intervention.
+
+### Health check (live cluster)
+
+| Check | Result |
+| ----- | ------ |
+| ArgoCD app `grafana` (openshift-gitops) | **Synced + Healthy**; synced revision `d81e454` == `origin/main` HEAD (no drift/staleness) |
+| Grafana Operator | `grafana-operator-controller-manager-v5` 1/1 Running on hpg5, 0 restarts |
+| `Grafana` CR (`grafanas.grafana.integreatly.org/grafana`) | v13.0.1, stage `complete`/`success`, `GrafanaReady=True`; 11 dashboards + 1 datasource applied into the instance |
+| Deployment `grafana-deployment` | 2/2 Running (grafana + oauth-proxy) on truenas-w1, **0 restarts** |
+| PVC `grafana-pvc` | **Bound**, 1Gi, `freenas-nvmeof-ssd-csi` |
+| Route `grafana-route` | **Admitted=True**, `grafana.apps.ocp.igou.systems`, reencrypt/Redirect |
+| Secrets | `grafana-tls` (service serving cert), `grafana-oauth-cookie` (populated), `grafana-sa-token` (populated) all present |
+| ExternalSecret `grafana-oauth-cookie` | `SecretSynced` / **Ready=True** |
+| Datasource `thanos-querier` | `DatasourceSynchronized=True (ApplySuccessful)` |
+| All 11 `GrafanaDashboard` CRs | `DashboardSynchronized=True (ApplySuccessful)` |
+
+Note: `oc get grafana` returns "No resources found" because the short name `grafana` resolves to the **External Secrets** `Grafana` generator kind, not the grafana-operator CR — a harmless naming collision. The operator's `grafanas.grafana.integreatly.org` CR is present and Ready.
+
+### Recovery assessment
+
+This component is **stateless-by-config** and recovered the rebuild cleanly. Every dashboard and the datasource are GitOps-managed CRs that the operator re-pushes into the fresh instance, so no external/Barman/tar restore was required. The 1Gi PVC only backs Grafana's internal sqlite (annotations/prefs); the meaningful state is reconstructed from git. Good design — nothing to restore, and nothing was missed.
+
+### Findings
+
+- **MEDIUM — cross-cutting DR risk: PVC on NVMe-oF with the shared-hostnqn latent bug.** `grafana-pvc` rides `freenas-nvmeof-ssd-csi` (RWO) and the Deployment uses `strategy: Recreate` for a single replica. The cluster-wide latent defect (all 3 nodes share the same NVMe `hostnqn`/`hostid`, nqn `...466937ab...`) causes intermittent volume-attach failures. The volume is currently attached and mounted fine on truenas-w1, but any future reschedule of this pod could hang on attach. One transient readiness-probe timeout was observed ~5m before review (pod recovered, still 0 restarts) — plausibly storage-latency-related. Not grafana-specific, but grafana is exposed. Since this instance is stateless-by-config, it is also a candidate to drop off NVMe-oF entirely.
+
+- **LOW — security (by design, worth restating):** `auth.proxy.enabled=true` + `users.auto_assign_org_role: Admin` means *any* OpenShift user who passes the OAuth-proxy SAR (`get services/grafana-service` in the `grafana` ns) is granted **Grafana Admin**. That SAR is a fairly low bar (namespace view). Documented as intentional (access control at the SAR layer) and acceptable for a homelab, but it is broad. `tlsSkipVerify: true` on the Thanos datasource is documented (internal service-CA cert) and acceptable.
+
+- **LOW — documentation drift:** `README.md` describes the Route as `grafana.apps.hub.igou.systems` and calls this the "hub cluster," but the live config and admitted route are `grafana.apps.ocp.igou.systems`. Cosmetic; the manifests are correct.
+
+- **INFO — self-healed bootstrap race:** At initial sync (~139m ago) the ExternalSecret `grafana-oauth-cookie` logged one `UpdateFailed: Password.generators.external-secrets.io "grafana-oauth-cookie" not found`. The ExternalSecret and its `Password` generator are both sync-wave `10`, so intra-wave ordering isn't guaranteed and the ExternalSecret reconciled first. It self-corrected and is now `SecretSynced=True`. Benign, but explains the stale Warning event.
+
+### Remediation
+
+- **Prioritize the cluster-wide shared-hostnqn/hostid fix** so this (and every other NVMe-oF) PVC re-attaches reliably on reschedule. Given grafana is stateless-by-config, also consider moving `grafana-pvc` to a simpler/non-NVMe-oF StorageClass (or dropping the PVC) to remove it from that failure domain.
+- Update `README.md` Route/intro to `grafana.apps.ocp.igou.systems` (drop the "hub" wording) to match reality.
+- Optional hardening of the sync-wave race: give the `grafana-oauth-cookie` ExternalSecret a later wave than its `Password` generator (e.g. generator wave 10, ExternalSecret wave 11) to eliminate the transient bootstrap error.
+- Optional: reconsider `auto_assign_org_role: Admin` vs `Editor`/`Viewer` if finer-grained Grafana access is ever wanted; today all authz collapses to the single SAR.
+
+---
+
+## hermes-agent
+
+**Status:** degraded — GitOps/platform scaffolding recovered clean and the VM is Running with state restored, but (a) the agent itself is not yet functional (convergence is operator-deferred, expected) and (b) one HIGH latent infra risk (shared NVMe hostnqn) already paused the VM once this session and remains unfixed.
+
+Git source: `applications/hermes-agent` (repo `igou-io/igou-openshift`). ArgoCD app `hermes-agent` is **Synced + Healthy**, synced revision `d81e454` == current `origin/main` HEAD (no drift). Last change to the path: `59a2bc7` "allow igou.io and sandsoftime.igou.io in Hermes egress firewall (#379)".
+
+### What GitOps manages vs. what Ansible manages
+Argo owns only the *guardrails*: namespace, blank `hermes-state` DataVolume, `default` EgressFirewall, `hermes-deny-ingress` + `hermes-egress` NetworkPolicies, and the `hermes-vm-hardening` ValidatingAdmissionPolicy. The **VM itself and the `hermes-root` DataVolume are NOT in git** — they are provisioned by Ansible (`/workspace/igou-ansible/playbooks/hermes/provision-vm.yml`) and owned by the `VirtualMachine` object. This is the intended hybrid Argo+Ansible design, but it is a DR fact worth recording: after a cluster wipe the VM must be re-created out-of-band by re-running the playbook (which is what was done).
+
+### Health check (live)
+- **VM/VMI:** `virtualmachine/hermes` = Running/Ready; `vmi/hermes` phase Running, `AgentConnected=True`, guest = CentOS Stream 10 (kernel 6.12), IP 10.129.0.36 on **hpg5**. Networking = single `masquerade` interface on the pod network (passes the VAP).
+- **PVCs:** `hermes-root` (30Gi) and `hermes-state` (30Gi) both **Bound** on `freenas-nvmeof-ssd-csi` (Block mode, RWO); both DataVolumes `Succeeded`.
+- **Security controls all present and correct vs git:** EgressFirewall has 84 rules, is **locked** (terminal `Deny 0.0.0.0/0`, no allow-all debug rule live) and explicitly allows `igou.io` + `sandsoftime.igou.io`; `hermes-deny-ingress` permits only TCP/22 from the `ansible-automation-platform` namespace; `hermes-egress` restricts east-west to named llmkube model pods / searxng / firecrawl-api / quay only; VAP `hermes-vm-hardening` bound with `Deny`, `failurePolicy: Fail`, and the live VM satisfies all four invariants (masquerade-exclusive, no hostDevices, no GPUs). No leftover `temp-allow-ssh-restore` NetworkPolicy — cleanup confirmed. OVN ACL logging active.
+
+### Findings
+
+**[HIGH] Shared NVMe hostnqn/hostid across all 3 nodes — already paused this VM; auto-restart could re-trigger it.**
+All nodes carry the identical `nqn.2014-08.org.nvmexpress:uuid:466937ab-…`, violating NVMe-oF uniqueness. Live evidence in the `hermes` namespace: at ~96m `FailedMapVolume … "unable to attach any nvme devices"` on the state volume, then at ~90m `IOerror — VM Paused due to IO error at the volume: state`. The VM recovered (currently Ready, no Paused condition), but because `runStrategy: Always`, **KubeVirt will auto-restart the VM on any crash/reschedule**, and the state (or root) nvmeof volume may again fail to attach — with a data-corruption risk from two hosts sharing one NVMe host identity. Hermes is acutely exposed (two nvmeof RWO volumes on a worker while the master may already hold a controller for that subsystem). This is the top risk. *Remediation:* apply a MachineConfig that regenerates unique `/etc/nvme/hostnqn` (`nvme gen-hostnqn`) + `/etc/nvme/hostid` per node and rolling-reboot; until then keep the human "do not stop/start the VM" guardrail.
+
+**[MEDIUM] VM is not live-migratable and cannot survive a node drain gracefully.**
+`vmi` condition `LiveMigratable=False (DisksNotLiveMigratable): PVC hermes-root is not shared (RWO, requires RWM)`. A recent (~92s) `Migrated` warning shows the cluster-default eviction strategy tried and could not migrate it. If hpg5 needs maintenance, hermes must be powered off — which collides with the hostnqn attach risk above. Consequence of RWO nvmeof storage; acceptable by design but a resilience gap to note. `evictionStrategy` is unset on the VM (inherits cluster default LiveMigrate).
+
+**[INFO / not a bug — operator-deferred] Hermes is Running but not yet FUNCTIONAL.**
+Guest-agent filesystem list shows **only `vda2` (root) mounted at `/`**; the state disk `vdb` is attached but **not mounted**, and there is no hermes user / gateway / dashboard process on this fresh guest. This means the guest is at Phase-2a only (cloud-init SSH-ready as `igou`, qemu-guest-agent up) and the convergence chain (`setup-os.yml` → `setup-hermes.yml` → `configure.yml`) has not run. Per the review instructions this convergence + go-live (telegram, enabling the systemd unit, re-locking egress) is **operator-deferred and explicitly NOT a defect** — recorded here only so no one mistakes "VM Running" for "agent operational."
+
+**[INFO] State PV restore is done and correct.**
+Per the reinstall record, the freshly-created blank `hermes-state` PVC (`pvc-46858de9`) was formatted xfs (UUID 431c7ecf) and ~1.4G of `.hermes` (auth.json / config.yaml / SOUL.md / agent-config / dashboard / cron / memory, uid 1001 preserved) was extracted from `/workspace/backups/hermes/hermes-state-20260703.tar.zst`, excluding the regenerable `./containers` podman store, then unmounted clean. `setup-os.yml` uses `mkfs … force: false`, so the already-formatted+populated disk will be re-mounted (not wiped) when convergence runs. This is consistent with the live observation (vdb present, unmounted). Non-`.hermes` `/home/hermes` content lived on the ephemeral root pre-disaster and is regenerable — not restored, by design.
+
+**[LOW] Transient `ClaimMisbound` events on `hermes-state`** (CDI prime-PVC artifact during the blank import) — no current impact; PVC Bound and in use.
+
+**[LOW] PSA `enforce` still not set** — namespace has `audit=restricted` + `warn=restricted` but no `enforce` (intentionally deferred pending a virt-launcher compatibility check). Minor hardening gap, documented in git.
+
+### Remediation summary
+1. **HIGH:** Fix the cluster-wide NVMe hostnqn/hostid collision (per-node MachineConfig + rolling reboot). This is the only finding that materially threatens hermes availability/integrity today. Do not stop/start the VM until it lands.
+2. **MEDIUM:** Accept or address non-migratability (would need RWX storage for `hermes-root`); at minimum ensure node-maintenance runbooks account for a required power-off of hermes.
+3. **When the operator chooses go-live:** run the deferred convergence (`setup-os` → `setup-hermes` → `configure`) to mount `vdb`, install the agent, and start the gateway/dashboard; then re-lock egress and enable the unit. Not a DR defect.
+
+---
+
+## image-registry
+
+**Status: healthy** (running and recovered cleanly via GitOps; one MEDIUM durability/design caveat — ephemeral `emptyDir` storage)
+
+Git source: `clusters/ocp/image-registry` (single `Config` CR, sync-wave 8). Manages the OpenShift internal image registry operator via `imageregistry.operator.openshift.io/v1 Config/cluster`.
+
+### Health check (live cluster)
+
+- **ArgoCD app** `image-registry` (project `cluster-config`): **Synced / Healthy**, revision `d81e454`.
+- **ClusterOperator** `image-registry`: `AVAILABLE=True, PROGRESSING=False, DEGRADED=False`, version `4.21.9`, stable ~7h27m.
+- **Config CR** `cluster`: `managementState: Managed`, `replicas: 1`, `rolloutStrategy: Recreate`, `storage: emptyDir {}`, condition `StorageExists=True` ("EmptyDir storage successfully created"), `Available=True`, `Degraded=False`. Created `2026-07-03T18:51:09Z`, storage ready `19:21:51Z` — i.e. reconstituted by GitOps during the reinstall, no manual restore required.
+- **Pods** (ns `openshift-image-registry`): `image-registry-*` 1/1 Running on `ocp.igou.systems` (control plane); `cluster-image-registry-operator` 1/1 Running (3 restarts — reinstall churn, not live-flapping); `node-ca` DaemonSet 3/3 Running across all nodes; `image-pruner` CronJob last run **Completed**. No CrashLoopBackOff, no Pending.
+- **PVCs**: none (expected — `emptyDir`). **Routes**: none (`defaultRoute` unset → registry not externally exposed). **Service**: `image-registry` ClusterIP `172.30.4.13:5000`.
+- Pod `/healthz` returning 200 and serving Prometheus metrics; 64 ImageStreams present cluster-wide.
+
+### Findings
+
+- **[MEDIUM] Registry storage is ephemeral `emptyDir` — no durability.** All registry content lives on the control-plane node's ephemeral disk and is wiped on any pod restart, on the `Recreate` rollout of a config change, or on a control-plane (MS-01) reboot. This matters because the PaC/Pipelines-as-Code tenants actively depend on the in-cluster registry: `clusters/ocp/pac-tenants/values.yaml` adds an `allow-internal-registry` egress rule specifically so Buildah can pull FROM base images resolved through ImageStreams at `image-registry.openshift-image-registry.svc:5000`. After a registry pod restart the cached layers vanish and tenant builds will transiently fail until ImageStreams re-import. Impact is bounded (final build artifacts go to Quay, base images re-import from upstream — nothing is permanently lost), but it is a real availability gap and is exactly the kind of state a DR review should surface.
+- **[LOW/INFO] No HA and pinned to the single control plane.** `replicas: 1` on `ocp.igou.systems`; combined with `emptyDir` + `Recreate`, a control-plane reboot means registry unavailability plus cache loss. Acceptable for a single-control-plane homelab, but worth stating explicitly.
+- **[POSITIVE] Immune to the shared-hostnqn NVMe-oF bug.** Because this component uses `emptyDir` and no PVC, it was unaffected by the duplicate `hostnqn/hostid` volume-attach failures that hit PVC-backed components during recovery — it came back with zero manual intervention.
+- **[LOW/INFO] Minimal attack surface / default trust config.** ClusterIP-only, no `defaultRoute` (not reachable off-cluster) — good. `images.config.openshift.io/cluster` `.spec` is empty `{}` (no `allowedRegistries`/`additionalTrustedCA` hardening) — this is stock OpenShift default, noted for completeness, not a regression.
+
+### Remediation
+
+1. **Decide and document the durability posture (MEDIUM).** If the internal registry is intentionally just a base-image/ImageStream cache with Quay as the real artifact store, add a comment in `cluster-config.yaml` stating `emptyDir` is deliberate and that a registry restart forces ImageStream re-import — so it isn't mistaken for an unfinished restore. Otherwise, back it with persistent storage: either a democratic-csi PVC (`storage.pvc`, RWO is fine given `replicas:1` + `Recreate`) or S3 object storage against the existing RustFS/MinIO used for the CNPG Barman backups (`storage.s3`) for durability across restarts and control-plane reboots.
+2. **No immediate action required for health** — operator, pod, ClusterOperator, and ArgoCD are all green and the component self-recovered from the reinstall via GitOps.
+
+---
+
+## ingresscontroller-certs
+
+**Status:** healthy
+
+### Overview
+Single-purpose GitOps component (`clusters/ocp/ingresscontroller-certs`) that declares one cert-manager `Certificate` — `apps-certificate` in namespace `openshift-ingress` — for the cluster ingress wildcard `*.apps.ocp.igou.systems`. It writes TLS material into secret `acme-apps`, issued by ClusterIssuer `cluster-acme` (Let's Encrypt/ACME). ArgoCD app in project `cluster-config`, sync-wave `2`.
+
+### Health check (live cluster)
+- **ArgoCD app `ingresscontroller-certs`:** Synced / Healthy, revision `d81e454`. Only managed resource is `Certificate/apps-certificate` (Synced/Healthy). No conditions/errors.
+- **Certificate `apps-certificate`:** `Ready=True`, reason `Ready`, "Certificate is up to date and has not expired". `notAfter=2026-10-01T18:40:48Z`, `renewalTime=2026-09-16` (renewBefore 15d honored). Age ~7.7h — freshly re-issued after the 2026-07-03 reinstall.
+- **Backing secret `acme-apps`:** present, type `kubernetes.io/tls`, 2 data keys. Leaf cert `CN=*.apps.ocp.igou.systems`, SAN `DNS:*.apps.ocp.igou.systems`, issuer `Let's Encrypt CN=YR2` (real public cert, not self-signed).
+- **CertificateRequest `apps-certificate-1`:** Approved + Ready; no outstanding ACME `Challenges` (issuance fully completed, not stuck).
+- **ClusterIssuer `cluster-acme`:** `Ready=True` (`ACMEAccountRegistered`).
+- **End-to-end wiring:** `ingresscontroller/default.spec.defaultCertificate = {name: acme-apps}` — the cert is actually consumed by ingress. IngressController is `Admitted=True`, `Available=True`, `Degraded=False`, all router replicas available. Live TLS probe of `console-openshift-console.apps.ocp.igou.systems:443` served `CN=*.apps.ocp.igou.systems` (Let's Encrypt), confirming the cert is functionally in use, not merely present.
+
+### Findings
+- **[INFO] Disaster recovery: fully self-healed, no manual restore needed.** Because the cert is ACME-issued, cert-manager re-requested and re-issued it automatically post-reinstall (cert/secret/request ages ~7–7.7h match the rebuild timeline). No Barman/tar restore was required for this component; it recovered cleanly on its own.
+- **[INFO] Correctly configured and functional.** 90d duration / 15d renewBefore matches Let's Encrypt's ~90d lifetime; RSA-4096, `rotationPolicy: Always` (key rotated on every renewal — good hygiene); usages server+client auth. No drift between git and cluster.
+- **[LOW] `spec.subject.organizations: ["Igou"]` is a no-op with this issuer.** Public ACME CAs (Let's Encrypt) strip subject O/organization fields — the served leaf is `CN=*.apps.ocp.igou.systems` with no `O=Igou`. Cosmetic only; the field silently does nothing. Not a functional problem.
+- **[LOW] Cross-component coupling not captured in this component.** The consumer wiring (`ingresscontroller/default.spec.defaultCertificate → acme-apps`) lives outside this git path. It is correctly set in the live cluster, but the two are maintained separately; if the IngressController config component drifted or were removed, this cert would exist but sit unused. Worth keeping the pairing documented.
+
+### Remediation
+- No action required — component is healthy, correctly configured, and end-to-end functional after the rebuild.
+- Optional (cosmetic): drop `spec.subject.organizations` since Let's Encrypt ignores it, to avoid implying a subject O that never appears on the issued cert.
+- Optional (hygiene): add a note/comment linking this Certificate to the IngressController `defaultCertificate` consumer so the secret-name coupling (`acme-apps`) is obvious to future maintainers.
+
+---
+
+## intel-device-plugins-operator
+
+**Status: healthy**
+
+Stateless operator that recovered the cluster rebuild cleanly from GitOps with no manual restore required. The ArgoCD app is `Synced`/`Healthy` (revision `d81e454`), the operator is running, and the GPU device plugin is not merely running but **verified functional** — it discovered real Intel iGPUs and is advertising them to the scheduler.
+
+### Evidence of health / functionality
+- **ArgoCD app** `intel-device-plugins-operator` (project `cluster-config`): `Synced` + `Healthy`; last sync "successfully synced (all tasks run)"; all 4 tracked resources (Namespace, OperatorGroup, Subscription, GpuDevicePlugin) Synced.
+- **Operator**: Subscription `state=AtLatestKnown`, channel `stable`, `installPlanApproval: Automatic` (InstallPlan `install-7kfl7` approved). CSV `intel-device-plugins-operator.v0.36.0` = `Succeeded` (AllNamespaces install mode). `intel-deviceplugins-controller-manager` Deployment `1/1` Running on hpg5; no error/fail/panic lines in logs.
+- **GpuDevicePlugin CR** `gpudeviceplugin`: DESIRED 3 / READY 3. DaemonSet `intel-gpu-plugin-gpudeviceplugin` `3/3` Ready.
+- **Real device discovery (the key functional proof)**: both bare-metal nodes advertise `gpu.intel.com/i915: 10` + `gpu.intel.com/monitoring: 1` in node capacity/allocatable — `ocp.igou.systems` (MS-01 control-plane/worker) and `hpg5.igou.systems`. Plugin log on hpg5 confirms it probed a physical Intel iGPU at PCI `0000:00:02.0` (`/dev/dri/card0`, `/dev/dri/renderD128`) and registered 10 healthy `card0-N` shared slots with kubelet (`sharedDevNum: 10`).
+- **No PVCs, no routes, no CRs with persistent state** → nothing to restore after the disaster. Component fully self-reconciled from git; recovery is complete and correct.
+- No Warning events in the namespace.
+
+### Findings
+
+- **[INFO] Recovered fully with no restore needed.** This is a stateless device-plugin operator (no PVCs/DBs). Post-rebuild it reconciled entirely from GitOps and re-registered the physical GPUs. No disaster-recovery gap.
+- **[LOW] GPU-plugin DaemonSet runs on the GPU-less VM worker.** `truenas-w1` (KubeVirt VM, no GPU passthrough) shows `gpu.intel.com/*` capacity `{}` yet still runs a plugin pod, because the DaemonSet nodeSelector in the CR is only `kubernetes.io/arch=amd64`. Harmless (the pod finds no `/dev/dri` device and advertises nothing) but wastes a pod slot and adds noise. Gating on an NFD/i915 label would keep it off nodes with no Intel GPU.
+- **[LOW] No NFD-based gating; relies on the plugin's own probe.** The component does not deploy or depend on Node Feature Discovery labels — device presence is detected only at plugin runtime. Fine for a 3-node homelab, but combined with the finding above it means placement is arch-only, not capability-based.
+- **[INFO] `spec.image` drift is benign (ServerSideApply).** The live GpuDevicePlugin CR carries `image: registry.connect.redhat.com/intel/intel-gpu-plugin@sha256:2569cfa0…` (a digest-pinned certified image) that is absent from git; this is the operator/CRD default. Because the app syncs with `ServerSideApply=true` (and `RespectIgnoreDifferences`), ArgoCD does not flag it OutOfSync. Acceptable — git intentionally lets the operator select the certified image. If a pinned, reviewable image is ever desired, add it to `gpu-device-plugin.yaml`.
+- **[INFO] Capacity is available but currently unused.** No workload in the cluster requests `gpu.intel.com/i915` right now — 20 shared slots (10 on each of ocp + hpg5) sit idle. Not a defect; just note the plugin's value is latent until a consumer (e.g. media transcode / jellyfin, ML) requests the resource.
+- **[INFO] `sharedDevNum: 10` = 10x oversubscription with no isolation.** Each physical iGPU is exposed as 10 schedulable units with no memory/compute isolation between co-scheduled containers. Expected homelab trade-off; consumers must tolerate GPU contention.
+
+### Remediation
+
+- No action required for health or recovery — component is healthy and correctly recovered.
+- Optional hardening (both low priority):
+  - Add a capability-based nodeSelector to the GpuDevicePlugin CR (e.g. an NFD label such as `intel.feature.node.kubernetes.io/gpu: "true"`) so the DaemonSet no longer schedules a pod on the GPU-less `truenas-w1` VM worker.
+  - If a git-reviewable, pinned plugin image is desired for auditability, set `spec.image` explicitly in `components/intel-device-plugins-operator/gpu-device-plugin.yaml`; otherwise leave the operator default as-is.
+
+---
+
+## jellyfin
+
+**Status: not-yet-deployed** (git-defined and re-enabled in `main`, but the ArgoCD child app has never been created — the app-of-apps rollout is stalled behind `quay-operator`).
+
+Media server deployed via the vendored upstream Helm chart (`jellyfin-helm` 3.2.0, image `10.11.11`) with cluster overrides. Source: `applications/jellyfin`, sync-wave 20 in `clusters/ocp/values.yaml`.
+
+### Health check (live cluster)
+
+- **No `jellyfin` ArgoCD Application** in `openshift-gitops` (`applications.argoproj.io jellyfin` → NotFound). **No `jellyfin` namespace, PV, or PVC** exist. The workload is entirely absent.
+- `root-applications` (app-of-apps) has synced to `d81e454` (PR #389, which re-enabled jellyfin), but its sync **operation is Running and gated**: `phase=Running, message="waiting for healthy state of argoproj.io/Application/quay-operator"`. In the root app's `status.resources`, `jellyfin` is listed `OutOfSync` (not yet applied), alongside the other wave-3 file apps also still missing: `firecrawl`, `searxng`, `llmkube`, `gotify`, `gitea-mirror`, `ansible-automation-platform`. Earlier wave-3 apps (`forgejo`, `rhdh`) reached Healthy; `quay-operator` is stuck `OutOfSync/Progressing` and is holding the whole ordered sync — so jellyfin is blocked purely by wave ordering, not by any defect of its own.
+- Root app syncPolicy is `automated + selfHeal + prune`, so jellyfin will be created automatically **once `quay-operator` goes Healthy** — no manual jellyfin action is needed to unblock it.
+
+### Findings
+
+- **[HIGH] jellyfin not deployed — blocked behind `quay-operator` in the app-of-apps wave gate.** The rollout is parked waiting for `quay-operator` to become Healthy before proceeding to the wave-20 apps. Root cause is external to jellyfin (owned by the quay reviewer); jellyfin's own manifests are intact and its infra deps are ready.
+- **[HIGH] `/config` restore gap — jellyfin will very likely come up as a FRESH install (data loss).** `jellyfin-config` PVC is *dynamically* provisioned from `freenas-nvmeof-ssd-csi` (democratic-csi, NVMe-oF) with **no `volumeName`/static bind** and the StorageClass reclaim policy is **Delete**. The DR restored hermes state and the CloudNativePG DBs, but there is **no evidence jellyfin's `/config` (library DB, users, watch/playback state, metadata, image cache) was backed up or restored**. When jellyfin finally schedules it will bind a brand-new empty 20Gi zvol, so the media server will "run" but present as an unconfigured first-boot instance — the definition of running-but-not-functional. (The media library itself is safe — see below — but all library state/user accounts/progress would be lost.)
+- **[MEDIUM] NVMe-oF hostnqn collision risk on the config volume.** The config PVC rides NVMe-oF (`freenas-nvmeof-ssd-csi`). The cluster-wide latent bug (all 3 nodes share the same nvme `hostnqn`/`hostid`) causes intermittent volume-attach failures. jellyfin is single-replica, RWO, `Recreate`, pinned to the MS-01 — an attach flake would wedge the only pod with no fallback.
+- **[LOW] Media library (`/media`) recovery is sound.** Static NFS PV `jellyfin-media-nfs` → `10.10.9.213:/mnt/cold/media/data/media`, `ReadOnlyMany`, `Retain`, with a pinned `claimRef` to `jellyfin/jellyfin-media`. It rebinds deterministically and is mounted read-only, so no data-loss exposure — only an external dependency on the TrueNAS cold pool.
+- **[LOW] Deprecated MetalLB annotation.** The chart Service still uses `metallb.universe.tf/address-pool` (MetalLB logs it deprecated). Functional; already noted in the README as future cleanup.
+- **[INFO / POSITIVE] All infra dependencies are healthy and ready to receive jellyfin the moment the gate clears:** `democratic-csi` Synced/Healthy and `freenas-nvmeof-ssd-csi` present (default SC); `gateway-api` Synced/Healthy; the shared `guest-dmz` Gateway is `PROGRAMMED=True` at `10.10.152.3`; MetalLB `guest-dmz` pool exists. Manifests are well-hardened: `Recreate` + single replica (RWO config + single iGPU), `nodeSelector` pinning to the MS-01 for i915 transcode, `externalTrafficPolicy: Local`, seccomp `RuntimeDefault`, `runAsNonRoot`, `drop: ALL`, supplementalGroup 797 for the iGPU, HTTPRoute with API-server defaults stated explicitly for SSA and `request: 0s` for streaming, and a blackbox Probe against the public `/health` path.
+
+### Remediation
+
+1. **Unblock the rollout:** clear `quay-operator` to Healthy (its reviewer's action). The app-of-apps is auto/selfHeal — jellyfin will then be created and synced with no jellyfin-specific step. Verify with `oc get applications.argoproj.io jellyfin -n openshift-gitops` and `oc -n jellyfin get pods,pvc`.
+2. **Resolve the `/config` restore before/at first sync (do this deliberately, not by accident):** decide whether the pre-disaster jellyfin config is recoverable. Options: (a) if the old TrueNAS zvol still exists, statically pre-create the PV and pin the `jellyfin-config` PVC to it via `volumeName` so the sync adopts the existing data instead of provisioning empty; or (b) accept a fresh library and plan re-setup (users, libraries, transcode settings). Either way, add jellyfin `/config` to a backup routine — it is currently the only jellyfin state not covered by the DR restore plan.
+3. **Confirm NVMe uniqueness before the config volume attaches:** ensure the shared-hostnqn/hostid fix is applied to the MS-01 (where jellyfin is pinned) so the RWO NVMe-oF config PVC attaches cleanly; otherwise the single pod risks an attach wedge.
+4. **After it comes up**, verify functionality end-to-end (not just Running): pod on `ocp.igou.systems`, config + media volumes mounted, iGPU (`gpu.intel.com/i915`) allocated, `https://jellyfin.dmz.igou.systems/health` returns 2xx through the Gateway, and the direct VIP `10.10.152.1:8096` answers.
+
+---
+
+## kubeletconfig
+
+**Status:** healthy
+
+Declarative single-resource component: one `KubeletConfig` CR (`set-max-pods`) applied via the `machineconfiguration.openshift.io` API and rolled out by the Machine Config Operator. No namespace-owned workloads, no operator, no PVCs, no persistent state. It recovered the post-disaster rebuild cleanly and is verifiably functional (not merely synced).
+
+### Health check (live cluster)
+
+- **ArgoCD app** `kubeletconfig` (project `cluster-config`, sync-wave 3): `Synced` / `Healthy`; last sync operation `Succeeded` at 2026-07-03T18:56:41Z on revision `d81e454`. Single tracked resource `KubeletConfig/set-max-pods` is Synced.
+- **KubeletConfig `set-max-pods`**: status condition `Success=True`, `observedGeneration: 1`. Age 7h53m (consistent with the 2026-07-03 reinstall).
+- **MCO rollout**: MC `99-master-generated-kubelet` generated 7h53m ago; `master` MCP is `UPDATED=True, UPDATING=False, DEGRADED=False` (1/1 machines). No degraded/pending pool.
+- **Effective on-node result (authoritative)**: master `ocp.igou.systems` reports `capacity.pods=1000` / `allocatable.pods=1000` — the config actually took effect on the kubelet. Master currently runs 201/1000 pods; node conditions `MemoryPressure=False, DiskPressure=False, PIDPressure=False, Ready=True`. Fully functional.
+- No CrashLoopBackOff / Pending / OutOfSync / Missing anywhere for this component.
+
+### Findings
+
+- **[INFO] Config is master-MCP-scoped only; workers keep default 250 maxPods.** `machineConfigPoolSelector` matches `pools.operator.machineconfiguration.openshift.io/master`. Workers `hpg5` and `truenas-w1` remain at `capacity.pods=250`. This is almost certainly intentional — the control plane `ocp.igou.systems` carries the `worker` role (SNO-style schedulable master) and hosts the bulk of workloads, hence the 1000-pod headroom there. Flagged only so the asymmetry is a known choice, not drift.
+- **[LOW] `maxPods: 1000` + `podsPerCore: 50` — effective limit is `min(maxPods, podsPerCore × cores)`.** Master has 20 CPU → podsPerCore yields exactly 1000, matching maxPods, so today they are consistent. If the control-plane were ever resized to fewer cores, `podsPerCore` would silently cap the limit below 1000 (e.g. 16 cores → 800). Not a current defect; note for any future CPU change.
+- **[LOW/observation] 1000 pods on a single control-plane that also does worker duty is aggressive.** `autoSizingReserved: true` mitigates by auto-sizing system-reserved based on node capacity, and there is no pressure at 201 pods today. Worth watching PID/memory reserves as workload density grows; the number is real headroom, not a safe steady-state target.
+- **[NONE] Security / DR:** No secrets, no ExternalSecrets, no persistent data — nothing to restore for this component. It was correctly re-materialized by GitOps on rebuild and the MCO re-derived + rolled the machineconfig automatically. No latent restore gap.
+
+### Remediation
+
+- No action required; component is correct, applied, and functional.
+- Optional hygiene: if either dedicated worker is expected to host many pods, add a worker-scoped `KubeletConfig` rather than relying on the master-only override (currently they sit at the 250 default).
+- If the control plane is ever rebuilt with a different core count, re-confirm `podsPerCore × cores ≥ maxPods` (or drop `podsPerCore`) so the intended 1000 limit still holds.
+
+---
+
+## llmkube
+
+**Status: not-yet-deployed** (blocked behind the in-progress app-of-apps recovery sync; also carries one HIGH latent misconfiguration that will break a model the moment it does deploy)
+
+LLMKube is the self-hosted LLM inference stack: the `defilantech/LLMKube` operator (Helm chart `0.8.8`) plus three `Model`/`InferenceService`/`Route` triplets in `llmkube-system` — `qwen3-35b-a3b` (2x RTX 4060 Ti on the casval burst node), `qwen35-2b` (Pascal P620 on p330), and `gemma-4-e2b` (CPU on hpg5).
+
+### Health check (live cluster)
+
+- **ArgoCD Application `llmkube` does not exist.** `oc get application llmkube -n openshift-gitops` → NotFound. The app-of-apps (`root-applications`) lists it as `OutOfSync | Missing`.
+- **Nothing is deployed:** namespace `llmkube-system` absent, `inference.llmkube.dev` CRDs absent (`the server doesn't have a resource type "inferenceservices"/"models"`), no controller, no Model/InferenceService CRs, no pods, no model-cache PVC, no routes.
+- **Why:** `root-applications` sync is `phase=Running` (started 2026-07-04T01:42Z) and repeatedly blocks "waiting for healthy state of" earlier-wave apps (observed cycling through `quay-operator`, `cert-manager-operator and 3 more`). The sync has not yet reached the point of creating the wave-19/20 apps. `llmkube` is one of **7 apps still `Missing`** for the same reason: `firecrawl` (w19), `gotify`/`jellyfin`/`searxng`/`llmkube` (w20), `gitea-mirror` (w23), `ansible-automation-platform` (w30). This is an **external app-of-apps ordering blocker, not a llmkube-specific defect.**
+- **Runtime substrate llmkube depends on is healthy** (good news for when it deploys): `nvidia-gpu-operator` Synced/Healthy, `cluster-api` Synced/Healthy (casval `MachineSet` present, DESIRED=0 as expected for scale-from-zero), and all three democratic-csi NFS storage classes recovered — including `freenas-nfs-ssd-csi` which the RWX model-cache requires.
+
+### Findings
+
+- **[HIGH] `qwen35-2b` is pinned to a node that no longer exists — it will be permanently unschedulable.** `qwen35-2b-inferenceservice.yaml` sets `nodeSelector: kubernetes.io/hostname: p330.igou.systems`, but **p330 is dead/no-BMC and is not in the cluster** (`oc get node p330.igou.systems` → NotFound; nodes are only ocp, hpg5, truenas-w1). With `replicas: 1` in git, the instant llmkube syncs this pod goes Pending forever (no other Pascal GPU exists). This is stale-hardware config that survived into the rebuild.
+- **[MEDIUM] Model-cache is empty post-disaster; first start re-downloads all GGUFs from HuggingFace.** The shared `llmkube-model-cache` RWX PVC was destroyed with the cluster and there is no restore step (it is a cache, so no data loss, but it is a functional cold-start cost + external dependency). On first sync the `Model` CRs will pull `Qwen3.6-35B-A3B-UD-Q5_K_XL.gguf` (~25 GiB) plus the qwen3.5-2b and gemma-4-e2b weights over the internet onto `freenas-nfs-ssd-csi` before any endpoint is Ready. Expect a long "Downloading" phase; verify TrueNAS NFS-ssd headroom for ~30+ GiB.
+- **[MEDIUM] Deployment is gated on an app-of-apps sync that is currently churning and not converging.** Until `root-applications` gets past the cert-manager/quay health waits, llmkube (and 6 peers) will never be created. Needs the upstream blocker cleared (out of llmkube's scope, but it is the reason for the not-yet-deployed status).
+- **[LOW] `replicas: 1` on all three InferenceServices contradicts the README's "default replicas: 0".** So all three attempt to run immediately on first sync — including the doomed p330 one. If the intent is manual scale-up, git drifted from the documented default. (The `ignoreDifferences` on `/spec/replicas` is correctly present in both `values.yaml` and the README, so ArgoCD will not fight manual scaling — that part is fine.)
+- **[LOW / INFO] `gemma-4-e2b` node pin is declarative-only.** The repo's own comment notes this controller build strips `nodeSelector` for CPU-accelerator models, so the `hpg5` pin is not enforced by the controller (hpg5 does exist and is Ready, so it is at least a valid target — unlike p330). Placement is not durable across reschedules.
+- **[INFO / positive] Configuration is otherwise sound and disaster-aware.** Controller image is digest-pinned with an explicit rationale guarding against the `--default-fsgroup` CrashLoop on newer builds; `fsGroup: 1001030000` is pinned into the OpenShift restricted-v2 SCC range on every inference pod; model-cache is correctly `ReadWriteMany` on the NFS-ssd class (RWO block classes would Multi-Attach-deadlock across the burst + p330 pins); CUDA vs CPU llama.cpp images are per-model digest-pinned with correct Pascal/Ada reasoning. None of these are broken — they just have not run yet.
+
+### Remediation
+
+1. **Fix the p330 pin (HIGH).** Until p330 hardware is replaced, either remove/repoint `qwen35-2b-inferenceservice.yaml`'s `nodeSelector` to a live GPU node or set its `replicas: 0`, so it does not sit permanently Pending after deploy. (Note: no live change possible/permitted now — this is a git edit for the maintainer.)
+2. **Clear the app-of-apps blocker (MEDIUM).** llmkube cannot deploy until `root-applications` finishes; drive `cert-manager-operator`/`quay-operator` (and the other early-wave gaters) to Healthy so the sync advances to wave 20. Then confirm the `llmkube` Application, `llmkube-system` namespace, CRDs, controller, and model-cache PVC appear.
+3. **Plan for the cold model re-download (MEDIUM).** After deploy, watch `Model` CR `phase` (Downloading → Ready) and confirm `freenas-nfs-ssd-csi` has room for the GGUFs before expecting any InferenceService endpoint to answer.
+4. **Reconcile `replicas` with intent (LOW).** Decide whether the checked-in default should be `0` (matching README) with manual scale-up, or keep `1`; either way ensure the p330 model is not the one left at `1`.
+5. **Post-deploy functional verification (do NOT mark healthy on "pods Running").** For each intended model, curl `https://<route-host>/v1/models` and a small `/v1/chat/completions` to confirm the endpoint actually serves (the README's sanity-check block), since "running" here means weights must also load into VRAM/RAM and the llama.cpp server must pass warmup.
+
+---
+
+## loki-operator
+
+**Status:** healthy (operator install fully recovered) — but functionally **idle**: no LokiStack instance exists anywhere, so no logs are actually aggregated.
+
+Component source: `components/loki-operator` (kustomize: `openshift-operators-redhat` namespace + OperatorGroup + Subscription). ArgoCD app `loki-operator` (project `cluster-config`, sync-wave 10) is **Synced / Healthy**, last sync Succeeded 2026-07-04T01:38:06Z on the rebuilt cluster.
+
+### Health check (cluster state)
+
+- **Subscription** `loki-operator` (channel `stable-6.5`, source `redhat-operators`, `installPlanApproval: Automatic`) — state `AtLatestKnown`, currentCSV == installedCSV == `loki-operator.v6.5.1`.
+- **CSV** `loki-operator.v6.5.1` — Phase **Succeeded** (replaced v6.5.0). InstallPlan `install-b5f8n` Automatic/approved.
+- **OperatorGroup** `loki-operator` present; namespace `openshift-operators-redhat` created with `openshift.io/cluster-monitoring: "true"`.
+- **Deployment** `loki-operator-controller-manager` **1/1 Available**; pod `...-9cw49` **Running, 0 restarts**, ~2.5h age, scheduled on `truenas-w1`. No errors/panics in recent controller logs.
+- **CRDs installed:** `lokistacks`, `alertingrules`, `recordingrules`, `rulerconfigs` (loki.grafana.com), created 2026-07-04T00:25:07Z — consistent with a clean post-reinstall bootstrap.
+- No OutOfSync / Degraded / Missing / Pending / CrashLoopBackOff for this component. The operator recovered the rebuild cleanly.
+
+### Findings
+
+1. **[Medium] No LokiStack instance — the operator is installed but does nothing.** `oc get lokistack -A` returns **No resources found**, and `git grep 'kind: LokiStack'` across `origin/main` (and full history via `-S`) returns nothing. The operator's sole job is to reconcile LokiStack CRs; with none declared, log aggregation/retention is not actually happening. The paired `openshift-logging` component (cluster-logging operator, also v6.5, Running) likewise ships **no LokiStack, no ClusterLogForwarder** (`oc get clusterlogforwarder -A` → none), so the end-to-end logging pipeline is non-functional. This is the current committed design (operators only), not a DR regression — but "running" here is not "functional."
+2. **[Low] No object-storage backing prepared for a future LokiStack.** A LokiStack requires an S3-style object-storage secret; `openshift-logging` has no such secret. History shows a NooBaa/MCG `lokistack-backingstore.yaml` once lived under the old `config/sno/live/multicloudgateway/` path but was deleted ("remove mcg briefly", f8b82e2) and never re-added in the current `components/` structure. Any attempt to instantiate a LokiStack today would block on missing object storage — worth noting given the incident's separate NVMe/CSI attach fragility (shared hostnqn) that would also affect Loki PVCs.
+3. **[Low] `installPlanApproval: Automatic`.** The operator silently rode the channel up to v6.5.1. Acceptable for a homelab, but on a single-control-plane cluster an unattended CSV bump is an uncontrolled change vector; consider `Manual` for the logging operators.
+4. **[Info] No post-disaster restore was required for this component** — it is stateless (operator + CRDs only); state, if any, would live in a LokiStack's PVCs, which don't exist. Nothing to restore, nothing lost.
+
+### Remediation
+
+- Decide intent: if cluster log aggregation is desired, add a `LokiStack` CR (with an S3/object-storage `Secret` and a `ClusterLogForwarder`) to the `openshift-logging` component and wire it via values.yaml; otherwise document that `loki-operator` + `cluster-logging` are intentionally installed idle (e.g. as a dependency/placeholder) so future reviewers don't read the empty state as breakage.
+- When a LokiStack is added, provision object storage first and confirm its PVCs bind cleanly given the known shared-hostnqn NVMe-oF attach bug.
+- Consider switching `installPlanApproval` to `Manual` for loki-operator (and cluster-logging) to gate future version bumps on this single-node cluster.
+
+_Scope note: findings 1–2 straddle the sibling `openshift-logging` component; the `loki-operator` component itself is correctly configured and healthy._
+
+---
+
+## lvms-operator
+
+**Status:** healthy (running, Synced/Healthy, LVMCluster reconciled, thin-pool rebuilt post-disaster) — but functionally **idle/unproven** and carrying a couple of data-safety footguns.
+
+Component provides node-local LVM/thin-pool storage via the LVM Storage operator (topolvm.io CSI). Git source: `clusters/ocp/lvms-operator` (cluster overlay: `lvmcluster.yml` + `lvms-lvm-local-storage-storageclass.yml`) which pulls in base `components/lvms-operator` (Namespace `openshift-storage` w0, OperatorGroup w1, Subscription w2). LVMCluster + StorageClass are sync-wave 5.
+
+### Health check (live cluster)
+
+| Object | State |
+|---|---|
+| ArgoCD app `lvms-operator` | **Synced / Healthy**, revision `d81e454`, no conditions/errors |
+| Subscription `lvms` → CSV `lvms-operator.v4.21.0` | **Succeeded**; InstallPlan `install-hgm6m` Approved=true |
+| Deployment `lvms-operator` | 1/1 Ready |
+| DaemonSet `vg-manager` | 1/1 Ready (1 desired — pinned to master, see F2). 1 restart = normal thin-pool bootstrap restart (`reason: Completed`, exit 0 at init), **not** a crashloop |
+| `LVMCluster/lvmcluster` | **Ready** — `ResourcesAvailable` + `VolumeGroupsReady` True; deviceClass `lvm-local-storage` on `ocp.igou.systems` Ready |
+| StorageClasses | `lvms-lvm-local-storage` (WaitForFirstConsumer, operator-generated) + `lvms-lvm-local-storage-immediate` (git-managed, Immediate); VolumeSnapshotClass `lvms-lvm-local-storage` present |
+| On-node (MS-01) | `/dev/nvme0n1p5` = 1.5T LVM2_member; VG `lvm-local-storage` present; thin-pool `lvm-local-storage-thin-pool` <1.38T, **0.00% data / 2.66% meta used** |
+| No Warning events in `openshift-storage` | — |
+
+**Disaster recovery: PASSED.** After the wipe/reinstall the operator + LVMCluster reconciled cleanly and `forceWipeDevicesAndDestroyAllData: true` re-created the VG/thin-pool on the master's `nvme0n1p5` with no manual intervention. Not affected by the shared-`hostnqn` NVMe-oF latent bug — LVMS is pure local LVM, so it is actually the one storage path independent of that fault (a resilience plus).
+
+### Findings
+
+- **[Low / informational] Zero consumers — running but functionally unproven.** 0 PVCs and 0 PVs exist on either topolvm StorageClass cluster-wide (thin-pool 0.00% used). Every live PVC uses democratic-csi (`freenas-nvmeof-ssd-csi` is the default). LVMS is healthy and idle; its data path has not been exercised since the rebuild. Intended consumers exist only in git (scaffold-vm skill default + `test-workloads/virtualmachine-devhosttest` DataVolume), none currently deployed. Recommend a quick provision smoke-test (PVC on `lvms-lvm-local-storage`, pod on master) to confirm end-to-end functionality rather than just "Ready".
+
+- **[Medium / data-safety] `forceWipeDevicesAndDestroyAllData: true` left permanently enabled** (`lvmcluster.yml`). Needed to reclaim `nvme0n1p5` during the reinstall, but persisting it is a footgun — if the device selector ever resolves to a different/repurposed partition, LVMS silently destroys it. Especially pointed given the incident was itself an unattended destructive reinstall. Steady-state risk is low (device is already an lvms-owned LVM2_member), but best practice is to flip it back to `false` now that the VG exists.
+
+- **[Low-Med / by-design SPOF] Master-only local storage.** LVMCluster `nodeSelector` pins the deviceClass to `node-role.kubernetes.io/master Exists` and tolerates the master taint (commit e43a7a2 — hpg5/truenas-w1 lack `/dev/nvme0n1p5`, and the webhook makes nodeSelector immutable). Consequence: topolvm volumes only provision on the single control-plane node (MS-01); no LVMS-backed local storage on either worker, and any consumer is hard-pinned to master. Acceptable as designed, but it is a single-node, non-HA storage path — do not use it for anything that must survive MS-01 loss.
+
+- **[Low / latent misconfig] Immediate-binding SC is a scheduling footgun.** The hand-rolled `lvms-lvm-local-storage-immediate` (`volumeBindingMode: Immediate`) provisions a node-local LV on the master *before* a consumer is scheduled; topolvm PVs are node-local and cannot attach to a pod that lands on hpg5/truenas-w1. It works only because it's used for master-pinned KubeVirt DataVolumes. Any future workload using this SC without a master nodeSelector will hit attach failures. Prefer the WaitForFirstConsumer SC unless immediate binding is truly required.
+
+### Remediation
+
+1. (Optional, verification) Run a PVC+pod smoke test on `lvms-lvm-local-storage` scheduled to `ocp.igou.systems` to prove the CSI data path post-rebuild; delete after.
+2. (Medium) After confirming the VG/thin-pool is stable, set `deviceSelector.forceWipeDevicesAndDestroyAllData: false` in `clusters/ocp/lvms-operator/lvmcluster.yml` and sync, to remove the standing data-destruction risk. (Note: the webhook makes some deviceClass fields immutable — validate whether this toggle requires an LVMCluster delete/recreate before attempting; do not act without operator sign-off.)
+3. (Low) Document/accept the master-only SPOF and keep `-immediate` SC usage restricted to master-pinned workloads (as scaffold-vm already defaults). No change required unless HA local storage becomes a requirement.
+4. No action needed on hostnqn — out of scope for LVMS.
+
+---
+
+## machineconfigs
+
+**Status:** degraded (ArgoCD app Synced/Healthy and it recovered the rebuild, but there is a worker-coverage gap and the component does not remediate the critical shared-hostnqn latent bug that falls squarely in its domain)
+
+Git source: `clusters/ocp/machineconfigs` (sync-wave 2, dest ns `openshift-machine-config-operator`). Contains exactly one resource: `MachineConfig 99-master-load-nvme-tcp` (kustomization + the MC YAML). It drops `/etc/modules-load.d/nvme-tcp.conf` = `nvme-tcp` (ignition 3.2.0) onto the **master** pool so the NVMe/TCP transport module loads at boot for democratic-csi NVMe-oF volumes.
+
+### Health check (read-only)
+
+- **ArgoCD app `machineconfigs`:** Synced / Healthy, last op Succeeded. Managed resource `MachineConfig/99-master-load-nvme-tcp` present and Synced.
+- **ClusterOperator `machine-config`:** 4.21.9, Available=True, Progressing=False, Degraded=False (8h).
+- **MachineConfigPools:** `master` Updated=True, Degraded=False (1/1); `worker` Updated=True, Degraded=False (2/2). No pending/updating pools.
+- **MCO pods:** controller, operator, server, and all 3 daemons Running (2/2). Non-zero restart counts on the two worker daemons/rbac-proxy (23, 14) but currently stable — consistent with the post-reinstall worker re-join churn, not an active fault.
+- **MC applied on cluster:** `99-master-load-nvme-tcp` created 2026-07-03T19:08 (during the rebuild recovery window) and is present in the master MCP rendered source list → **it did recover**.
+- **Live verification (SSH):** on `ocp.igou.systems` (master) `/etc/modules-load.d/nvme-tcp.conf` exists and `nvme_tcp`/`nvme_fabrics` are loaded. On `hpg5` and `truenas-w1` (worker-only) the file is **absent**, yet `nvme_tcp` is loaded anyway (lazily modprobe'd by the democratic-csi node plugin at first volume attach).
+
+### Findings
+
+- **[CRITICAL] Shared NVMe hostnqn/hostid across all 3 nodes — not remediated by any component.** Confirmed live: all of `ocp`, `hpg5`, `truenas-w1` report the identical `nqn.2014-08.org.nvmexpress:uuid:466937ab-67bf-4315-971b-bc110d55ce28` and hostid `466937ab-...`. This violates NVMe-oF host-identity uniqueness and is the documented cause of intermittent volume-attach failures. The rebuild did NOT fix it, and no MachineConfig (or any git-managed resource) addresses it. This node-level Ignition concern belongs in this component's domain but is currently unowned.
+- **[MEDIUM] nvme-tcp module persistence covers only the master pool; the actual worker attach-points are not covered.** The MC targets `machineconfiguration.openshift.io/role: master`. The nodes that actually run most workloads and attach democratic-csi NVMe-oF volumes are the dedicated workers `hpg5` and `truenas-w1`, which get NO persistent `modules-load.d` entry. It "works" today only because the CSI node driver modprobes `nvme_tcp` on demand — meaning a first NVMe-oF attach immediately after a worker reboot can race/fail before the module is up (retry then succeeds), which is precisely the failure mode a boot-time module-load is meant to prevent. There is no `99-worker-load-nvme-tcp` MC. (The single-node master is schedulable — roles master+worker — which is why only it was given the guarantee; the true workers were overlooked.)
+- **[LOW/INFO] Component scope is minimal.** Only the nvme-tcp module is managed here; SSH keys and registries MCs on the cluster are MCO/agent-install generated, not GitOps-owned — expected, just noting the component does not manage them.
+
+### Remediation
+
+1. **Fix the shared hostnqn/hostid (critical).** Add a MachineConfig to this component (both `master` and `worker` roles) that installs a oneshot systemd unit regenerating a per-node identity, e.g. write `/etc/nvme/hostnqn` via `nvme gen-hostnqn` and `/etc/nvme/hostid` from a fresh UUID (or derive deterministically from `/etc/machine-id`), guarded so it only runs when the value still equals the shared `466937ab...` placeholder, followed by a one-time reboot/reconnect. Do NOT ship a static file (that would re-pin identical values). Validate uniqueness across all 3 nodes afterward. This is the highest-value change and directly clears the incident's latent bug.
+2. **Extend nvme-tcp module load to the worker pool (medium).** Add `99-worker-load-nvme-tcp` (identical body, `role: worker`) or generalize to a shared MC per pool so `/etc/modules-load.d/nvme-tcp.conf` is present on `hpg5` and `truenas-w1`, removing the first-attach-after-reboot race. Confirm the resulting `worker` MCP rolls out cleanly (it will trigger one rolling reboot of the workers).
+3. **No action needed on operator health** — MCO, MCPs, and the existing master MC are all healthy, in-sync, and recovered.
+
+---
+
+## metallb
+
+**Status: healthy**
+
+MetalLB (git sources `components/metallb-operator` + `clusters/ocp/metallb`) fully recovered from the 2026-07-03 cluster reinstall. Both ArgoCD apps are `Synced`/`Healthy` at `origin/main` (`d81e454`), the operator CSV is `Succeeded`, all BGP sessions are Established, and the one live LoadBalancer service (the guest-dmz ingress gateway) has its IP assigned and advertised end-to-end. MetalLB is stateless (no PVCs), so there was nothing to restore — GitOps reconciliation alone brought it back.
+
+### Health check (live cluster)
+
+- **ArgoCD apps**: `metallb-operator` = Synced/Healthy; `metallb` (pools/peers/advertisements) = Synced/Healthy. No drift vs `origin/main`.
+- **Operator**: `metallb-operator.v4.21.0-202606240914` CSV `Succeeded`; Subscription `stable`/`redhat-operators`, InstallPlan Approved (Automatic). MetalLB CR `metallb` reports `Available=True`, `Degraded=False`, `Progressing=False`.
+- **Pods** (all Running, all on schedule):
+  - `controller` 2/2, `metallb-operator-webhook-server` 1/1 — 0 recent restarts.
+  - `speaker` DaemonSet **3/3** across all three nodes (`ocp.igou.systems`, `hpg5`, `truenas-w1`) — confirms the `workload=burst` `speakerTolerations` in the MetalLB CR is doing its job so every node runs a speaker (needed for `externalTrafficPolicy: Local`).
+- **CRs reconciled**: 3 IPAddressPools (`trusted-lan` 10.10.150.0/24, `iot` 10.10.151.0/24, `guest-dmz` 10.10.152.0/24, all `autoAssign:false` + `avoidBuggyIPs`), 3 BGPAdvertisements (aggregationLength /32 + per-tier community), 1 BGPPeer (`mikrotik` 10.10.9.1, myASN 64513 / peerASN 64512), 1 Community (`tier`).
+- **BGP is actually up (functional, not just running)**: all 3 speakers show the `10.10.9.1` (64512) neighbor Established with multi-hour uptime (7h32m / 4h56m / 4h52m), each advertising `PfxSnt=1`.
+- **End-to-end proof**: `guest-dmz-openshift-default` (openshift-ingress) has EXTERNAL-IP **10.10.152.3** from the `guest-dmz` pool; `show bgp ipv4 unicast` on the master speaker confirms `10.10.152.3/32` is the best path advertised to the router. The DMZ gateway path (jellyfin, etc.) is live through MetalLB.
+- **PVCs**: none (component is stateless). No post-disaster data restore required — recovered by reconciliation only.
+
+### Findings
+
+- **[Info] Operator manager restarted 8× during bootstrap, now stable.** `metallb-operator-controller-manager` last terminated exitCode 1 at 2026-07-03T19:43:37 (during the initial post-reinstall install window, a CRD/webhook readiness race). No restarts in the last ~7h; currently 1/1 Running. Self-healed — no action needed, just noted so it isn't mistaken for an active crashloop.
+- **[Low] BGPPeer has no MD5/authentication and no BFD profile.** `mikrotik-bgppeer.yaml` sets `holdTime: 180s`/`keepaliveTime: 60s` but no `password` and no `bfdProfile`. Consequence: (a) no session authentication, and (b) failover on node/link loss waits out the ~180s hold timer rather than sub-second BFD. Acceptable for a trusted homelab LAN, but sub-second failover would need a BFD profile added on both MetalLB and the RouterOS side.
+- **[Low/expected] `metallb-system` namespace is PSA `privileged`** (`pod-security.kubernetes.io/enforce: privileged`, `podSecurityLabelSync:false`). This is required by the speaker (host networking / raw sockets for BGP+ARP) and is the standard MetalLB posture — flagged only for completeness.
+- **[Info] `iot` and `trusted-lan` pools are provisioned but currently carry no LoadBalancer services** (only `guest-dmz` is in use, `PfxSnt=1` per speaker). Not a defect — capacity staged ahead of workloads; nothing to advertise yet.
+
+### Remediation
+
+- No corrective action required — component is healthy and functional post-rebuild.
+- Optional hardening (both `clusters/ocp/metallb/mikrotik-bgppeer.yaml`): add a `bfdProfile` (+ matching BFD config on the rb5009) for fast failover, and consider an MD5 `password` (sourced via ExternalSecret) on the BGP session.
+- No monitoring change needed; keep the operator-manager restart count in mind only if it climbs again (would indicate a webhook/CRD issue rather than the one-time bootstrap race seen here.)
+
+---
+
+## molecule
+
+**Status: degraded** — the component itself (the namespace) is Synced/Healthy and recovered cleanly, but the end-to-end molecule test capability is **not functional** because the `ansible-molecule` service-account token was never re-published to 1Password after the reinstall (a cross-cutting PushSecret 403 in the sibling `service-accounts` component). The namespace has no persistent data, so there was nothing to restore.
+
+### What the component is
+
+`components/molecule` is intentionally tiny — a single scratch `Namespace` (`molecule`) used to run ad-hoc Ansible **molecule** test scenarios against the cluster. The git source is just:
+
+- `kustomization.yaml` → `molecule-namespace.yaml`
+- `molecule-namespace.yaml` — the namespace with `openshift.io/description: "This namespace is used to run ad-hoc molecule tests"`
+
+The actual test-runner RBAC/credentials live in the separate `components/service-accounts` component:
+- ServiceAccount `ansible-molecule` (in ns `service-accounts`)
+- ClusterRole `molecule-kubernetes` (verbs on `kubevirt.io/virtualmachines`, core `services` [full CRUD], core `pods` [get/list]) bound into the `molecule` namespace via rolebinding `ansible-molecule-molecule-kubernetes`
+- ClusterRoleBinding `ansible-molecule-node-reader` → `system:node-reader`
+- **PushSecret `ansible-molecule-token-push`** → publishes the SA token to 1Password item `ocp-ansible-molecule` (property `token`) so external Ansible molecule runs can auth to the cluster
+
+### Health check (cluster state)
+
+- ArgoCD app `molecule` (project `cluster-config`, sync-wave 39): **Synced / Healthy**, last op Succeeded 2026-07-03T23:23:38Z.
+- Namespace `molecule`: Active (created 2026-07-03T23:23:38Z, ~post-reinstall). Correct PSA labels (`restricted` warn/audit), Argo tracking-id present.
+- No Deployments/StatefulSets/DaemonSets/pods/PVCs/routes/quotas — expected; it is a bare scratch namespace (nothing OutOfSync, Pending, or CrashLooping).
+- RBAC in-cluster is correct: rolebinding `ansible-molecule-molecule-kubernetes` → ClusterRole `molecule-kubernetes`, subject = SA `ansible-molecule` in ns `service-accounts`. ClusterRole and SA both exist.
+
+### Findings
+
+- **[HIGH] Stale/undistributed molecule SA credential — test capability broken.** PushSecret `service-accounts/ansible-molecule-token-push` is `Ready=False / Errored`:
+  `set secret failed: ... error updating 1Password Item: status 403: Authorization: token does not have permission to perform update on vault iggugnytc2y6nenftd65o4eyvi`.
+  Because the reinstall minted a brand-new SA token (new cluster CA/signing keys), the token still sitting in 1Password item `ocp-ansible-molecule` is the **pre-disaster, now-invalid** one, and the fresh token cannot be pushed. Any external molecule run that pulls `ocp-ansible-molecule` from 1Password to authenticate will fail. So molecule is "running" (namespace + RBAC present) but not "functional".
+- **[HIGH — root cause, cross-cutting, not molecule-specific] onepassword-sdk-claude lacks write grant.** This is not a molecule bug. **All 6** PushSecrets in `service-accounts` are Errored with the same 403 (`ansible-molecule-token-push`, `claude-edit-token-push`, `cluster-edit-token-push`, `cluster-read-only-token-push`, `ns-agent-token`, `virtualmachine-ops-token`). The `onepassword-sdk-claude` ClusterSecretStore itself validates (`Ready=True`), so the SDK service-account token has read but not **update/write** grant on vault `iggugnytc2y6nenftd65o4eyvi`. This matches the known pattern in memory ("Connect server edit grant was the final fix"; "queued writes drain on grant fix") — the vault write/edit grant for the SDK token was not re-applied after the DR rebuild.
+- **[INFO] No data-restore gap for molecule.** The namespace holds no PVCs/stateful workloads, so no Barman/tar restore was required; the component recovered fully from GitOps. Sync-wave ordering is correct (molecule ns wave 39 precedes service-accounts RBAC wave 40).
+
+### Remediation
+
+1. **Fix the 1Password SDK write grant (fixes all 6 SAs, including molecule).** Grant the `onepassword-sdk-claude` service account **write/edit** permission on vault `iggugnytc2y6nenftd65o4eyvi` (the same edit-grant step from the prior 1Password Connect rollout). Then let External Secrets re-reconcile the PushSecrets — they should flip to `Ready=True` and overwrite the stale tokens.
+2. **Verify the fresh molecule token lands in 1Password.** After the grant, confirm PushSecret `ansible-molecule-token-push` is `Ready=True` and that item `ocp-ansible-molecule.token` now matches the current in-cluster SA token, so external molecule runs can authenticate again. (Out of scope for this read-only review — no changes were made.)
+3. **No change needed to `components/molecule` itself** — the component is correctly defined and healthy. Track the fix under the `service-accounts` / 1Password Connect grant workstream, not molecule.
+
+---
+
+## nmstate
+
+**Status: healthy** — operator and all NNCPs recovered cleanly after the rebuild; the applied node network state matches git. One coverage gap and one dormant/stale policy noted below (both low severity, neither degrading).
+
+Git source: `clusters/ocp/nmstate` (overlay) → `components/nmstate` (base). ArgoCD app `nmstate`: **Synced / Healthy**, revision `d81e45401b47`, last sync Succeeded 2026-07-03T19:16:40Z, all tracked resources Synced/Healthy.
+
+### What is deployed and working
+- **Operator**: `kubernetes-nmstate-operator.4.21.0-202606240914` (channel `stable`, Automatic approval) — CSV Phase Succeeded, version matches cluster 4.21. `NMState` instance `nmstate` = Available / SuccessfullyDeployed.
+- **Workloads** (ns `openshift-nmstate`): deployments `nmstate-operator`, `nmstate-webhook`, `nmstate-metrics`, `nmstate-console-plugin` all 1/1; DaemonSet `nmstate-handler` 3/3 Ready (one handler per node). No crashloops/pending; the two single restarts on the hpg5 and truenas-w1 handlers (~4h58m ago) coincide with worker re-join reboots, not faults.
+- **Recovery verified end-to-end**: post-reinstall the NNCPs re-applied on both intended nodes. NNCEs `ocp.igou.systems.mapping` and `hpg5.igou.systems.mapping-hpg5` = Available / SuccessfullyConfigured. Confirmed against live `NodeNetworkState`:
+  - `ocp` (master): `br-secondary` OVS bridge present, `enp2s0f1.45` VLAN present, OVN bridge-mapping `br-secondary → trunk-network` present.
+  - `hpg5`: `br-secondary` present, `enp2s0.45` VLAN present, `br-secondary → trunk-network` mapping present.
+  - This restored the secondary/trunk localnet path that Multus/localnet secondary-network workloads depend on. nmstate did its job in the DR.
+
+### Findings
+
+- **[LOW / informational] truenas-w1 worker has no NNCP → no `br-secondary`/`trunk-network` localnet coverage.** The cluster now runs three nodes (ocp, hpg5, **truenas-w1**), but only `mapping` (master) and `mapping-hpg5` exist. `truenas-w1`'s NodeNetworkState shows only the default `br-ex → physnet` OVN mapping — no `br-secondary`, no `trunk-network`. This is architecturally expected: `truenas-w1` is a nested KubeVirt VM worker with a single virtio NIC (`ens3`) and no second physical/trunk port to bridge. Impact: any secondary-network (localnet `trunk-network`) or VLAN-45 workload scheduled onto `truenas-w1` will fail to attach — nmstate cannot and does not guard scheduling. Not a regression from the rebuild.
+
+- **[LOW] `mapping-casval` NNCP is dormant (Ignored / NoMatchingNode) and carries stale storage config.** `casval` is the burst GPU node whose MachineSet is scaled to zero / deprovisioned, so the policy correctly reports `Ignored / NoMatchingNode` and — thanks to `argocd.argoproj.io/ignore-healthcheck: 'true'` — does not degrade the ArgoCD app. It re-applies automatically if the burst node returns, so keeping it is defensible. Note it also pins casval-specific storage networking (Mellanox CX4 `enp1s0f0np0` @ 9000 MTU, `10.199.0.2/24`, host route `10.10.9.213/32 → 10.199.0.1`); if the burst node or its NIC layout has changed, this is latent drift that would silently mis-apply on next scale-up.
+
+- **[INFO] No nmstate-specific persistent state to restore.** nmstate is a declarative, git-sourced operator; there is no PVC/database. "Restore" = re-reconcile from git, which happened correctly. Nothing was missed in the DR for this component. No security gaps: no secrets, no routes, standard operator RBAC, webhook and metrics healthy.
+
+- **[INFO] `maxUnavailable: 2` on all NNCPs.** Harmless on this 3-node cluster (the `mapping` policy selects the single master; worker policies select one node each), but worth remembering if the cluster grows — a rollout could reconfigure networking on 2 nodes simultaneously.
+
+### Remediation
+
+1. **Confirm intent for truenas-w1**: decide whether secondary/trunk-network workloads are ever meant to land there. If not (expected, given single-NIC VM), ensure such workloads carry node affinity/anti-affinity or a nodeSelector that keeps them off `truenas-w1` (a workload-side control, not nmstate). If they are meant to, `truenas-w1` needs a trunk NIC and a dedicated NNCP — currently impossible with one virtio interface.
+2. **Validate `mapping-casval` before the next burst scale-up**: verify the CX4 interface name (`enp1s0f0np0`), the `10.199.0.0/24` storage addressing, and the `10.10.9.213/32` route still match reality; prune or update the policy if the burst node's hardware/topology changed. Otherwise leave as-is (correctly ignored).
+3. No action required on the operator, handler DaemonSet, or the `mapping`/`mapping-hpg5` policies — all healthy and correctly recovered.
+
+---
+
+## nvidia-gpu-operator
+
+**Status:** healthy (operator fully recovered; currently idle — no GPU nodes present in cluster)
+
+The NVIDIA GPU Operator recovered cleanly from the 2026-07-03 cluster reinstall via GitOps. The ArgoCD app is `Synced / Healthy`, the operator CSV `gpu-operator-certified.v25.10.1` is `Succeeded`, the `gpu-cluster-policy` ClusterPolicy is `ready`, and the operator pod has 0 restarts. It is stateless (no PVCs/routes), so no post-disaster data restore was required — a redeploy from git was sufficient and complete.
+
+The important caveat: the operator is doing its job but has **zero GPUs to manage right now**. Both `NVIDIADriver` CRs are `notReady`, and no node carries the `nvidia.com/gpu` label. This is the expected consequence of the current hardware state (p330 dead, casval scaled to 0), not an operator defect.
+
+### Live state observed
+- ArgoCD `nvidia-gpu-operator`: **Synced / Healthy**.
+- Subscription `gpu-operator-certified` (channel `v25.10`, Automatic approval) → CSV `gpu-operator-certified.v25.10.1` **Succeeded**; InstallPlan `install-k8cql` approved.
+- Deployment `gpu-operator` 1/1, pod on `truenas-w1`, 0 restarts, reconcile loop clean.
+- ClusterPolicy `gpu-cluster-policy` state `ready`, condition `Ready=True` reason **`NoGPUNodes`** ("No GPU node found, watching for new nodes to join the cluster") — healthy idle state.
+- `NVIDIADriver pascal-580`: **notReady** — `no nodes matching the given node selector for pascal-580` (targets `p330.igou.systems`).
+- `NVIDIADriver burst-595`: **notReady** — `no nodes matching the given node selector for burst-595` (targets `casval.igou.systems`).
+- NFD healthy (`nfd-instance`, 3 workers running) — feature detection is up and will label a GPU node when one appears.
+- ServiceMonitors present (`gpu-operator`, `nvidia-dcgm-exporter`, `nvidia-node-status-exporter`); namespace has `openshift.io/cluster-monitoring: "true"`.
+- No PVCs, no routes — nothing stateful to restore.
+
+### Findings
+
+**[INFO / expected] No live GPU capacity — both driver CRs notReady.**
+`pascal-580` targets `p330.igou.systems`, which is dead (no BMC) per the incident record, and `burst-595` targets `casval.igou.systems`, whose CAPI MachineSet `casval-worker` is scaled to 0/0. With no matching nodes, neither driver DaemonSet can be created, so the cluster currently advertises no `nvidia.com/gpu` resource. This is correct behavior given the hardware, but it means GPU workloads (e.g. llmkube scaling) cannot schedule until casval bursts up or a Pascal node is restored. Not a regression from the rebuild.
+
+**[MEDIUM] `time-slicing-config-configmap.yaml` is orphaned and non-functional.**
+The file exists under `components/nvidia-gpu-operator/` but is **not listed in `kustomization.yaml`**, so ArgoCD never renders it — confirmed live: `configmaps "time-slicing-config" not found` in the namespace. Even if it were deployed, the ClusterPolicy's `devicePlugin` block does **not** reference it (no `devicePlugin.config.name`/`configMapName: time-slicing-config`), so the intended 4-replica GPU time-slicing is wired up nowhere. Net effect: the single Pascal/burst GPU could not be shared across pods as this config implies — the feature is silently inert. This is pre-existing incomplete config (not something the rebuild broke), but it is drift between apparent intent and actual behavior.
+
+**[LOW] Subscription uses `installPlanApproval: Automatic`.**
+Consistent with the other operators in this cluster, but it means the operator auto-upgraded to `v25.10.1` unattended. Acceptable for a homelab; worth being aware of since GPU driver-branch compatibility (Pascal 580 ceiling) is version-sensitive.
+
+**[INFO] `ClusterPolicy.spec.driver.version: 580.105.08` is a dead default.**
+Documented in-file as unused while `useNvidiaDriverCRD: true` (per-node versions come from the NVIDIADriver CRs). Correct and intentional — no action.
+
+### Remediation
+1. No action needed for the operator itself — it recovered fully and is correctly idle. When `casval` next bursts, confirm the node joins as `casval.igou.systems` (matching the `burst-595` selector) and that the driver DaemonSet lands and advertises `nvidia.com/gpu`; if the burst node name differs, update `nvidiadriver-burst-595.yaml`.
+2. Resolve the orphaned time-slicing config: either (a) delete `time-slicing-config-configmap.yaml` from the component if time-slicing is not wanted, or (b) if it is wanted, add it to `kustomization.yaml` **and** wire it into the ClusterPolicy (`devicePlugin.config.name: time-slicing-config` with a default entry). As-is it is misleading dead config.
+3. Track the p330 replacement/repair (dead, no BMC) — until then `pascal-580` will remain `notReady` by design; consider whether that CR should stay in git or be commented out to avoid a permanently-notReady resource.
+4. (Optional) Consider pinning the Subscription to a specific CSV or Manual approval if GPU driver-branch stability matters, given the Pascal 580 compatibility ceiling.
+
+---
+
+## ocp-base-config
+
+**Status: healthy**
+
+ArgoCD app `ocp-base-config` (sync-wave 8) is **Synced / Healthy** (revision `d81e454`). It is a Helm chart (`.helm/charts/ocp-base-config`) rendered by kustomize `helmCharts`, cluster-scoped (no dedicated namespace). Given the ocp `values.yaml`, the only feature block that actually renders resources is **auth**; `monitoring`, `network.hostRouting`, and `timesync` are all `false`, and the `certManager` block renders nothing (see F1). All live auth resources are present and functional, and they recovered the rebuild automatically with no manual restore.
+
+### What it manages (live verification)
+- `OAuth/cluster` — HTPasswd IDP named `igou` → `htpasswd-secret`. **Synced.**
+- `Group/global-admins` — `users: [igou]`. **Synced.**
+- `ClusterRoleBinding/global-admins-binding` — `global-admins` group → `cluster-admin`. **Synced.**
+- `ExternalSecret/htpasswd-secret` (openshift-config) — condition `SecretSynced` / "secret synced"; backing `Secret` present (keys: `htpasswd`, `notesPlain`, `password`), created `2026-07-03T19:25:53Z` (post-rebuild). **Synced/Healthy.**
+- Generated `Secret/v4-0-config-user-idp-0-file-data` (openshift-authentication), created post-rebuild.
+- `clusteroperator/authentication`: **Available=True, Degraded=False, Progressing=False** ("All is well").
+- `ClusterSecretStore/onepassword-sdk-ocp-pull` (dependency): **Ready=True**.
+
+**DR outcome: fully recovered, no manual intervention required.** The component is pure declarative config plus a 1Password-backed ExternalSecret, so it re-materialized the htpasswd secret and re-applied OAuth/group/RBAC on GitOps bootstrap. htpasswd login → `cluster-admin` for `igou` is working end-to-end.
+
+### Findings
+
+**F1 — LOW (misleading dead config): `certManager` block in `values.yaml` renders nothing.**
+`clusters/ocp/ocp-base-config/values.yaml` carries a full `certManager:` block (`enabled: true`, `apiCert: true`, `defaultIngressCert: true`, ACME base, Cloudflare DNS-01 solvers, `dns-token` ExternalSecret). The chart `.helm/charts/ocp-base-config/templates/` has **no cert-manager templates** (only `auth/`, `monitoring/`, `networking/`, `timesync/`). So none of it is applied — a reader would wrongly believe this app provisions the API server cert and default ingress cert. Actual cert handling lives in the separate `cert-manager-config` (wave, `clusters/ocp/cert-manager-config`) and `apiserver-certs` (wave 9, `clusters/ocp/apiserver-certs`) apps. Not a functional break, but it is stale/duplicative config that invites drift and confusion during a DR (someone could "fix" certs here to no effect).
+
+**F2 — LOW (durability): monitoring is disabled → ephemeral in-cluster metrics.**
+`monitoring.enabled: false`, so no `cluster-monitoring-config` ConfigMap is rendered; Prometheus/Alertmanager fall back to `emptyDir`. Metrics and silences are lost on pod restart/reschedule. The chart already supports persistent PVCs (`storageClass: freenas-nvmeof-fast-csi`, 50Gi Prometheus / 10Gi Alertmanager). Likely intentional, but confirm this is desired given the cluster now has working democratic-csi storage.
+
+**F3 — INFO (latent template inconsistency): OAuth hardcodes the secret name.**
+`templates/auth/oauth-config.yaml` sets `htpasswd.fileData.name: htpasswd-secret` literally instead of `{{ .Values.auth.externalSecret.name }}`. Harmless today (value equals the literal), but if `auth.externalSecret.name` were ever changed, the OAuth would silently keep pointing at the old name and break login.
+
+**F4 — INFO (secret hygiene): ExternalSecret extracts the whole 1Password item.**
+`htpasswd-secret` is created via `dataFrom.extract`, so extra item fields (`notesPlain`, `password`) land in the openshift-config Secret alongside the needed `htpasswd` key. No exposure risk (restricted namespace, single field consumed), but a `data`-scoped `remoteRef` to just the `htpasswd` field would be cleaner.
+
+### Remediation
+1. **F1:** Remove the `certManager:` block from `clusters/ocp/ocp-base-config/values.yaml` (or re-add cert-manager templates to the chart if this app is meant to own certs — but do not, since `cert-manager-config`/`apiserver-certs` already do). Read-only review: no change applied.
+2. **F2:** Decide explicitly on monitoring persistence; if wanted, set `monitoring.enabled: true` (PVCs already parameterized) — otherwise leave and document as intentional.
+3. **F3:** Template the OAuth `fileData.name` from `.Values.auth.externalSecret.name` for consistency.
+4. **F4:** Optional — switch the ExternalSecret to a field-scoped `data` ref for the `htpasswd` key only.
+
+All remediation is config-quality / drift-reduction; none blocks current operation. Component is healthy and DR-recovered.
+
+---
+
+## onepassword-connect
+
+**Status: degraded** — Connect itself is healthy and the READ path (its primary function, feeding External Secrets Operator) fully recovered post-disaster; but the WRITE path (all 6 `PushSecret` reverse-publish flows) is broken with HTTP 403 because the restored Connect credential lacks vault write grants.
+
+Git source: `clusters/ocp/onepassword-connect` (Helm chart `connect` v2.4.1, images `1password/connect-{api,sync}:1.8.2`). ArgoCD app `onepassword-connect` (project `cluster-config`): **Synced / Healthy**, revision `d81e454`.
+
+### Health check (live cluster)
+
+| Aspect | State |
+|---|---|
+| ArgoCD app | Synced / Healthy, no conditions |
+| Pod `onepassword-connect-759c7d68f4-c9r6f` | 2/2 Running, 0 restarts, 7h24m, on `ocp.igou.systems` (control-plane, as pinned by nodeSelector/tolerations) |
+| Deployment/ReplicaSet/Service | 1/1 available; ClusterIP `172.30.169.214` :8080 (connect-api) + :8081 (connect-sync) |
+| Route | `onepassword-connect-onepassword-connect.apps.ocp.igou.systems`, edge TLS + Redirect, default LE `acme-apps` cert |
+| NetworkPolicy `connect-allow-eso-and-router` | present; ingress restricted to `external-secrets-operator` + `openshift-ingress` on 8080 (correct) |
+| RoleBinding `onepassword-connect-nonroot-v2` | present; `default` SA → `nonroot-v2` SCC so UID/fsGroup 999 runs (avoids #282) |
+| `op-credentials` secret | present, key `1password-credentials.json`, `managed-by: ansible` (age 8h — seeded BEFORE the pod) |
+| connect-sync | clean startup, DB initialized, 21 vaults synced, **no sync-side errors** |
+| connect-api | `/health` & `/heartbeat` 200; **5542× 200 (reads) but 1332× 403 (writes)** |
+
+### Findings
+
+**[HIGH] All 6 PushSecrets fail with 403 — Connect credential has no write grant on the `claude` and `ocp-push` vaults.**
+Every `PushSecret` in namespace `service-accounts` is `Errored`:
+- via `onepassword-sdk-claude` → vault `claude` (`iggugnytc2y6nenftd65o4eyvi`): `ansible-molecule-token-push`, `claude-edit-token-push`, `cluster-edit-token-push`, `cluster-read-only-token-push`
+- via `onepassword-sdk-ocp-push` → vault `ocp-push` (`dtd2bcigxk7ud64ed4nvsb7hl4`): `ns-agent-token`, `virtualmachine-ops-token`
+
+All report `status 403: Authorization: token does not have permission to perform update on vault …`, matching the 1332 `PUT … (403: Forbidden)` in connect-api. These flows publish generated k8s ServiceAccount tokens BACK into 1Password so downstream consumers (AAP/Ansible, molecule, ns-agent, virtualmachine-ops, Claude container) can read them. The root cause sits in this component: the Connect integration's per-vault access grant (embedded in the restored `1password-credentials.json` / its issued token) is **read-only** for these two vaults. Reads (ExternalSecrets) are unaffected. This is almost certainly a restore regression — the credential was re-seeded during the rebuild without carrying the prior read+write grants on `claude` and `ocp-push`.
+
+**[MEDIUM] Bootstrap secrets live entirely outside GitOps (DR single point).**
+`op-credentials` (this ns) and `onepassword-connect-token` (in `external-secrets-operator`) are both `managed-by: ansible`, pre-seeded out-of-band (documented as "Task 4" in the kustomization). Nothing in Git or ArgoCD can recreate them — Connect (and therefore ~all ExternalSecrets cluster-wide) cannot start without a correct manual seed. The read path was restored correctly, but the same seed step is exactly where the missing write grant (HIGH above) slipped through. This dependency must be captured in the DR runbook and, ideally, the seed automated/verified.
+
+**[LOW] Misleading ClusterSecretStore naming.**
+The stores are named `onepassword-sdk-*` but their provider is the **Connect** provider (`connectHost: http://onepassword-connect.onepassword-connect.svc:8080` + `connectTokenSecretRef`), not the 1Password SDK provider. Cosmetic, but can misdirect an operator during an incident.
+
+**[INFO / positive — recovery confirmed] Read path is fully functional.**
+All ExternalSecrets across the cluster are `SecretSynced=True` (zero exceptions); all 3 ClusterSecretStores validate `Ready=True` against Connect; 21 vaults synced; 5542 successful reads. In-cluster plaintext HTTP is acceptable (edge Route terminates TLS; NetworkPolicy limits ingress to ESO + router). Chart version, images, nodeSelector, tolerations, and SCC binding all match Git — no drift.
+
+### Remediation
+
+1. **Restore write access (fixes HIGH).** In the 1Password admin console, grant this Connect integration **read+write** on the `claude` and `ocp-push` vaults (currently read-only). Alternatively regenerate `1password-credentials.json` (and, if re-issued, the token) with those write grants, re-seed `op-credentials` + `onepassword-connect-token` via the Ansible playbook (`managed-by: ansible`), then `oc rollout restart deploy/onepassword-connect -n onepassword-connect` so connect-sync re-reads. The 6 PushSecrets will then reconcile. Verify with `oc get pushsecret -A`.
+2. **Confirm the token↔server mapping:** ensure `onepassword-connect-token` (in `external-secrets-operator`) belongs to the same Connect server that now holds the write grants.
+3. **Harden the DR runbook (fixes MEDIUM):** document and, where possible, automate/verify the out-of-band seed of `op-credentials` and `onepassword-connect-token` — including the required vault **read+write** grants — as an explicit post-reinstall step, since GitOps cannot reproduce them.
+4. **(Optional, LOW):** rename the ClusterSecretStores to reflect that they are Connect-backed to reduce operator confusion.
+
+---
+
+## openshift-logging
+
+**Status:** degraded — the cluster-logging **operator** recovered cleanly and is Healthy, but the logging **pipeline is non-functional**: no `LokiStack` (log store) and no `ClusterLogForwarder` (collector) exist anywhere in git or on the cluster, so zero logs are being collected, stored, or forwarded.
+
+### Scope
+`components/openshift-logging` deploys **operator-only** manifests: `namespace.yaml`, `operatorgroup.yaml` (`cluster-logging`, `upgradeStrategy: Default`), and `subscription.yaml` (`cluster-logging`, channel `stable-6.5`, `installPlanApproval: Automatic`, `redhat-operators`). A sibling `components/loki-operator` installs the Loki operator into `openshift-operators-redhat`. Both are sync-wave 10 in `clusters/ocp/values.yaml`.
+
+### Health check (read-only)
+- **ArgoCD app** `openshift-logging`: **Synced / Healthy**, revision `d81e454`, project `cluster-config`, selfHeal on. `loki-operator` app also Synced/Healthy.
+- **Subscription/CSV**: `cluster-logging.v6.5.1` **Succeeded**; InstallPlan `install-229gv` approved. Loki `loki-operator.v6.5.1` Succeeded.
+- **Deployment/Pods**: `cluster-logging-operator` 1/1 Available, pod Running on hpg5, **0 restarts**, 149m. `loki-operator-controller-manager` 1/1 Running. No crashloops/pending.
+- **CRDs present**: `clusterlogforwarders.observability.openshift.io`, `logfilemetricexporters.logging.openshift.io`, plus Loki CRDs (`lokistacks`, `alertingrules`, `rulerconfigs`, etc.).
+- **PVCs**: none (operator has no persistent state). **Routes/UIPlugin**: none. **Warning events**: none.
+- Operator logs show the CLF controller started and is idle-watching for a `ClusterLogForwarder` — confirming none exists.
+
+### Findings
+1. **[HIGH — functional gap] No log collection/storage/forwarding is configured.** `oc get clusterlogforwarder -A`, `oc get lokistack -A` both return *No resources found*. In Logging 6.x the operators are inert until you create a `LokiStack` (store) and a `ClusterLogForwarder` (collector DaemonSet). Neither is committed in `components/openshift-logging` or `components/loki-operator`. Result: application/infra/audit logs are **not being aggregated at all** — the stack is "running but not functional."
+2. **[INFO — not a DR regression] Nothing to restore.** This component is operator-only with no PVCs/persistent state, so the reinstall recovered it correctly and completely. The missing pipeline is a **pre-existing design gap**, not disaster-recovery drift (git never defined a LokiStack/CLF, and the live cluster matches git exactly — hence Synced/Healthy).
+3. **[LOW — supply-chain/version pinning] `installPlanApproval: Automatic` on `stable-6.5`.** Combined with the incident's netboot/auto-reinstall theme, automatic operator upgrades mean a channel bump can roll the operator unattended. Acceptable for logging, but worth noting given the environment's sensitivity to unattended automation.
+4. **[LOW — no visualization]** No logging `UIPlugin`/console log view and no route; even once a LokiStack exists, log viewing in the console would need the Cluster Observability Operator UIPlugin (not part of this component).
+
+### Remediation
+- To make logging actually functional, add (in git, GitOps-managed) a `LokiStack` CR referencing an object-storage secret (TrueNAS/RustFS S3 is already used for CNPG Barman backups and would be the natural bucket) plus a `ClusterLogForwarder` (`observability.openshift.io/v1`) selecting the desired log types → Loki. Wire storage-secret provisioning via ExternalSecret/1Password as done elsewhere.
+- Optionally add a logging `UIPlugin` (Cluster Observability Operator) for in-console log viewing.
+- Consider pinning to a specific CSV / `installPlanApproval: Manual` if unattended operator upgrades are a concern.
+- No post-disaster restore action required for this component specifically — it is stateless and already reconciled to git.
+
+---
+
+## openshift-nfd
+
+**Status:** healthy
+
+Node Feature Discovery (Red Hat NFD operator) recovered cleanly from the 2026-07-03 cluster reinstall and is fully functional — it is producing node feature labels on all three nodes, not merely running. NFD is entirely stateless (no PVCs, no persistent data, no external secrets), so it required zero post-disaster restore: the operator re-derives all labels from live hardware on each `sleepInterval`.
+
+### Evidence / health snapshot
+
+- **ArgoCD app** `openshift-nfd`: `Synced` / `Healthy` at rev `d81e454`; app-of-apps sync-wave 5 (`clusters/ocp/values.yaml`), `IgnoreExtraneous` compare-option.
+- **Operator**: CSV `nfd.4.21.0-202606240914` = `Succeeded`; Subscription `nfd` (channel `stable`, Automatic approval) = `AtLatestKnown`, installedCSV==currentCSV; InstallPlan approved. OperatorGroup `openshift-nfd` scoped to its own namespace (own-namespace mode) — correct.
+- **Workloads**: `nfd-controller-manager` 1/1, `nfd-gc` 1/1, `nfd-master` 1/1, DaemonSet `nfd-worker` 3/3 — all Running, 0 restarts. No CrashLoopBackOff/Pending.
+- **CR** `NodeFeatureDiscovery/nfd-instance`: `Available=True (AllInstanceComponentsAreDeployedSuccessfuly)`, `Degraded=False`, `Progressing=False`.
+- **Functional proof**: `NodeFeature` objects exist for all 3 nodes; `feature.node.kubernetes.io/*` labels present (81 on ocp master, 60 on hpg5, 51 on truenas-w1). PCI whitelist is working — `pci-0200_*` (network, class 0200) and `pci-0300_*` (display, class 03) labels are populated per node, plus `network-sriov.capable`, `rdma.available`, CPU/kernel/OS-release feature labels.
+- No PVCs, no Routes (expected — NFD is stateless and cluster-internal). No Warning events.
+
+### Findings
+
+1. **[Low–Medium] Operand image drift: pinned to v4.20 on a 4.21 cluster.**
+   `nfd-instance-nodefeaturediscovery.yaml` hardcodes `spec.operand.image: registry.redhat.io/openshift4/ose-node-feature-discovery-rhel9:v4.20`, and the running master/worker/gc pods confirm the `:v4.20` tag — while the cluster is OpenShift 4.21.9 and the operator (controller-manager) is `ose-cluster-nfd-rhel9-operator` 4.21. Red Hat's guidance is that the operand image track the operator/cluster version. It is working today (NFD is version-tolerant and the labels are correct), but this is a real version skew that will diverge further on future upgrades and defeats the operator's own operand-image management. Note also the tag is mutable (`imagePullPolicy: Always` + floating `:v4.20`), so the exact operand digest is not pinned.
+
+2. **[Info] Benign nfd-worker log noise.** Every discovery cycle logs `failed to detect Swap nodes ... open /host-proc/swaps: no such file or directory`. This is cosmetic on RHCOS (swap is disabled by design); discovery still completes (`feature discovery completed` each cycle). No action.
+
+3. **[Info] PCI whitelist class `12` (processing accelerators) yields no labels.** The `workerConfig` whitelists device classes `0200`/`03`/`12`; only `0200` (network) and `03` (display) match hardware present today — no class-12 accelerator is installed, so no such label appears. Harmless; the whitelist is evidently intended to feed downstream GPU/accelerator consumers (nvidia-gpu-operator and intel-device-plugins-operator CSVs are both installed on this cluster).
+
+### Remediation
+
+- **Recommended:** Bump `spec.operand.image` to `...:v4.21` to match the 4.21 cluster/operator, or (preferred) drop the explicit `spec.operand.image` override entirely and let the operator select the version-matched operand from its CSV `relatedImages`. For reproducibility, prefer a digest (`@sha256:...`) over a floating tag. This is a single-line change in `components/openshift-nfd/nfd-instance-nodefeaturediscovery.yaml`; low risk, no data to migrate.
+- No DR remediation needed — component is stateless and self-heals; nothing was lost in the reinstall.
+- The Info items require no action.
+
+---
+
+## openshift-pipelines
+
+**Status: broken** (operator never reinstalled after the 2026-07-03 DR rebuild; component is functionally down. The ArgoCD app misleadingly reports `Healthy`.)
+
+### Summary
+The OpenShift Pipelines (Tekton) operator failed to install during the post-disaster GitOps re-bootstrap and has been stuck ever since. The `openshift-pipelines` namespace does not exist, no CSV is installed, the `TektonConfig` CRD is absent, and no Tekton/Pipelines-as-Code controllers are running. ArgoCD has been retrying (attempt #19) to apply `TektonConfig` and failing with `no matches for kind "TektonConfig" ... ensure CRDs are installed first`. Root cause is an OLM shared-InstallPlan approval block, not a bad manifest — the git config itself is well-written.
+
+### Findings
+
+**[CRITICAL] Pipelines operator never installed — whole component non-functional.**
+- Subscription `openshift-pipelines-operator` (ns `openshift-operators`) is stuck `state: UpgradePending`, `installedCSV: None`, `currentCSV: openshift-pipelines-operator-rh.v1.22.4`. Conditions: `InstallPlanPending=True (RequiresApproval)`, `BundleUnpacking=True`.
+- No `openshift-pipelines` namespace, no CSV, `tektonconfig`/`pipelinesascode`/`tekton` API resources absent, zero pods/deployments/statefulsets.
+- Subscription created `2026-07-03T23:21` (during the DR GitOps re-bootstrap) and has never progressed — a direct casualty of the reinstall.
+
+**[CRITICAL — root cause] Automatic pipelines install is blocked behind a co-bundled Manual InstallPlan.**
+- The pipelines Subscription is `installPlanApproval: Automatic`, but OLM bundled its install into InstallPlan `install-khg9h`, which contains **two** CSVs: `servicemeshoperator3.v3.3.5` **and** `openshift-pipelines-operator-rh.v1.22.4`.
+- Because `servicemeshoperator3` uses `installPlanApproval: Manual` and is unapproved, the entire shared plan is `approval: Manual, approved: false, phase: RequiresApproval` — so the Automatic pipelines install cannot proceed. This is the classic shared-`openshift-operators`-OperatorGroup gotcha: one Manual operator in the namespace gates co-bundled Automatic operators.
+- The servicemesh subscription is **out-of-band** (owned by the ingress operator for Gateway API — annotation `ingress.operator.openshift.io/owned`; pinned `startingCSV: servicemeshoperator3.v3.2.0`, channel `stable`). It is **not** in git or ArgoCD, so this blocker sits outside GitOps visibility.
+
+**[HIGH] Downstream consumers are also down.**
+- `TektonConfig config` and `ExternalSecret signing-secrets` show ArgoCD status `OutOfSync / Missing` (they can't apply — CRD and namespace don't exist).
+- The `pac-tenants` ArgoCD app is `OutOfSync` (its Pipelines-as-Code `Repository` CRDs don't exist). Any PAC webhooks/CI PipelineRuns and Tekton Chains signing are non-functional cluster-wide.
+
+**[LOW/INFO] ArgoCD app health is misleading.**
+- `openshift-pipelines` app reports `SYNC=OutOfSync, HEALTH=Healthy`. The aggregate is `Healthy` only because the Subscription reports Healthy and the two blocked children have health `Missing` (which doesn't downgrade the app). `operationState.phase=Running` with a `SyncFailed` on `TektonConfig` is the real signal. Do not trust the top-line Healthy here.
+
+**[POSITIVE] DR-restore design for signing state is sound; manifests are correct.**
+- Tekton Chains signing key is restored declaratively via `ExternalSecret signing-secrets` from 1Password item `tekton-chains-signing` (ClusterSecretStore `onepassword-sdk-ocp-pull` is `Ready`), with `creationPolicy: Merge` + `deletionPolicy: Retain`. No manual DR step is needed — it will self-materialize once the namespace/operator exist. No separate backup/restore gap for this component.
+- Config quality is good: pruner enabled (keep 20, daily), CI pod hardening (`runAsNonRoot`, `automountServiceAccountToken: false`, `tekton-ci-low` PriorityClass for preemptible PR runs), resolvers enabled, PAC wired to the console, Chains transparency/fulcio disabled (appropriate for homelab), and a well-documented note on why `seccompProfile` is deliberately omitted (avoids the OCP SCC `pipelines-scc` empty-seccompProfiles rejection). No misconfiguration found in the component manifests.
+
+### Remediation
+1. **Unblock the operator install (primary fix).** Approve the pending shared InstallPlan:
+   `oc patch installplan install-khg9h -n openshift-operators --type merge -p '{"spec":{"approved":true}}'`
+   **Caveat:** this ALSO upgrades OSSM `servicemeshoperator3` v3.2.0 → v3.3.5, which underpins Gateway API (jellyfin and other Gateways). Confirm that upgrade is acceptable first. If it is not, instead delete the pending plan (`oc delete installplan install-khg9h -n openshift-operators`) and let OLM regenerate; verify the regenerated pipelines plan is not re-bundled with servicemesh before it auto-approves.
+2. **Let it converge.** Once the CSV reaches `Succeeded`, the operator creates the `openshift-pipelines` namespace and the `TektonConfig`/`TektonPipeline`/PAC CRDs; ArgoCD self-heal (automated + selfHeal) will then apply `TektonConfig` and the `signing-secrets` ExternalSecret. Verify: `oc get csv -n openshift-operators | grep pipelines`, `oc get tektonconfig config`, `oc get secret signing-secrets -n openshift-pipelines`, and the app returns to `Synced`.
+3. **Recover downstream.** Refresh/sync `pac-tenants` and confirm PAC `Repository` objects and Chains signing are live after the operator is up.
+4. **Preventive (MEDIUM).** Document/guard the shared-namespace gotcha: pipelines (Automatic) shares the global `openshift-operators` OperatorGroup with the Manual, ingress-operator-owned servicemesh subscription, so any future OSSM upgrade will re-block pipelines. Options: add a periodic pending-InstallPlan approval/alert for `openshift-operators`, or bring the servicemesh subscription under GitOps and set a deliberate approval policy so this drift is visible.
+
+---
+
+## openshift-virt
+
+**Status:** degraded (running and Synced/Healthy, but a VM-storage reliability bug is actively hitting the workload and one placement guard is silently non-functional)
+
+The component deploys OpenShift Virtualization (KubeVirt HyperConverged / CNV) into `openshift-cnv`: the `hco-operatorhub` Subscription (channel `stable`), OperatorGroup, the `HyperConverged` CR, and nine CDI `StorageProfile` overrides for the democratic-csi backends (nvmeof / iscsi / nfs × ssd/fast/cold).
+
+### Health check (live cluster)
+
+- **ArgoCD app `openshift-virt`:** `Synced` + `Healthy`, operationState `Succeeded`, synced to `d81e454` which is exactly `origin/main` HEAD — no git/tracked-revision drift.
+- **Operator:** Subscription `AtLatestKnown`; CSV `kubevirt-hyperconverged-operator.v4.21.10` `Succeeded`; InstallPlan `install-xk76d` Complete. (Operator is 4.21.10 vs cluster 4.21.9 — expected, HCO tracks its own channel.)
+- **HyperConverged:** `Available=True`, `Progressing=False`, `Degraded=False`, `Upgradeable=True`, `systemHealthStatus=healthy`. featureGates `deployTektonTaskResources` + `enableCommonBootImageImport` active as configured.
+- **Pods:** all 36 in `openshift-cnv` Running; `virt-handler` DaemonSet 3/3 ready; virt-operator/virt-api/virt-controller healthy. The Warning events on `openshift-cnv` (FailedMount tls secrets, ssp-operator ComponentUnhealthy, SecretUpdateFailed) are all ~171m old from the post-reinstall operator bring-up and have cleared. `AdvancedFeatureUse` warnings are normal (HCO sets 2 infra replicas on a multi-node cluster).
+- **StorageProfiles:** all 9 present; `.status.claimPropertySets` matches `.spec` on every one (block RWO for iscsi/nvmeof, RWX+RWO Filesystem for nfs, cloneStrategy snapshot) — correctly reconciled.
+- **Golden images:** DataImportCrons for centos-stream9/10, fedora, rhel8/9/10 all `Ready=True`; boot-image PVCs Bound on `freenas-nvmeof-ssd-csi`. (rhel7 + all win* DataSources `Ready=False` is expected — no upstream/registry source is provided for those default templates; not a defect.)
+- **Workload:** the restored `hermes` VM is `Running` / `Ready=True` on hpg5, DataVolumesReady, AgentConnected. **The rebuild recovered.**
+
+### Findings
+
+**[HIGH] NVMe-oF shared hostnqn/hostid bug is actively degrading VM storage.**
+The default virt storage class is `freenas-nvmeof-ssd-csi` (RWO Block), and hermes' `hermes-root`/`hermes-state` PVCs both live there. During bring-up the `virt-launcher-hermes` pods logged `MapVolume.SetUpDevice failed ... unable to attach any nvme devices` (100–106m ago) and the VM was `Paused due to IO error at the volume: state` (~94m ago). This is the exact signature of the incident's known latent defect (all 3 nodes share one nvme `hostnqn`/`hostid`, violating NVMe-oF uniqueness). The VM has since stabilized (current launcher up 103m, no nvme errors in ~90m), but the uniqueness violation is unfixed and will recur on any reattach/reschedule/reboot. Root cause is node-level config (fix belongs in the ansible/node layer, not this component), but it manifests directly as openshift-virt VM attach/IO failures because nvmeof-ssd is the default VM disk backend.
+
+**[MEDIUM] The "keep virt-handler/VMs off truenas-w1" guard is a silent no-op (misconfiguration introduced by PR #376, commit c36a124).**
+`HyperConverged.spec.workloads.nodePlacement` excludes `kubernetes.io/hostname NotIn [truenas-w1.igou.systems]`, and that propagated to the virt-handler DaemonSet nodeAffinity as written. But the node's actual `kubernetes.io/hostname` label is `truenas-w1` (node name is alphanumeric, not the FQDN). The `NotIn` therefore never matches, the exclusion does nothing, and **virt-handler is running on truenas-w1** (DS desired=3, pod `virt-handler-mb2gj` on truenas-w1). The documented intent — keep VM scheduling off the nested-KVM worker that shares a failure domain with the cluster's CSI storage — is not in effect. Fix: change the affinity value from `truenas-w1.igou.systems` to `truenas-w1`.
+
+**[LOW/MEDIUM] No explicit virt-default storage class; default VM disk is RWO Block → VMs are not live-migratable.**
+No StorageClass carries `storageclass.kubevirt.io/is-default-virt-class`; VM disks fall back to the k8s default SC `freenas-nvmeof-ssd-csi` (RWO Block). Combined with the cluster-wide HCO default `evictionStrategy: LiveMigrate`, this makes VMs non-migratable: hermes' VMI reports `LiveMigratable=False` ("PVC hermes-root is not shared, live migration requires RWX"). On a node drain such VMs are force-stopped rather than migrated — and a cold restart re-exposes them to the NVMe attach bug above. Consider setting an explicit virt-default class and/or an RWX-capable tier (nfs) for migratable VMs, or intentionally documenting non-migratable as the accepted tradeoff.
+
+### Remediation
+
+1. **Fix NVMe uniqueness (owner: node/ansible layer, cross-cluster CRITICAL):** assign a unique `/etc/nvme/hostnqn` + `/etc/nvme/hostid` per node and re-detach/re-attach affected volumes. This is the single change that removes the "unable to attach any nvme devices" / IO-pause class of failures for all KubeVirt VMs.
+2. **Correct the placement guard** in `components/openshift-virt/kubevirt-hyperconverged.yml`: set the `NotIn` value to `truenas-w1` (the real hostname label). After merge/sync, confirm virt-handler DS `desired` drops to 2 and no virt-handler pod lands on truenas-w1.
+3. **Decide the migration story:** either add `storageclass.kubevirt.io/is-default-virt-class` on an RWX tier for migratable VMs, or explicitly document that nvmeof-ssd RWO Block VMs are pin-to-node / non-live-migratable so eviction/drain behavior is not a surprise.
+4. No action needed on the rhel7/win DataSources (`Ready=False` is expected) or the aged post-reinstall operator Warning events (already cleared).
+
+---
+
+## pac-tenants
+
+**Status: degraded** — all namespace scaffolding for the sole tenant (`igou-ansible`) was correctly restored and is healthy, but the tenant is **not functional**: the Pipelines-as-Code `Repository` CR cannot be created because the OpenShift Pipelines operator (and thus the `pipelinesascode.tekton.dev` CRDs) never installed after the rebuild. CI for the tenant is dead until the upstream operator is unblocked.
+
+### What it is
+
+ArgoCD app `pac-tenants` (project `cluster-config`, sync-wave 20, source `clusters/ocp/pac-tenants`) renders the local Helm chart `.helm/charts/pac-tenant` (`includeCRDs: false`). It provisions per-repo CI tenant namespaces for OpenShift Pipelines-as-Code (PaC). Currently one tenant: `igou-ansible` in namespace **`ci-igou-ansible`** (ansible-builder EE image builds → push to shared Quay).
+
+### Health check (live)
+
+- ArgoCD app: **SYNC=OutOfSync, HEALTH=Healthy**, `selfHeal: true`, retry limit `-1` — currently on **retry attempt #25**, failing every cycle.
+- Sole failing/OutOfSync resource: **`Repository/igou-ansible` (pipelinesascode.tekton.dev/v1alpha1) — status Missing**. Sync error: `no matches for kind "Repository" in version "pipelinesascode.tekton.dev/v1alpha1" … ensure CRDs are installed first`.
+- Everything else in the namespace is **Synced/Healthy and correctly restored**:
+  - Namespace `ci-igou-ansible`, `ResourceQuota ci-quota` (pods 20, cpu 8/16, mem 16/32Gi, storage 50Gi, pvc 5), `LimitRange ci-limits`, ServiceAccount `pipeline`.
+  - 3 ExternalSecrets all `SecretSynced/Ready=True` (backed by `onepassword-sdk-ocp-pull` ClusterSecretStore): `forgejo-webhook-config`, `quay-push-config` (image-pull), `rh-automationhub-credentials`. Verified the synced secrets carry the exact keys the manifests reference — `provider.token` + `webhook.secret` (forgejo) and `token` (automation hub) — so credential restore is complete.
+  - ImageStream `ee-minimal-rhel9`; 6 NetworkPolicies (`default-deny-all`, `allow-dns`, `allow-external-egress`, `allow-internal-registry`, `allow-quay-push`, `allow-forgejo-clone`).
+- No PVCs expected or present — the component is **stateless**, so there is no data-restore obligation here.
+
+### Findings
+
+- **[HIGH] Tenant CI is non-functional — `Repository` CR missing (root cause is upstream).** The PaC `Repository` is the object that binds the Forgejo webhook to a PipelineRun. Without it (and without the PaC controller), no `igou-ansible` CI runs. Direct cause: the `pipelinesascode.tekton.dev` and `operator.tekton.dev` (`TektonConfig`) CRDs are absent — the OpenShift Pipelines operator is not installed.
+- **[HIGH] Post-disaster restore gap — OpenShift Pipelines operator blocked by an unapproved, co-bundled Manual InstallPlan (OLM gotcha).** The `openshift-pipelines` ArgoCD app (wave 10) is OutOfSync (`TektonConfig/config` + `signing-secrets` Missing). Its Subscription `openshift-pipelines-operator` is `installPlanApproval: Automatic` and `currentCSV: openshift-pipelines-operator-rh.v1.22.4`, but the Subscription is stuck `InstallPlanPending / RequiresApproval`. The referenced InstallPlan **`install-khg9h`** is `approval: Manual, approved: false` and bundles **two** CSVs: `["servicemeshoperator3.v3.3.5", "openshift-pipelines-operator-rh.v1.22.4"]`. Because OLM co-resolved the auto pipelines install into the same plan as a *manual* Service Mesh upgrade, the manual gate wins and the (otherwise automatic) pipelines operator is blocked. No pipelines CSV → no CRDs → `pac-tenants` cannot converge and thrashes retries.
+- **[LOW] pac-tenants own config is correct; it will self-heal once the CRD exists.** The Repository template carries `SkipDryRunOnMissingResource=true` and the app has `selfHeal: true` + infinite retry, so no change to this component is required — it recovers automatically the moment the PaC CRD lands. This is purely a dependency-ordering victim, not a misconfiguration.
+- **[INFO] Security posture is sound.** Namespace is default-deny with narrowly scoped egress (DNS, internal registry :5000, Forgejo/Quay via router IP 10.10.9.10:443 only). The `Repository` `settings.policy` (`pull_request` / `ok_to_test`) restricts who can trigger CI. Automation-hub token is delivered via `secret_ref` (not inlined).
+
+### Remediation
+
+1. **Unblock the Pipelines operator (owner: openshift-pipelines / servicemesh components — read-only here, do not execute in this review).** Preferred safe fix: delete the stuck shared InstallPlan so OLM regenerates a **pipelines-only, auto-approved** plan while preserving Service Mesh's intentional manual gate:
+   `oc -n openshift-operators delete installplan install-khg9h`
+   Alternative (couples the two): `oc -n openshift-operators patch installplan install-khg9h --type=merge -p '{"spec":{"approved":true}}'` — but this **also upgrades Service Mesh 3.2.0 → 3.3.5**, which was deliberately gated Manual; only do this if that upgrade is intended.
+2. **Verify operator install:** CSV `openshift-pipelines-operator-rh.v1.22.4` reaches `Succeeded`; CRDs `repositories.pipelinesascode.tekton.dev` and `tektonconfigs.operator.tekton.dev` exist; `openshift-pipelines` app goes Synced/Healthy (TektonConfig applied, PaC controller running).
+3. **Recover pac-tenants:** it should self-heal; if not, hard-refresh the app. Confirm `Repository/igou-ansible` becomes `Synced/Healthy` and the namespace shows `oc get repository -n ci-igou-ansible`.
+4. **Functional validation (beyond "running"):** trigger the tenant's PaC path end-to-end — a Forgejo PR/`ok-to-test` on `igou-ansible` should spawn a PipelineRun in `ci-igou-ansible` that builds the EE and pushes to Quay via `quay-push-config`. Nothing has exercised this path since the rebuild.
+5. **Hardening (prevent recurrence):** pin the pipelines operator (`startingCSV` / dedicated `spec.config` or a distinct sync grouping) so OLM does not co-bundle its auto-install into the Service Mesh manual InstallPlan; and/or add a CRD-presence/health dependency so `pac-tenants` doesn't burn infinite retries while the operator is absent.
+
+---
+
+## quay-operator
+
+**Status: healthy** (recovered during this review; two follow-up items — a DR-cleanup footgun and a stalled clair rollout on the flaky NVMe-oF CSI)
+
+Red Hat Quay `igou-registry` in `quay-enterprise`, operator in `quay-operator`. Postgres for both Quay and Clair is provided by an external CNPG cluster (`quay-pg`) restored from Barman; registry image blobs live on external RustFS S3.
+
+### Timeline observed
+When the review started the ArgoCD app was `OutOfSync / Progressing` with `operationState: waiting for healthy state of postgresql.cnpg.io/Cluster/quay-pg`. The CNPG cluster had been in `Setting up primary / Creating primary instance quay-pg-1` for ~60 min: a Barman **full-recovery** pod was replaying pre-disaster WAL (`0000000100...` through `...1BA00000027`+). The replay **completed successfully during the review** (`restore command execution completed without errors`), the primary came up `2/2`, the quay-app upgrade/migration job ran to `Completed`, and the operator brought every component up. This ~60-min "Progressing" window was expected DR behavior (Argo gates later sync-waves on the CNPG Cluster becoming healthy), not a defect — just slow WAL replay.
+
+### Health check (end state)
+- **ArgoCD app** `quay-operator`: `health=Healthy`, `operationState: successfully synced (all tasks run)`. Sync is `OutOfSync` but the **only** remaining OutOfSync resource is `Cluster/quay-pg` (CNPG SSA drift — see Finding 1). Earlier transient OutOfSync/Missing on Subscription/OperatorGroup/Namespace/PodMonitor/ServiceMonitor/QuayRegistry all resolved once the DB unblocked the sync.
+- **Operator**: CSV `quay-operator.v3.17.3` `Succeeded`, Subscription `AtLatestKnown`, channel `stable-3.17`, `installPlanApproval: Automatic`. OperatorGroup is AllNamespaces (`spec: {}`) — correct per the in-file note (Quay operator does not support MultiNamespace).
+- **QuayRegistry** `igou-registry`: `Available=True — All components reporting as healthy`. Managed: quay(1)/clair(1)/redis/mirror(1)/route/monitoring/tls. Unmanaged (external): postgres, clairpostgres, objectstorage, hpa.
+- **Pods**: `quay-pg-1` 2/2; `quay-app` 1/1; `redis` 1/1; `mirror` 1/1; clair 1/1 on the old ReplicaSet (a second clair pod is stuck Pending — Finding 2).
+- **PVCs**: `quay-pg-1` (40Gi) Bound; clair old `indexer-layer-storage` (20Gi) Bound; clair **new** `indexer-layer-storage` Pending.
+- **Route/serving**: `quay.apps.ocp.igou.systems` admitted (edge/Redirect); `GET /health/instance` → **HTTP 200**. Registry is live and serving.
+- **Backups**: ObjectStore `quay-pg-backup` → `s3://cnpg-backups/quay-pg` on `truenas.igou.systems:20292`; ScheduledBackup `quay-pg-daily` fired immediately (`quay-pg-daily-20260704025550`, phase `started`); WAL archiving to the new serverName is flowing.
+
+### Findings
+
+**1. [Medium] DR cleanup not done — git still pins `bootstrap.recovery`, a re-restore footgun.**
+`components/quay-operator/quay-pg-cluster.yaml` on `origin/main` still declares `bootstrap.recovery.source: quay-pg` (the initdb block is commented out). The file's own comment says to revert to initdb "once the DB is recovered and verified." Consequences while it stays: (a) the live Cluster is permanently `OutOfSync` (CNPG mutates/strips the bootstrap stanza post-bootstrap), the last dirty spot on this Argo app; (b) **if the `quay-pg` Cluster CR is ever deleted and recreated by Argo, it will re-restore from the pre-disaster backup (`serverName: quay-pg`) and silently lose everything written since recovery.** The recovery↔archive serverName split is correct (recovery reads `quay-pg`, new WAL archives to `quay-pg-r20260704`), so the archive side is safe — the risk is purely the stale recovery bootstrap.
+Remediation: verify quay data (push/pull a repo, confirm orgs/users), then revert `quay-pg-cluster.yaml` to the commented `bootstrap.initdb` block, commit, and sync; confirm `Cluster/quay-pg` goes Synced.
+
+**2. [Medium] Clair rollout wedged — democratic-csi NVMe-oF provisioning failing.**
+A clair rolling update spawned a new pod whose `indexer-layer-storage` PVC (20Gi RWO `freenas-nvmeof-ssd-csi`) will not provision: `ProvisioningFailed ... DeadlineExceeded / context deadline exceeded`, `Aborted: operation locked due to in progress operation(s)`, and `Internal: AxiosError: timeout of 60000ms exceeded` (democratic-csi → TrueNAS API on truenas-w1). Clair still serves via the old pod (`ComponentClairReady=True`), so this is not currently an outage, but the Deployment rollout cannot complete and a full clair restart while the CSI is unhealthy would take clair down. This is the storage-stack instability flagged in the incident (shared `hostnqn`/`hostid` across all 3 nodes + TrueNAS-API latency), surfacing through quay-operator's clair.
+Remediation: stabilize democratic-csi/TrueNAS API + fix the duplicate NVMe hostnqn/hostid; once healthy the Pending PVC should provision and the rollout completes. Consider whether clair's indexer *layer cache* (scratch data) needs RWO NVMe-oF at all — every clair rollout mints a fresh 20Gi NVMe-oF volume, amplifying exposure to this flaky path.
+
+**3. [Low] Timeline `.history` WAL archive fails repeatedly.**
+The primary logs recurring `archive command failed ... wal-archive ... pg_wal/00000002.history` (exit status 1) while ordinary WAL segments archive fine (`00000002000001BA00000074` archived OK). Likely a benign CNPG/barman quirk on the timeline-switch history file, but if the history object never lands it can impair PITR *across* the 00000001→00000002 timeline switch. Watch after the initial backup completes; confirm the `.history` object appears under `quay-pg-r20260704`.
+
+**4. [Low / security] Open self-registration on a public route + plaintext DB SSL.**
+`config-bundle-secret` sets `FEATURE_USER_CREATION: true` with the registry exposed on a public edge route (`quay.apps.ocp.igou.systems`) — anyone who can reach the endpoint can self-register accounts (only `SUPER_USERS: [igou]` is privileged). Acceptable for a homelab but worth a conscious decision; set `FEATURE_USER_CREATION: false` if the registry is reachable beyond the LAN. Minor hardening: Clair connstrings use `sslmode=disable` and `DB_URI` sets no sslmode (in-cluster to `quay-pg-rw.svc`, so low risk).
+
+**5. [Info / positive] Recovery genuinely succeeded — data, not just process.**
+Registry image blobs are external/unmanaged on RustFS (`RHOCSStorage` → `truenas.igou.systems:20292`, bucket `quay`, `storage_path /datastorage/registry`) and survived the wipe; quay-app validates storage on boot and came up 1/1 with a 200 health check. The DB was restored via Barman WAL replay and the schema-migration job completed against the restored data. The `config-bundle-secret` is fully reconstructed from 1Password via ExternalSecret (DB_URI + clair connstrings + S3 creds). This component recovered the rebuild.
+
+### Remediation summary (priority order)
+1. Verify quay data, then revert `quay-pg-cluster.yaml` from `bootstrap.recovery` back to `bootstrap.initdb` and sync (Finding 1) — removes the re-restore footgun and the last OutOfSync diff.
+2. Fix democratic-csi/TrueNAS NVMe-oF provisioning + duplicate hostnqn/hostid so the clair rollout completes (Finding 2).
+3. Confirm the daily backup finishes and the `.history` object archives; keep an eye on WAL archiving (Finding 3).
+4. Decide on `FEATURE_USER_CREATION` given the public route (Finding 4).
+
+---
+
+## remote-tenants
+
+**Status: healthy** (guardrail scaffolding fully recovered; one latent, non-active onboarding prerequisite is missing — see MED-1)
+
+Git source: `clusters/ocp/remote-tenants` (kustomize + local Helm chart `.helm/charts/remote-tenant`, `includeCRDs: false`). App-of-apps entry: `clusters/ocp/values.yaml` sync-wave 20, project `cluster-config`.
+
+### What this component is
+Per-user locked-down OpenShift namespaces reachable over the tailnet via the Tailscale API-server proxy. The cluster values file carries `tenants: []` (no tenants onboarded — onboarding was the only outstanding item pre-disaster). With an empty tenant list the chart renders **only its shared, once-rendered cluster-scoped guardrails**; all per-tenant objects (Namespace, ResourceQuota, LimitRange, NetworkPolicies, RoleBinding) are absent by design.
+
+### Health check (live cluster)
+- ArgoCD app `remote-tenants`: **Synced + Healthy**. Last sync `2026-07-03T23:23:20Z` at revision `d81e454` (= current `origin/main` HEAD). No conditions/errors.
+- All 5 managed resources present and `Synced`, ~3h29m old (created during the reinstall recovery):
+  - ClusterRole `remote-tenant-operator`
+  - ValidatingAdmissionPolicy + Binding `remote-tenant-no-burst`
+  - ValidatingAdmissionPolicy + Binding `remote-tenant-no-secondary-net`
+- No tenant namespaces (`oc get ns -l igou.systems/tenant-type=remote-user` → none) — **expected**, `tenants: []`.
+- No Deployments/StatefulSets/DaemonSets/PVCs/Routes/CRs owned by this component (it manages RBAC + admission policy only). Nothing to be Pending/CrashLooping.
+- Functional dependency **Tailscale API-server proxy: enabled** — operator deploy env `APISERVER_PROXY=true` (git: `components/tailscale-operator/kustomization.yaml apiServerProxyConfig.mode: "true"`), operator pod Running 3h31m. This is the auth/impersonation path tenants use; it recovered.
+
+### Findings
+
+**MED-1 — Latent onboarding blocker: `node-role.kubernetes.io/tenant` label missing on all nodes post-reinstall.**
+The chart default `defaults.nodeSelector: "node-role.kubernetes.io/tenant="` pins every tenant pod to that label and stamps it on each tenant Namespace as `openshift.io/node-selector`. That label is a **one-time out-of-band prerequisite** (`oc label node ... node-role.kubernetes.io/tenant=""`, per the chart README) — it is **not** managed by this GitOps component, nor by the Ansible repo (grep of both = only README docs). After the rebuild **no node carries it**: `hpg5` re-joined without it, `truenas-w1` never had it, and `p330` is dead/removed. Consequence: onboard a tenant today and all its pods are unschedulable (Pending forever) because the namespace node-selector matches no node. **No active impact right now** (zero tenants), but it is a silent trap for the next onboarding and will re-break on every future rebuild since nothing reconciles it. Recommend labeling `hpg5.igou.systems` and codifying the label so it survives rebuilds (Ansible node-label play or a MachineConfig/label-controller), and adding it to the DR runbook.
+
+**LOW-2 — Stale `p330` references in default node pool.** Chart README prereqs and the "hpg5/p330 worker pool" wording still name `p330`, which is dead (no BMC). `hpg5` is the sole surviving tenant-pool worker. Doc/label drift; update the README prereq (drop the `p330` label line) so the next operator does not chase a dead node.
+
+**INFO-3 — Recovery of this component is complete.** Because the component is guardrail-only with `tenants: []`, there was no persistent/per-tenant state to restore; the cluster-scoped ClusterRole + both VAPs/bindings re-applied cleanly via GitOps. Nothing DR-specific is outstanding for the component itself.
+
+**INFO-4 — Burst-guard VAP literals are a maintenance coupling (not a defect).** `remote-tenant-no-burst` hardcodes `workload=burst` taint + `node-role.kubernetes.io/burst`, which must track `clusters/ocp/cluster-api/casval-worker-machineset.yaml`. The casval burst node is currently scaled to 0/deprovisioned, so the policy is dormant but correctly still denies future burst targeting. No action.
+
+### Remediation
+1. (MED-1) Label the tenant worker pool before any onboarding: `oc label node hpg5.igou.systems node-role.kubernetes.io/tenant=""` — and, to make it rebuild-durable, add the label to an Ansible node-labeling play (igou-ansible) or a label-managing MachineConfig/controller, plus a line in the reinstall runbook. Verify with `oc get nodes -L node-role.kubernetes.io/tenant`.
+2. (LOW-2) Update `.helm/charts/remote-tenant/README.md` one-time prereqs to drop `p330` and reflect `hpg5` as the current tenant node.
+3. No cluster changes required for the component to be considered recovered — it is Synced/Healthy and all guardrails are live. The above are pre-onboarding hardening, not outage fixes.
+
+---
+
+## rhdh
+
+**Status: healthy** (fully functional and recovered the 2026-07-03 rebuild) — with one benign ArgoCD `OutOfSync` and one latent disaster-recovery correctness gap that will bite on a *future* recreate.
+
+Red Hat Developer Hub (Backstage) in namespace `rhdh`, backed by a single-instance CloudNativePG cluster `rhdh-pg`, is serving live at `https://rhdh.apps.ocp.igou.systems` (route `/` → HTTP 200, `/healthcheck` → 200). `rhdh-operator.v1.10.1` CSV `Succeeded`; `backstage-rhdh-developer-hub` Deployment 1/1 Ready; `Backstage` CR condition `Deployed=True`; `rhdh-pg-1` 2/2 Running (postgres + injected barman-cloud sidecar). All 3 ExternalSecrets Healthy; both PVCs Bound (`freenas-nvmeof-ssd-csi`). The Backstage DB was restored from the Barman backup: the `backstage` database is present with **120 tables across 216 schemas** (per-plugin `schema` division), and the app connects with no DB errors in the logs.
+
+### Findings
+
+- **[INFO / recovered] DR restore succeeded end-to-end.** `rhdh-pg` bootstrapped via `bootstrap.recovery` from the RustFS Barman archive; `backstage` DB fully repopulated; UI + healthcheck return 200; DB connectivity clean. `ContinuousArchiving=True (ContinuousArchivingSuccess)`, `LastBackupSucceeded=True`, and a fresh `ScheduledBackup` (`rhdh-pg-daily-20260704015209`) completed at 01:52 with no error. New WAL/backups land under a fresh serverName (see below), confirmed by `ObjectStore.status.serverRecoveryWindow["rhdh-pg-r20260704"]` (firstRecoverabilityPoint/lastSuccessfulBackupTime = 2026-07-04T01:52:15Z). This component recovered the rebuild correctly.
+
+- **[MEDIUM — latent DR gap] `bootstrap.recovery` in git still points at the STALE pre-disaster archive.** `components/rhdh/rhdh-pg-cluster.yaml` recovers from `externalClusters[0].serverName: rhdh-pg` (the pre-disaster base, ~2026-07-02), while the *live* cluster now archives all WAL + backups to a **different** serverName `rhdh-pg-r20260704`. Because CNPG `bootstrap` is immutable, the running cluster is fine and its data is safely backed up under `rhdh-pg-r20260704`. **But if `rhdh-pg` is ever deleted and recreated from git (i.e. the exact scenario this repo just lived through), CNPG will recover from the OLD `rhdh-pg` server and silently lose everything created since 2026-07-02.** The in-code comment ("Revert to the initdb block below once recovered and verified") is itself a footgun: reverting to `initdb` would make a future recreate come up **empty**. Correct fix is to repoint recovery at the current archive, not to initdb.
+
+- **[LOW — cosmetic] ArgoCD app `rhdh` is `OutOfSync` (Healthy).** The only drifting resource is `Cluster/rhdh-pg`. Cause: CNPG's mutating webhook adds operator-defaulted fields the git manifest omits — on the immutable `bootstrap.recovery` block (`database: app`, `owner: app`) and on `externalClusters[0].plugin` (`enabled: true`, `isWALArchiver: false`). The app has `syncPolicy.automated.selfHeal=true` + `ServerSideApply=true`, but selfHeal cannot converge because `bootstrap` is immutable, so it stays permanently OutOfSync. No functional impact (cluster is Healthy). This is the kind of persistent noise that masks *real* drift on the app tile.
+
+- **[LOW — resilience] Backstage pod rides an RWO NVMe-oF PVC on a worker, unpinned.** `dynamic-plugins-root` (RWO, `freenas-nvmeof-ssd-csi`) is attached to the backstage pod on worker `truenas-w1`, and the Deployment has no node pinning. Given the cluster-wide latent bug where all 3 nodes share the SAME NVMe hostnqn/hostid (per the reinstall record), a reschedule of this pod to another node while the volume is still attached is exactly the multi-attach failure mode. The CNPG cluster was deliberately pinned to the control-plane node to dodge this (good — and `rhdh-pg-1` is correctly on `ocp.igou.systems`), but the backstage workload was not. Lower blast radius (it's a plugin cache, repopulated on init) but still an availability risk until the shared-hostnqn bug is fixed cluster-wide.
+
+- **[LOW — security/config] No identity provider configured.** `app-config-rhdh` defines only `auth.externalAccess` (legacy service-to-service token) and no user sign-in provider / `signInPage`. The hub UI is reachable at a public-ish route with edge TLS (redirect) but effectively has no user authentication in front of it. Acceptable for a homelab, but worth an explicit decision. (Secrets themselves are handled well: backend + postgres creds via ExternalSecrets from 1Password, `deletionPolicy: Retain`.)
+
+- **[LOW — noise] Backstage catalog "Policy check failed" / "metadata.name is not valid" warnings.** Repeated `catalog warn` for RHDH marketplace `extensions-package-provider` entities whose package names exceed 63 chars or carry an extra `author` property. These are upstream RHDH marketplace metadata issues, cosmetic only — no functional impact on the hub.
+
+### Remediation
+
+1. **(MEDIUM) Close the DR recreate gap.** After confirming the current data is good, update `components/rhdh/rhdh-pg-cluster.yaml` so a from-git recreate restores the *current* data: point `bootstrap.recovery.externalClusters[0].parameters.serverName` at `rhdh-pg-r20260704` (the live archive), matching the WAL archiver's serverName. Do **not** switch to the `initdb` block (that would recreate empty). Verify the `rhdh-pg-backup` ObjectStore has a valid `serverRecoveryWindow` for `rhdh-pg-r20260704` first (it does, as of 2026-07-04T01:52:15Z).
+2. **(LOW) Silence the benign OutOfSync.** Add an ArgoCD `ignoreDifferences` for `Cluster/rhdh-pg` on `spec.bootstrap` (and, if needed, `spec.externalClusters` plugin defaults), or declare the operator-defaulted values (`database: app`, `owner: app`, `enabled`/`isWALArchiver`) in git so SSA matches. This restores a clean `Synced` tile so genuine drift is visible.
+3. **(LOW) Pin backstage or fix the root cause.** Either add a control-plane nodeSelector to the Backstage Deployment (as done for CNPG) to avoid the shared-hostnqn NVMe-oF multi-attach trap, or — preferably — fix the cluster-wide duplicate `hostnqn`/`hostid` so RWO NVMe-oF PVCs reschedule safely for all workloads.
+4. **(LOW) Decide on auth.** If the hub should be more than open/guest, add a real sign-in provider to `app-config-rhdh`; otherwise document that guest/legacy-only access is intentional.
+
+---
+
+## searxng
+
+**Status: not-yet-deployed** (git config is sound; the component never came back after the rebuild because the parent app-of-apps sync is wedged)
+
+SearXNG is the in-cluster, internet-facing metasearch backend consumed east-west by `hermes-agent` (Hermes web search) and `firecrawl` (`SEARXNG_ENDPOINT`). Git source: `applications/searxng` (bjw-s `app-template` 4.6.2, stateless Deployment). Added in a single recent commit (`dfd7c72 feat(searxng): add internal search service`).
+
+### Findings
+
+- **[CRITICAL] Component is entirely absent from the cluster — did NOT recover from the rebuild.** There is no `searxng` ArgoCD Application, no `searxng` namespace, and no workloads/service/secret. `oc get applications.argoproj.io searxng -n openshift-gitops` → NotFound; `oc get ns searxng` → NotFound.
+
+- **[CRITICAL] Root cause: the `root-applications` app-of-apps sync is wedged, blocking creation of searxng.** `root-applications` is OutOfSync/Progressing with an in-flight sync operation stuck `Running … waiting for healthy state of argoproj.io/Application/quay-operator` (startedAt 01:42Z, still running >1h, retryCount 4). `quay-operator` (wave 22) never reaches Healthy (its `QuayRegistry igou-registry` is Missing and the `quay-pg` CNPG cluster is Progressing). Because a sync operation is perpetually in-flight, ArgoCD's selfHeal cannot create the child Applications that are currently `Missing`: **searxng**, `firecrawl`, `jellyfin`, `llmkube`, `gotify`, `gitea-mirror`, `ansible-automation-platform`. searxng is collateral damage of the stuck quay-operator wave — nothing is wrong with searxng itself.
+
+- **[HIGH] Downstream capability loss.** `firecrawl` (also Missing) and `hermes-agent`'s web-search path have no SearXNG backend. `hermes-agent` is Synced/Healthy but its in-cluster web search is non-functional until searxng is up.
+
+- **[MEDIUM] NetworkPolicy will block firecrawl even once both deploy.** `searxng-networkpolicy.yaml` ingress permits port 8080 only from `namespaceSelector kubernetes.io/metadata.name: hermes`. But `firecrawl` runs in namespace `firecrawl` and is configured with `SEARXNG_ENDPOINT: http://searxng.searxng.svc.cluster.local:8080`. With default-deny ingress, firecrawl→searxng will be dropped. The ingress rule omits the `firecrawl` namespace. (hermes ns exists and is correctly labeled, so the hermes path is fine.)
+
+- **[LOW] Runtime secret dependency unverified.** `SEARXNG_SECRET` env pulls key `secret_key` from Secret `searxng-secrets`, populated by an ExternalSecret using `dataFrom.extract` on 1Password item `searxng-secrets` (ClusterSecretStore `onepassword-sdk-ocp-pull` is Ready/Valid). The 1P item must contain a `secret_key` field or the pod won't start; could not confirm item contents read-only.
+
+- **[POSITIVE] Config is well-formed and secure; nothing to restore.** Image pinned by digest (`searxng/searxng:2026.6.24…@sha256:77b6ec…`); hardened securityContext (runAsNonRoot, drop ALL caps, `allowPrivilegeEscalation: false`, seccomp RuntimeDefault, `automountServiceAccountToken: false`); liveness/readiness/startup probes on `/healthz:8080`; `search.formats` includes `json` (required by firecrawl/API consumers); `limiter: false` is acceptable (no Redis, internal-only); settings mounted read-only from a ConfigMap. Stateless (no PVC) so there is **no post-disaster data to restore**. No Route/HTTPRoute — internal-only, matching the netpol; egress allows DNS + public internet while denying RFC1918 (good lateral-movement containment for upstream search-engine access).
+
+### Remediation
+
+1. **Unblock the parent app-of-apps** (the real fix): get `quay-operator` to Healthy (its `quay-pg` CNPG cluster and `QuayRegistry igou-registry` — see the quay/CNPG review) OR terminate the stuck `root-applications` sync operation so selfHeal can proceed and create the Missing child Applications. Once unblocked, searxng should be created and sync automatically (config requires no changes to deploy).
+2. **As an immediate unblock for searxng specifically** (independent of quay): create/sync just this app, e.g. `argocd app sync searxng` after the Application exists, or apply the `searxng` entry directly. Verify: namespace created, ExternalSecret `searxng-secrets` becomes Ready with a `secret_key` key, pod reaches Ready on `/healthz`, and `curl http://searxng.searxng.svc:8080/search?q=test&format=json` returns JSON.
+3. **Fix the NetworkPolicy before relying on firecrawl→searxng**: add the `firecrawl` namespace to `searxng-networkpolicy.yaml` ingress (`namespaceSelector kubernetes.io/metadata.name: firecrawl`, port 8080), or firecrawl's SearXNG integration will silently fail.
+4. **Confirm the 1Password `searxng-secrets` item contains a `secret_key` field** before/at first sync to avoid a CreateContainerConfigError.
+
+---
+
+## service-accounts
+
+**Status:** degraded
+
+The in-cluster half of this component (ServiceAccounts + RBAC) recovered cleanly and is functionally verified. The disaster-recovery-critical half — republishing the freshly-minted post-rebuild SA tokens back into 1Password via ExternalSecrets `PushSecret`s — is **broken and has never succeeded since the rebuild**, leaving 6 downstream automation consumers reading stale (pre-disaster / invalid) tokens from 1Password. ArgoCD reports Synced/Healthy, which masks the real functional failure.
+
+### What it is
+Git source `clusters/ocp/service-accounts` → Helm chart `service-account-access` (via `components/service-accounts`, `.helm/charts`). It provisions namespace `service-accounts`, 9 managed ServiceAccounts (+ long-lived `-token` secrets, `automountServiceAccountToken: false`), 4 ClusterRoles (`molecule-kubernetes`, `virtualmachine-reader/-deployer/-ops`), assorted RoleBindings/ClusterRoleBindings, and 6 `PushSecret`s that publish each SA's token into 1Password (vault `claude` and vault `ocp-push`) for off-cluster consumers (Claude, ansible-molecule CI, ns-agent, vm-ops automation, devhost cluster-read-only access).
+
+### Findings
+
+**[HIGH] All 6 PushSecrets are `Errored` — SA tokens are NOT being published to 1Password (403 write-denied).**
+`oc get pushsecret -n service-accounts` shows all six `Errored`, `lastPushTime=<none>`, `Ready=False` since `2026-07-03T19:25:38Z` (the rebuild) — never a single successful push in 7.5h. ESO controller logs and PushSecret status give the exact cause:
+`status 403: Authorization: token does not have permission to perform update on vault iggugnytc2y6nenftd65o4eyvi` (vault `claude`) and `...vault dtd2bcigxk7ud64ed4nvsb7hl4` (vault `ocp-push`).
+Root cause: the 1Password **Connect token** backing `onepassword-connect-token` (ns `external-secrets-operator`), used by ClusterSecretStores `onepassword-sdk-claude` and `onepassword-sdk-ocp-push`, has **read** access to those vaults but no **write/update (edit)** grant. This is an out-of-band 1Password integration grant that did not recover with the rebuild — the exact failure mode recorded in memory `onepassword-kubeconfig-publish` ("Connect server edit grant was the final fix; queued writes drain on grant fix").
+Impact: because the cluster was fully reinstalled (new SA signing key), every token stored in 1Password is now stale/invalid. The 6 consumers reading these items authenticate with dead credentials:
+- vault `claude`: `ocp-cluster-read-only`, `ocp-cluster-edit`, `ocp-claude-edit`, `ocp-ansible-molecule`
+- vault `ocp-push`: `ns-agent`, `ocp-virtualmachine-ops`
+
+**[LOW] ArgoCD health masks the failure.** `applications.argoproj.io/service-accounts` = Synced + Healthy, and it lists the PushSecrets as "Healthy", yet their actual `Ready=False`. Health checks here should not be trusted as a functional signal for this app.
+
+**[INFO / not a regression] Misleading store status.** Both ClusterSecretStores report `Valid / ReadWrite / Ready=True` ("store validated") because validation only exercises a read; the write grant gap is invisible until a push is attempted.
+
+**[GOOD] In-cluster RBAC recovered and is functionally correct** (verified with `oc auth can-i --as=system:serviceaccount:...`):
+- `cluster-read-only`: get nodes = yes, delete pods = no ✓
+- `cluster-edit`: create deployments in `default` = yes, in `kube-system` = no ✓
+- `claude-edit`: create pods = no (matches intentional empty roleBindings) ✓
+- `virtualmachine-reader`: list VMs = yes ✓; `virtualmachine-deployer`: create VMs = yes ✓; `virtualmachine-ops`: create datavolumes = yes ✓
+- `ns-agent`: no perms (no bindings defined — token published for use elsewhere) ✓
+- Security posture is sound: `automountServiceAccountToken: false`, VM roles are scoped, cluster-edit is namespace-scoped to `default`.
+
+### Remediation
+1. **Grant the 1Password Connect integration write/edit access to vaults `claude` and `ocp-push`** (1Password admin console → the Connect server/integration used by `onepassword-connect-token`). This is the fix; it is out-of-band and not represented in git.
+2. After the grant, force the queued pushes to drain (ESO retries automatically, or annotate/refresh the PushSecrets / restart the ESO controller). Confirm `lastPushTime` populates and `Ready=True` on all 6.
+3. **Verify downstream tokens** actually rotated in 1Password (compare item `updatedAt`) and that consumers work: `ocp-cluster-read-only` (devhost access), `ocp-claude-edit`, `ocp-ansible-molecule` (molecule CI), `ns-agent`, `ocp-virtualmachine-ops`. Until step 1 lands, treat all six 1Password token items as invalid.
+4. Consider a lightweight post-DR checklist item / alert on `PushSecret Ready=False`, since ArgoCD Healthy does not catch this and it silently strands automation credentials.
+
+---
+
+## tailscale-operator
+
+**Status: healthy** — fully recovered from the 2026-07-03 rebuild, ArgoCD Synced/Healthy, and end-to-end egress functionality verified live (not merely running).
+
+### Scope
+- Git source: `components/tailscale-operator` (Helm chart `tailscale-operator` v1.98.4 from pkgs.tailscale.com, `includeCRDs: true`) plus overlay manifests.
+- Namespace: `tailscale` (created 3h31m ago during recovery, sync-wave `-100`).
+- Wired into app-of-apps at `clusters/ocp/values.yaml:270` (sync-wave 10, `ignoreDifferences` on the egress Service `externalName`).
+- Purpose here: (a) tailnet-joined operator with the k8s API-server auth-proxy enabled, (b) a single cluster-egress proxy that DNATs to `node_exporter` on the igou.io VPS so UWM Prometheus can scrape it.
+
+### Health check (read-only)
+- **ArgoCD app** `tailscale-operator`: `Synced` / `Healthy`, last op `Succeeded`, no conditions. All 27 tracked resources Synced (CRDs, operator Deployment, ExternalSecret, ServiceMonitor, RBAC, IngressClass).
+- **Pods**: `operator-…-8svkp` 1/1 Running, `ts-igou-io-node-exporter-8jftz-0` 1/1 Running — both **0 restarts**, ~3h31m, scheduled on `truenas-w1`. No CrashLoop/Pending.
+- **Workloads**: `deployment/operator` 1/1, `statefulset/ts-igou-io-node-exporter-8jftz` 1/1. No DaemonSets.
+- **ExternalSecret** `operator-oauth`: `SecretSynced` / Ready=True from ClusterSecretStore `onepassword-sdk-ocp-pull` (item `tailscale-oauth`); target Secret `operator-oauth` (5 keys) present. OAuth creds **auto-restored** post-disaster with no manual step.
+- **CRDs**: all 7 tailscale.com CRDs installed & Healthy. No Connectors/ProxyGroups/ProxyClasses/DNSConfigs/Recorders defined (expected — this deployment only uses an ExternalName egress Service).
+- **PVCs**: none. Proxy state lives in a k8s Secret (`ts-…-0`), so this component has **no storage dependency** and was immune to the shared-hostnqn NVMe attach bug — it restored purely from Helm + ExternalSecret.
+
+### Functionality review (is it actually working?)
+- **Operator**: authenticated to the tailnet, actively reconciling (logs show clean service-reconciler loops; the `[unexpected] no ProxyGroup annotation` lines on `quay-pg-*` services are benign — those are CNPG services not meant for tailscale).
+- **Egress proxy — VERIFIED FUNCTIONAL**: `tailscale status` inside the proxy shows the VPS device `racknerd-49580b0` **active, direct** (192.129.238.44:41641, tx 502K/rx 6.4M). Curling the proxy pod IP `:9100` and the `igou-io-node-exporter-metrics` ClusterIP from the operator pod both return real VPS metrics (`node_exporter_build_info … version="1.11.1"`). DNAT egress path works end-to-end.
+- **Scrape plumbing**: UWM enabled (`enableUserWorkload: true`); selector Service `igou-io-node-exporter-metrics` targets the proxy pod via stable `tailscale.com/*` labels; `ServiceMonitor` relabels `instance=igou.io`. Wiring is correct and complete.
+- **Anti-drift engineering (working)**: the config deliberately writes API-defaulted fields explicitly (ExternalSecret `conversionStrategy/decodingStrategy/…`, ServiceMonitor relabel `action: replace`) and the app-of-apps `ignoreDifferences` defers the operator-rewritten `externalName` — the app is genuinely Synced, not force-synced.
+- **Rebuild recovery**: complete. Git history (`#309`, `#314`, API-server-proxy enablement) matches live state; no post-disaster restore is outstanding for this component.
+
+### Findings
+- **[Medium — security surface]** `apiServerProxyConfig.mode: "true"` exposes the Kubernetes API server over the tailnet with **identity impersonation** (`tailscale-auth-proxy` ClusterRole holds `impersonate` on `users`/`groups`). This is intentional (remote-tenant access design) but is a broad control-plane exposure — its blast radius is entirely defined by the Tailscale ACL grants, which live outside this repo and are not verifiable here. Audit the tailnet ACL to confirm only intended tags/identities can reach `tag:k8s-operator` and that granted k8s groups are least-privilege.
+- **[Low — security]** ClusterRoleBindings grant `system:openshift:scc:privileged` to the `proxies` SA and `anyuid` to the `operator` SA. Required for the proxy's NET_ADMIN/iptables DNAT, but these are broad SCC grants; they are correctly scoped to the two service accounts.
+- **[Low — availability]** The VPS egress runs as a **single replica** (statefulset 1/1) and currently sits on `truenas-w1` (a KubeVirt-VM worker). If that node is unavailable, VPS `node_exporter` scraping gaps until reschedule. No HA/anti-affinity (a ProxyGroup would be the HA path).
+- **[Info]** Operator `logging: "debug"` — verbose (steady `/localapi/v0/debug` chatter in proxy logs); fine operationally, consider `info` to cut log volume.
+- **[Info]** `valuesInline.oauth: {}` is empty by design — the chart consumes the ExternalSecret-provisioned `operator-oauth` Secret by convention; confirmed working.
+
+### Remediation
+- No corrective action required for health — component is fully operational.
+- **Verify the Tailscale ACL** (out-of-repo) for the API-server proxy grants and the `tag:openshift → tag:vps tcp/9100` egress grant; document/version them alongside this component so the auth surface is auditable and reproducible after a rebuild.
+- Optional hardening/resilience: lower operator log level to `info`; consider migrating the VPS egress to a `ProxyGroup` (or add replicas/anti-affinity) to remove the single-node SPOF for VPS metrics.
+
+---
+
+## udn
+
+**Status: healthy**
+
+Component source: `clusters/ocp/udn` (ArgoCD app `udn`, project `cluster-config`, sync-wave 6). It deploys a single cluster-scoped resource: the `ClusterUserDefinedNetwork/vlan9-no-ipam` — a **Secondary Localnet** OVN network that tags workload traffic onto VLAN 9 of the hub trunk (`physicalNetworkName: trunk-network`, IPAM disabled). No namespaces, operators, Deployments, PVCs, or routes are owned by this component; it is effectively a stateless network-definition CRD.
+
+### Health check (live cluster)
+
+- **ArgoCD app `udn`**: `Synced` + `Healthy`. Last sync 2026-07-03 18:56:41Z (immediately after the reinstall), self-heal on, retry limit -1, ServerSideApply. Reconciled cleanly, no OutOfSync/degraded history.
+- **CUDN `vlan9-no-ipam`**: present (created 2026-07-03 18:56:41Z), `generation: 1`, finalizer `k8s.ovn.org/user-defined-network-protection` set. Status condition `NetworkCreated=True`, reason `NetworkAttachmentDefinitionCreated`.
+- **Underlay dependency satisfied on master + hpg5**: the `trunk-network` → `br-secondary` OVS localnet bridge-mapping (nmstate) that this CUDN relies on is `Available / SuccessfullyConfigured` via NNCPs `mapping` (master `ocp.igou.systems`) and `mapping-hpg5`. `mapping-casval` is `Ignored (NoMatchingNode)` — expected, that burst node is absent.
+- No crashloops/pending pods, no PVCs — none exist for this component. Recovery from the rebuild was clean.
+
+### Findings
+
+1. **[INFO] No consumers currently — NAD generated in 0 namespaces (expected).** The CUDN condition message is `NetworkAttachmentDefinition has been created in following namespaces: []`; no namespace carries the `network.igou.systems/vlan9: "true"` label, so no NAD is materialized anywhere. The only repo consumers of `vlan9-no-ipam` are `test-workloads/vlan9-vm-multinode/*` and `test-workloads/virtualmachine-devhosttest` — ephemeral test workloads that are **not** part of the app-of-apps and are not deployed (namespaces `vlan9-vm-multinode` / `devhosttest` absent). There is **no persistent state to restore** for a network CRD, so nothing was lost in the disaster. The network sits idle and ready by design.
+
+2. **[LOW/MEDIUM] `truenas-w1` worker has no `trunk-network` bridge mapping.** NNCPs cover master and hpg5 only (`mapping-casval` targets the absent `casval` host). The `truenas-w1` KubeVirt-VM worker is `Ready` but is not covered by any nmstate localnet mapping, so a pod/VM scheduled there and attached to `vlan9-no-ipam` would have no OVS underlay path to VLAN 9. Impact is limited today: per prior ops notes KubeVirt is fenced off `truenas-w1`, and `truenas-w1`'s VLAN-9 trunk is handled at the TrueNAS host/bridge level (br9) rather than by OpenShift nmstate. Still a latent gap if this network is ever consumed by a plain pod scheduled on that node.
+
+3. **[INFO] Config is correct and consistent.** `physicalNetworkName: trunk-network` matches the live `ovn.bridge-mappings` (`localnet: trunk-network` → `br-secondary`); VLAN access id 9, role Secondary, `ipam.mode: Disabled`. IPAM-disabled is intentional (README documents that consumers must supply addressing via DHCP/cloud-init/static). README also correctly flags CUDN immutability (delete+recreate to change VLAN/IPAM). No drift between git (`d81e454`) and cluster; no security gaps for a Secondary localnet definition.
+
+### Remediation
+
+- **No action required for DR recovery** — the component is fully restored and healthy; being a stateless CRD, it needed no data restore and reconciled correctly post-reinstall.
+- **Optional (finding 2):** if `vlan9-no-ipam` should ever be usable from workloads on `truenas-w1`, add a matching nmstate NNCP (`trunk-network` → `br-secondary`) for that node, or explicitly document that `truenas-w1` is intentionally excluded from this localnet. Read-only review — no change applied.
+- **Optional (finding 1):** none needed; if a real workload is meant to consume this network, label its namespace `network.igou.systems/vlan9: "true"` and verify the NAD appears.
+
+---
+
+## user-workload-monitoring
+
+**Status: healthy** — fully recovered the rebuild and functional end-to-end. The only firing alerts are *true positives* about **other** components (Quay mid-recovery, AAP/automation absent), which actually proves the probing + alerting path works.
+
+### Scope
+Git path `components/user-workload-monitoring` (ArgoCD app `user-workload-monitoring`, sync-wave 6). Enables OpenShift UWM and layers on: platform/UWM monitoring config, a blackbox-exporter (HTTP/TLS probes), a MikroTik `mktxp` exporter, in-cluster wiring for the off-cluster `upsmonitor` Pi exporters, and 4 ServiceMonitor/PodMonitor bundles (argocd, cert-manager, external-secrets, grafana-operator).
+
+### Health check (live)
+- **ArgoCD app:** `Synced` + `Healthy`.
+- **UWM core** (`openshift-user-workload-monitoring`): `prometheus-operator` 2/2, `prometheus-user-workload-0` 6/6, `thanos-ruler-user-workload-0` 4/4 — all Running (~136m, i.e. post-reinstall). Both PVCs **Bound** on `freenas-nvmeof-fast-csi` (prometheus 20Gi, thanos-ruler 10Gi).
+- **Config matches git:** `cluster-monitoring-config` has `enableUserWorkload: true` + `enableUserAlertmanagerConfig: true` with the `alertmanager-eda-event-stream` / `alertmanager-slack-bot-token` secrets; UWM Alertmanager is intentionally `enabled: false` so user alerts route through platform `alertmanager-main` (correct, matches manifests).
+- **Exporters:**
+  - *blackbox-exporter*: Deployment 1/1 Running; all 5 Probe CRDs present; **probe_success = 12/14 up** (2 legit failures, below).
+  - *mktxp*: Deployment 1/1 Running; ExternalSecret `mktxp-secret` = `SecretSynced/Ready=True` (1Password-backed config re-synced cleanly post-disaster); all **3 routers reporting** (RB5009, CRS328, CRS317).
+  - *upsmonitor*: no in-cluster pods (correct — exporters live on the Pi); selectorless Service + Endpoints (`10.10.9.32:9100/:9199`) + 2 ServiceMonitors + PrometheusRule all present; **both UPSes reporting** (apc1500 + cyberpower1500 at 100% charge), node_exporter up.
+- **Scrape health:** 33/33 UWM active targets **UP**. The 2 argocd ServiceMonitors are correctly scraped by the **platform** Prometheus (namespace `openshift-gitops` carries `openshift.io/cluster-monitoring: true`, and UWM excludes `openshift-*`) — both `up`. cert-manager (3), external-secrets (3 pods), grafana-operator all `up`.
+- **Rules:** `blackbox.*` and `ups.*` PrometheusRules loaded and evaluating in-Prometheus (`leaf-prometheus` scope, correct).
+
+### Findings
+
+1. **[Info — not a UWM defect] Two blackbox probes firing are TRUE POSITIVES.**
+   - `https://quay.apps.ocp.igou.systems` (tier=critical) → `BlackboxProbeFailed` + `BlackboxProbeFailedCritical`. Quay is still mid-recovery (app `quay-operator` OutOfSync/Progressing; only the `quay-pg-1-full-recovery` pod is up; no Quay route yet). This alert self-clears once Quay finishes restoring.
+   - `https://automation.apps.ocp.igou.systems` (tier=standard) → `BlackboxProbeFailed`. There is **no `automation` route on this cluster** and no AAP/EDA app in the app-of-apps. Either AAP is not yet restored, or this is now a **stale probe target** that will fire forever.
+   These demonstrate the monitoring works; the failures belong to other components.
+
+2. **[Medium — latent] UWM state volumes sit on the shared-hostnqn NVMe-oF path.** Both `prometheus-user-workload-0` and `thanos-ruler-user-workload-0` PVCs use CSI driver `org.democratic-csi.nvmeof-fast`, and both pods run on `truenas-w1`. The cluster-wide latent bug (all 3 nodes share nqn `…466937ab…`) can cause intermittent NVMe-oF attach failures. Currently Bound/Running so no impact, but any reschedule of these StatefulSet pods risks the attach race and blinds monitoring. Exposure only — fix is at the cluster/node level.
+
+3. **[Low] blackbox-exporter `serviceMonitor.enabled: true` is dead config.** No ServiceMonitor is rendered anywhere (chart v11.13.0 only emits one when `serviceMonitor.targets` is set; here Probe CRDs are used instead). Consequence: the exporter's **own self-metrics** (`blackbox_exporter_build_info`, config-reload success, module errors) are scraped by nothing. Probe results are unaffected. Either drop the block or add a real self-metrics ServiceMonitor selecting the `blackbox-exporter` service on `:9115`.
+
+4. **[Info] Post-disaster restore: nothing to restore, and it recovered cleanly.** UWM TSDB is ephemeral (15d retention) and repopulating on freshly-provisioned PVCs; the mktxp 1Password secret re-synced automatically via ESO. No Barman/tar restore applies to this component.
+
+5. **[Nit] `saas-https` Probe has an empty target list (`static: []`)** — a harmless placeholder producing no series.
+
+### Remediation
+- **Prune or fix the `automation.apps.ocp.igou.systems` probe target** in `exporters/blackbox-exporter/probes/infra-https-probe.yaml` if AAP will not live on this cluster — otherwise `BlackboxProbeFailed` fires indefinitely and adds noise to the EDA/Slack pipeline. (The Quay alert needs no action; it clears when `quay-operator` finishes recovery.)
+- **Track the NVMe-oF shared-hostnqn fix at the node level**; until fixed, avoid unnecessary reschedules of the UWM prometheus/thanos-ruler pods.
+- **Optional cleanup:** remove the ineffective `serviceMonitor` block in `exporters/blackbox-exporter/kustomization.yaml`, or replace it with an explicit ServiceMonitor for the exporter's self-metrics.

--- a/docs/post-mortems/2026-07-03-ocp-disaster-recovery.md
+++ b/docs/post-mortems/2026-07-03-ocp-disaster-recovery.md
@@ -1,0 +1,1593 @@
+# Post-mortem: 2026-07-03 `ocp` Cluster Disaster & Recovery
+
+> Compiled 2026-07-04 from a multi-agent review (Claude, Opus 4.8). Each section
+> below was authored by a dedicated expert reviewer or professional persona.
+> Companion documents: [`2026-07-03-component-reviews.md`](./2026-07-03-component-reviews.md)
+> (per-component health/functionality) and the runbooks under
+> [`../runbooks/`](../runbooks/).
+
+## Contents
+- [Executive Summary](#executive-summary)
+- [Incident Timeline, Root Causes & Mistakes](#incident-timeline-root-causes-mistakes)
+- [GitOps Repository Review](#gitops-repository-review)
+- [Ansible Repository Review](#ansible-repository-review)
+- [Architecture & Environment Review](#architecture-environment-review)
+- [Perspective: Kubernetes / OpenShift Administrator](#perspective-kubernetes-openshift-administrator)
+- [Perspective: Site Reliability Engineer](#perspective-site-reliability-engineer)
+- [Perspective: Software Engineer](#perspective-software-engineer)
+- [Perspective: Virtualization Administrator](#perspective-virtualization-administrator)
+- [Perspective: Database Administrator](#perspective-database-administrator)
+- [Perspective: Code & Process Readability](#perspective-code-process-readability)
+- [Consolidated Action Items](#consolidated-action-items)
+
+---
+
+## Executive Summary
+
+On 2026-07-03 the single-control-plane OpenShift cluster `ocp` (control plane on MS-01 = `10.10.9.10`, OCP 4.21.9; workers `hpg5` + the `truenas-w1` KubeVirt VM; `p330` permanently dead) was **destroyed by a self-inflicted netboot reinstall**. MS-01 firmware boots the network before its local disk, and a per-host iPXE pin on the rb5009 router — armed since a 2026-05-11 netboot migration and left defaulting to `install-openshift` on a 30-second timeout — had sat as a latent landmine for roughly seven weeks. A routine unattended reboot was all it took: the agent-based installer wiped the 990 PRO, and its own mid-install reboot re-entered PXE and reinstalled again, turning a single wipe into a self-amplifying loop that only broke when an operator manually flipped the pin to `local` at the exact `status=installing` moment. etcd and all local control-plane state were unrecoverable; the cluster identity was gone. Detection was entirely human — the in-cluster alerting pipeline dies with the cluster it monitors, so **MTTD was effectively unbounded**.
+
+Recovery was a manual tour de force by a single expert operator: regenerate the agent-install PXE artifacts, break the reinstall loop (pin default → `local`, `inv#120`), reinstall 4.21.9, re-seed the out-of-band bootstrap secrets (1Password Connect credentials + token), re-bootstrap OpenShift GitOps / ArgoCD app-of-apps + External Secrets, re-join both workers (hpg5 by PXE, truenas-w1 by node-image ISO), and restore persistent data — Hermes agent state from a zstd-verified tar and the quay / rhdh / forgejo CloudNativePG databases from Barman backups on RustFS. Approximate timeline: **~2.3h to a live API, ~5h to workers + core apps, 12h+ to substantially-restored data.** Two genuine DR bugs in the bootstrap playbook were found and merged mid-incident (`ansible#312`), and the netboot pin default fix (`inv#120`) makes this exact trigger non-recurring.
+
+**Outcome: the cluster is healthy and no committed data was permanently lost** — all cluster operators `Available`, 3/3 nodes `Ready`, the Hermes VM Running with state restored, and the rhdh/forgejo/quay databases restored with real data (backstage 119 tables; forgejo 128 tables / 356 repos; quay 103 + clair 31). But recovery succeeded **despite the design, not because of it**: it leaned on luck (the democratic-csi zvols survived because only MS-01 was wiped, RustFS could be un-wedged in time, and one operator held the entire undocumented runbook in their head). A repeat of the same unattended reboot — or any loss of the single TrueNAS box that holds every zvol, every Barman backup, the boot artifacts, and truenas-w1 itself — would land very differently.
+
+**The five most important takeaways:**
+
+1. **A latent NVMe-oF identity collision is the single biggest correctness risk on the cluster and is still unfixed.** All three nodes were baked with the identical `/etc/nvme/hostnqn`/`hostid` (`…466937ab…`), and — deeper than the incident record captured — the democratic-csi node plugin overrides that with its *own* image-baked NQN (`941e4f03…`) that is likewise identical on every node. This violates NVMe-oF host uniqueness, already paused the Hermes VM once during recovery, and carries a genuine filesystem-corruption risk. The host-only MachineConfig fix is necessary but **not sufficient** — the CSI node plugin must also inherit the per-node identity.
+
+2. **The settings that made the cluster recoverable live only on the running cluster, not in git.** The ArgoCD repo-server tuning (`cpu=2`, `ARGOCD_EXEC_TIMEOUT=3m`) and the PushSecret/ExternalSecret health-checks — the exact patches that un-stalled the wave gate and the repo-server timeouts during DR — are hand-applied to a playbook-created ArgoCD CR and absent from git. The next bootstrap re-run silently reverts them, reintroducing the very stalls that cost hours this time.
+
+3. **Several stateful restores are committed as one-shot recovery mode, which is a silent data-loss trap.** All three CNPG databases still carry `bootstrap.recovery` in `origin/main` pointed at the pre-disaster archive; a Cluster recreate would silently roll them back to the 2026-07-02 snapshot (and forgejo additionally came up serving an *empty* database with its 356 repos orphaned and its git filesystem never restored). This needs to be reverted to a steady state and guarded before the next rebuild.
+
+4. **There is no cluster-state backup and no external detection.** No etcd snapshot, no OADP/Velero (the operator is in-repo but disabled), no off-cluster heartbeat, and backups that share a failure domain with primary storage. The netboot trigger is fixed, but the *class* of "unattended reboot wipes a node" survives (firmware is still netboot-first, the install menu still defaults to install on a timeout), and if it recurs the detection would again be a human noticing.
+
+5. **The runbooks lag the operator's knowledge — in two places they point the next engineer at the wrong thing.** The committed DR runbook names the stale, drifted bootstrap playbook (not the one recovery actually used), the destructive-pin root cause and the mid-install "flip to local" step are undocumented, and the shared-hostnqn bug lives only in a memory file. Recovery was repeatable by *one* person; making it repeatable by *any* engineer is the difference between a resilient system and a fragile one.
+
+---
+
+## Incident Timeline, Root Causes & Mistakes
+
+Single-control-plane OpenShift cluster `ocp.igou.systems` (control plane on MS-01 = `10.10.9.10`; workers `hpg5` + `truenas-w1` KubeVirt VM; `p330` dead/no-BMC) was **destroyed by a stale netboot pin that auto-reinstalled the control-plane node**, wiping etcd and all local disk state. The cluster was fully rebuilt on 4.21.9 and all high-value persistent data restored from TrueNAS. At the time of writing the cluster is healthy (`ClusterVersion 4.21.9 Available`, all 3 nodes `Ready`, hermes VM `Running`, rhdh/forgejo CNPG DBs `healthy`, quay-pg still `Setting up primary`).
+
+### Timeline (times UTC, 2026-07-03)
+
+| Time | Event |
+|---|---|
+| 2026-04-23 | OpenShift PXE install artifacts staged on the boot server (latent). |
+| 2026-05-11 | Netboot migration arms rb5009 pin `netboot/per-host/MAC-5847ca77098a.ipxe` **defaulting to `install-openshift` on a 30s timeout** — the landmine sits armed for ~7 weeks. |
+| ~17:00 | **Unattended reboot of MS-01.** UEFI BootOrder is netboot-first (PXE I226-V → PXE I226-LM → disk LAST, 3s), the pin's 30s default fires `install-openshift`, and the agent-based installer wipes the 990 PRO. Mid-install reboot re-enters PXE → **reinstall loop** (installs forever). Old cluster is unrecoverable (etcd/state overwritten). PV zvols on TrueNAS survive. |
+| (recovery) | hermes state rescued off old zvols before touching anything: `hermes-home-root-20260703.tar.zst` (6.8G) + `hermes-state-20260703.tar.zst` (11.9G), `zstd -t` verified, from snapshot clones `ssd/k8s/rescue-hermes-{root,state}`. Pull secret recovered from the live installer host. |
+| (recovery) | Fresh 4.21.9 PXE artifacts regenerated via `playbooks/openshift/agent-install/deploy_pxe_assets.yml` (bypassing dead 1Password via `-e @override.yml` + `--skip-tags op-save`), uploaded to TrueNAS nginx boot dir; safe pin (default `local`) staged. |
+| 18:24 | **Loop broken:** pin flipped to default-`local` at `status=installing`. |
+| 18:31 | Mid-install reboot boots FROM DISK (not PXE) — loop is dead. |
+| ~18:38 | Control-plane node `Ready`; CVO climbing toward 4.21.9. |
+| ~19:20 | **Install complete:** `ClusterVersion 4.21.9 Available`. 21 essential Argo apps applied, 28 non-essential deferred (`igou-openshift#383` merged); `inv#120` merged (pin default `local` — durable fix). |
+| (recovery) | User supplies a working "dr" 1Password service-account token (all 5 vaults); secrets re-seeded (`op-credentials`, `onepassword-connect-token`). GitOps re-bootstrapped via `playbooks/openshift/hub-cluster/bootstrap_gitops.yaml`; 2 real bugs found + fixed + merged (`ansible#312`). ArgoCD root-applications + 21 apps Synced. |
+| ~21:51 | **Both workers re-joined** (`hpg5` by PXE add-node, `truenas-w1` by `oc adm node-image` ISO). CSR-approval column bug (below) cost ~40 min here. |
+| (recovery) | Waves restored in order by un-commenting `clusters/ocp/values.yaml` blocks: wave 1 stateless/CAPI/CNV/tenants (`#384`), wave 2 observability (`#385`), wave 3 hermes-agent (`#386`) + CNPG DB restores from Barman (`#387`/`#388`) + all remaining file apps + AAP (`#389`). All 49 apps re-enabled in git. |
+| (recovery) | hermes VM re-provisioned fresh; state PV re-formatted xfs and 1.4G of essential `.hermes` restored from backup (excluding regenerable `./containers`). |
+
+### Root Causes
+
+**Technical**
+- **Boot order + destructive default.** MS-01 boots network before disk (disk is LAST, 3s), and the per-host iPXE pin's *default* menu entry was the destructive `install-openshift` on a 30s timeout. Any reboot with no operator at the console self-selects a full disk-wiping reinstall.
+- **Agent installer is unconditionally destructive and self-looping.** It wipes the target disk on entry, and its own mid-install reboot re-enters PXE → the installer runs again. There is no "already installed, boot local" guard — the loop only breaks by flipping the pin to `local` *while* `status=installing`.
+- **Latent NVMe identity collision (separate but cluster-wide).** The agent-based install baked the **same** `/etc/nvme/hostnqn` and `/etc/nvme/hostid` (`nqn.2014-08.org.nvmexpress:uuid:466937ab-67bf-4315-971b-bc110d55ce28`) into **all three** RHCOS nodes — confirmed live on `10.10.9.10`, `hpg5`, and `10.10.9.21`. This violates NVMe-oF host-identity uniqueness and causes intermittent volume-attach failures (it bit the hermes state disk during restore). Still unfixed.
+
+**Process**
+- **The pin was never disarmed after the original install.** Left defaulting to `install-openshift` since the 2026-05-11 netboot migration — a ~7-week armed landmine with no expiry and no alarm.
+- **No off-cluster etcd/control-plane backup.** Only PV zvols survived, and only because democratic-csi's backing store lives on TrueNAS, not on the node. Cluster identity (etcd) had no recovery point — the rebuild was a fresh install, not a restore.
+- **Single control plane = single point of total loss.** Wiping the one master is game-over; there is no HA quorum to survive one node.
+- **No alerting** that a production control-plane node's netboot pin pointed at a destructive install, nor that its boot order preferred network over disk.
+
+### What Went Well
+
+- **Data survived and was recoverable.** Democratic-csi zvols on TrueNAS were untouched by the node wipe; `p330`'s death and the MS-01 wipe cost no persistent data.
+- **Backups existed and were verified.** hermes state was captured to `zstd`-verified tarballs *before* any restore action; CNPG Barman backups on RustFS enabled clean DB recovery (rhdh 111 tables, forgejo 128 tables, quay WAL-replaying) via `bootstrap.recovery` + `externalClusters` barman plugin.
+- **GitOps made config reproducible.** The app-of-apps pattern meant the entire application tier (49 apps) was rebuilt by un-commenting `values.yaml` blocks and letting ArgoCD reconcile — no hand-rebuilding. The "rebuild from original" trick (`git show <defer-commit>^:...values.yaml`, re-comment only still-deferred apps) made staged restore clean.
+- **The loop was broken correctly and durably.** Flipping the pin to `local` at `status=installing` (18:24) stopped the reinstall loop, and `inv#120` merged the pin default to `local` so this exact failure cannot recur.
+- **Recovery hardened the runbook.** Two genuine DR bugs in `bootstrap_gitops.yaml` were found, fixed, and merged (`ansible#312`: Connect JWT lives in the item's `credential` field not `token`; `onepassword_doc` returns bytes needing `|b64encode` + `data:` not `stringData`), plus `ansible#311` (publish path). Future DR runs are less fragile.
+- **Workers rejoined largely unattended** once the CSR selector was corrected (monitor auto-approves the CSRs).
+
+### Mistakes That Cost Time
+
+1. **CSR condition parsed by wrong column — ~40 min (largest single loss).** The monitor used `awk '$5=="Pending"'` but `oc get csr` puts CONDITION in **column 6**, so it silently matched nothing while 9 node-bootstrapper CSRs piled up and both workers hung un-joined. *Prevent:* never positionally-`awk` `oc get` output; select on the API field — `oc get csr -o go-template='{{range .items}}{{if not .status}}{{.metadata.name}}{{"\n"}}{{end}}{{end}} | xargs oc adm certificate approve`.
+
+2. **truenas-w1 VM guest clock in local time → x509 "cert not yet valid".** VM `time` was `LOCAL`, so the guest RTC ran ~4h behind and Ignition's `GET api-int:22623/config/worker` failed x509 because the MCS cert's valid-from was the reinstall time (18:23). Cost multiple restart/debug cycles. *Prevent:* provision KubeVirt/TrueNAS VMs with `time: UTC` (`midclt call vm.update <id> '{"time":"UTC"}'`); RHCOS assumes hwclock=UTC.
+
+3. **truenas-w1 netboot RAW `.dsk` mechanism is broken.** A raw `netboot.xyz.efi` written to a disk device is not a valid ESP, so UEFI drops to the EFI shell instead of netbooting. Dead-end before switching to the working method (`oc adm node-image create --dir` → 1.4G ISO → attach as CDROM → full QEMU restart). *Prevent:* for TrueNAS `vm.*` workers use the node-image ISO/CDROM path; document the RAW-dsk approach as non-viable.
+
+4. **STALE local checkout rendered OLD manifests.** `/workspace/igou-openshift` was ~100 commits behind, so `oc kustomize` from it produced obsolete YAML (quay got `initdb` instead of `recovery`). *Prevent:* always `git fetch` and apply from `git show origin/main:<path>` during DR; treat the local checkout as untrusted.
+
+5. **CNPG recovery WAL-archive collision.** Recovery failed `WAL archive check failed: Expected empty archive` because the archiving plugin's `serverName` still pointed at the non-empty source path; also the stuck full-recovery Job had to be deleted so CNPG recreated it. Cost debugging on all three DBs (`#387`/`#388`). *Prevent:* on `bootstrap.recovery`, set the archiving `serverName` to a NEW value (`<db>-r<date>`) up front and `oc delete job -l cnpg.io/jobRole=full-recovery` after changing it.
+
+6. **1Password share link burned on first load.** The first backup SA-token share link (view-once) was consumed by a headless-browser preflight load; the re-issued SA was then deleted server-side (403). *Prevent:* extract view-once share links on the FIRST real page load with clipboard capture; never pre-load them in a bot/preview.
+
+7. **Recurring wave-gate stalls.** The app-of-apps gates wave N+1 on wave N *health*, so any transient operator-install degrade (service-accounts, grafana, cluster-api) or a slow repo-server render stalled the whole pipeline repeatedly. Two systemic fixes were needed live: patch ArgoCD `resourceHealthChecks` for the read-only-token PushSecret 403s (so `service-accounts` reports Healthy), and bump repo-server to cpu=2 + `ARGOCD_EXEC_TIMEOUT=3m` (heavy helm render of `clusters/ocp/` exceeded the default 90s on 1 CPU). *Prevent:* fold both patches into `hub-cluster/bootstrap_gitops.yaml` (they are currently LIVE-ONLY on a playbook-managed ArgoCD CR and will be lost on re-run).
+
+8. **Boot-file permissions (rsync 750 → nginx 403).** `rsync -a` set the boot-files dir to 750; nginx returned 403 on the PXE artifacts until `chmod 755`. Small but on the critical install path. *Prevent:* `chmod 755` the publish dir after rsync (the `ansible#311` publish-path fix addresses this class).
+
+9. **Large-file transfer over `virtctl port-forward` is flaky.** The WebSocket drops ~1006 after ~5 min on multi-GB single streams, which is why the hermes state restore had to exclude `./containers` (10.5G) to fit. Not fatal (containers are regenerable) but forced a workaround. *Prevent:* for byte-exact multi-GB restores, `dd` the old zvol clone directly rather than tar-over-port-forward.
+
+### Still Open (carried into follow-ups)
+
+- **Fix the shared NVMe hostnqn/hostid cluster-wide** (MachineConfig regenerating `/etc/nvme/hostnqn`+`hostid` where `==466937ab` + rolling reboot) — a real correctness bug; **do NOT stop/start the hermes VM until fixed.**
+- Fold the live-only ArgoCD CR patches (PushSecret health-check + repo-server cpu/timeout) into `bootstrap_gitops.yaml`.
+- Revert CNPG `bootstrap.recovery` → `initdb` in git once DBs confirmed healthy (so a future re-sync doesn't re-trigger recovery).
+- Optional per-app file-PV restores from preserved old zvols (e.g. jellyfin config `pvc-3f5e1c03`); hermes convergence + operator-deferred go-live.
+
+---
+
+## GitOps Repository Review
+
+Reviewer scope: the `igou-io/igou-openshift` app-of-apps repo as it stands at `origin/main`
+(`d81e454`, all 49 apps re-enabled). Focus: the failure modes the 2026-07-03 control-plane
+reinstall actually stressed — sync-wave gating, the ArgoCD instance config, CNPG
+backup/restore state, the 1P Connect/ESO secret bootstrap, and the netboot/agent-install
+coupling. Every finding below was cross-checked against the live cluster.
+
+Findings are ranked by blast radius. Each is written to be a single, self-contained PR.
+
+---
+
+### 1. [CRITICAL — data-loss landmine + permanent drift] Three CNPG clusters are frozen in `bootstrap.recovery`
+
+`applications/forgejo/forgejo-pg-cluster.yaml`, `components/quay-operator/quay-pg-cluster.yaml`,
+and `components/rhdh/rhdh-pg-cluster.yaml` all still carry the disaster-recovery bootstrap in
+git, with the `initdb` block commented out:
+
+```yaml
+bootstrap:
+  recovery:
+    source: forgejo-pg          # restores the pre-disaster Barman base backup
+externalClusters:
+  - name: forgejo-pg
+    plugin:
+      parameters:
+        barmanObjectName: forgejo-pg-backup
+        serverName: forgejo-pg          # <-- PRE-DISASTER archive path
+```
+
+Meanwhile the live cluster now **archives WAL to a *different* serverName**
+(`serverName: forgejo-pg-r20260704`, confirmed on-cluster). Two distinct problems fall out
+of this, both verified live:
+
+**(a) Rebuild-time silent rollback.** `bootstrap` only runs when a `Cluster` is created from
+scratch. If ArgoCD ever prunes+recreates the `Cluster` (namespace re-create, a bad prune, or
+the next full DR), CNPG will re-bootstrap from `serverName: forgejo-pg` — the **frozen
+2026-07-02 base backup** — and every byte written since the recovery is silently gone. The
+recovery source points at the *old* archive, not the live `-r20260704` one the DB is writing
+to now. This is the single most dangerous line in the repo.
+
+**(b) Permanent `OutOfSync` today.** `.spec.bootstrap` is immutable after init; CNPG's webhook
+has already defaulted the live object (`recovery: {database: app, owner: app, source: …}`) so
+it no longer matches git. I confirmed the `forgejo` and `rhdh` ArgoCD apps are `OutOfSync`
+for exactly one resource each — `Cluster/forgejo-pg` and `Cluster/rhdh-pg` — and they will
+never converge because Argo cannot patch an immutable field back to the git shape.
+
+**PR:** For all three clusters, (i) restore `bootstrap.initdb` as the desired rebuild state
+(quay/registry, backstage, and forgejo are all cheaply re-seedable; or keep `recovery` **only
+if** you repoint the recovery `serverName` to the live `-r20260704` archive so a rebuild
+restores *current* data), and (ii) add an `ignoreDifferences` on `/spec/bootstrap` (and the
+operator-defaulted `/spec/externalClusters/.../isWALArchiver`) for these apps so the immutable
+live field stops holding the app `OutOfSync`. `gitea-pg` and `temporalio-pg` are already on
+`initdb` — this revert is well-scoped to the three recovered DBs. Do **not** simply flip git
+to `initdb` with no `ignoreDifferences` — that trades a landmine for a permanent SyncFailed.
+Also unify the inconsistent sync-waves: `rhdh-pg` uses `sync-wave: '10'` while forgejo/quay
+use `'-1'`.
+
+---
+
+### 2. [CRITICAL — cluster-wide correctness] All 3 nodes share one NVMe `hostnqn`/`hostid`, and no MachineConfig fixes it
+
+Confirmed live on every node (`/etc/nvme/hostnqn` **and** `/etc/nvme/hostid`):
+
+```
+master 10.10.9.10  : nqn.2014-08.org.nvmexpress:uuid:466937ab-67bf-4315-971b-bc110d55ce28
+hpg5               : nqn.2014-08.org.nvmexpress:uuid:466937ab-67bf-4315-971b-bc110d55ce28
+truenas-w1 10.10.9.21: nqn.2014-08.org.nvmexpress:uuid:466937ab-67bf-4315-971b-bc110d55ce28
+```
+
+The agent-based install baked one NVMe host identity into every RHCOS node. NVMe-oF requires
+uniqueness per host; this already caused the hermes state volume to fail to attach on a second
+node during recovery and risks data corruption on the `freenas-nvmeof-*` storage classes the
+whole cluster depends on. There is nothing in `clusters/ocp/machineconfigs/` addressing it.
+
+**PR:** Add `clusters/ocp/machineconfigs/99-nvme-unique-host-identity-machineconfig.yaml` — a
+systemd oneshot (Ignition) that, when `/etc/nvme/hostnqn` still contains `466937ab…`, runs
+`nvme gen-hostnqn > /etc/nvme/hostnqn` + `uuidgen > /etc/nvme/hostid` and reboots. Ship it for
+**both** `master` **and** `worker` roles.
+
+**Related gap in the same PR:** `99-master-load-nvme-tcp-machineconfig.yaml` loads the
+`nvme-tcp` module for the **master role only**, but nvmeof volumes attach on workers too (the
+hermes state disk landed on hpg5). Add a worker-role counterpart, or collapse both into a
+single all-roles MC. Cross-reference `docs/runbooks/nvmeof-stuck-multiattach.md` — the
+control-plane `nodeSelector` pinning on every CNPG cluster is a *workaround* for this same
+storage fragility.
+
+---
+
+### 3. [HIGH — the recovery-critical ArgoCD tuning is not in git at all]
+
+The ArgoCD `argocd.argoproj.io/ArgoCD` CR is **absent from this repo** (`git grep 'kind: ArgoCD'`
+→ nothing). It is created out-of-band by `igou-ansible` `bootstrap_gitops.yaml`. During the
+incident two fixes were applied **live-only**, and I confirmed both are present on the running
+CR but nowhere in git:
+
+- `spec.repo`: `resources.limits {cpu: 2, memory: 2Gi}` + env `ARGOCD_EXEC_TIMEOUT=3m`. This
+  was the root cause of the recurring "Unknown"/`context deadline exceeded` wave stalls — the
+  helm render of `clusters/ocp/` blows past the default 90s on 1 CPU.
+- `spec.resourceHealthChecks`: a lenient Lua health-check for `external-secrets.io/PushSecret`
+  (and `ExternalSecret`) that reports `Healthy` even when the outbound 1P publish 403s.
+
+Both evaporate the next time the bootstrap playbook runs — i.e. the exact tuning that let the
+cluster converge during DR is the tuning most likely to be missing during the *next* DR.
+
+**PR (in this repo, preferred):** Self-manage the ArgoCD CR via GitOps — add a wave-`0`
+`openshift-gitops-config` Application (or a component under `clusters/ocp/`) that owns the
+`ArgoCD` CR including the repo-server resources, `ARGOCD_EXEC_TIMEOUT`, and both health-checks.
+Argo managing its own instance is the idiomatic fix and makes the tuning durable and reviewable.
+(Fallback, if instance management must stay in Ansible: codify all three in
+`bootstrap_gitops.yaml` — that's a companion PR for the ansible-repo reviewer.) Either way the
+current state — the cluster's own controller config existing only as an un-versioned live patch
+— is the biggest single process gap the incident exposed.
+
+---
+
+### 4. [HIGH — architecture] One monolithic health-gated app-of-apps serialized the entire recovery
+
+`root-applications` renders all 43 child `Application`s from `clusters/ocp/values.yaml` with a
+single monotonic `sync-wave` ladder (0 → 50). ArgoCD will not create/sync wave N+1 until every
+wave-N `Application` is `Synced` **and** `Healthy`. In steady state that's fine; in DR it means
+**any** degraded low-wave app freezes everything above it. The incident hit this hard:
+`service-accounts` (wave 40) was `Degraded` on 403 PushSecrets → `openshift-virt` (wave 50) and
+all higher waves could not even be created, and manually creating a gated app got pruned by the
+root app. Recovery became a serial "fix wave, unstick, refresh, repeat" grind.
+
+Three PR-sized improvements, in priority order:
+
+1. **Codify the operator-bootstrap toil as a sync option.** The recurring manual pattern
+   ("apply ns+OG+Subscription, wait CSV Succeeded, then sync with
+   `SkipDryRunOnMissingResource=true`") exists because CR-consuming apps fail dry-run before
+   their CRD is installed (CNV/HyperConverged→CDI→StorageProfile, cluster-api providers, quay,
+   loki). Add `syncOptions: [SkipDryRunOnMissingResource=true]` to those specific apps in
+   `values.yaml`. This is the highest-leverage, lowest-risk DR-toil reducer.
+2. **Split the monolith into a few independent roots** — e.g. `platform` (operators/storage/
+   networking, waves 0–12), `services` (observability/pipelines/tenants), `apps` (user
+   workloads + CNPG). A failure in the apps tier then no longer gates platform reconvergence,
+   and each root converges in parallel. Keep intra-root waves only where a real CRD/operator
+   dependency exists.
+3. **Rationalize the wave map.** Many apps share the same wave (six at wave 6, five+ at wave
+   10, ~ten at wave 20) so the ordering is already coarse; document which crossings are real
+   dependencies vs incidental, and drop waves that don't encode a true prerequisite so fewer
+   apps can gate each other.
+
+---
+
+### 5. [MEDIUM — honesty of desired state] Broken-by-design PushSecrets are masked by a live-only health-check
+
+`components/service-accounts/values.yaml` defines 6 `pushSecrets` (into vaults `ocp-push` and
+`claude`) that **cannot succeed** — the Connect token is read-only, so every push 403s forever.
+Today they're only "green" because of the live-only `PushSecret` Lua health-check (finding #3),
+which is not in git. That's two layers of hidden state papering over a permanent failure.
+
+**PR:** Make git tell the truth. Either (a) set `enabled: false` on those 6 pushSecrets in
+values.yaml — the chart already gates on `if $push.enabled` (`.helm/charts/service-account-access/
+templates/pushsecrets.yaml`), so this cleanly stops generating doomed resources; or (b) grant
+Connect a write-scoped token for those vaults and keep them. Option (a) removes the dependency
+on the out-of-band health-check patch entirely and is the honest representation of the
+operator's stated choice to leave publishing off.
+
+---
+
+### 6. [MEDIUM — bootstrap ordering is undocumented in-repo] The whole tree hinges on two hand-seeded secrets
+
+Everything under ESO — the `ClusterSecretStore`s
+(`clusters/ocp/external-secrets-operator/onepassword-sdk-*.yaml`), every `ExternalSecret`, the
+CNPG S3 creds, hermes — transitively depends on two secrets that must exist **before** GitOps
+can converge, and which no manifest in the repo can create:
+
+- `op-credentials` (ns `onepassword-connect`, key `1password-credentials.json`) — consumed by
+  the Connect helm chart in `components/onepassword-connect/kustomization.yaml`
+  ("pre-seeded out-of-band (Task 4)").
+- `onepassword-connect-token` (ns `external-secrets-operator`, key `token`) — the Connect JWT.
+
+This is architecturally correct (a chicken-and-egg root of trust), but it was a real recovery
+blocker and the only record is the incident memory file. Two live bugs bit during DR and belong
+in a checked-in runbook so the next operator doesn't rediscover them: the Connect JWT lives in
+the 1P item's **`credential`** field (not `token`), and `onepassword_doc` returns **bytes** so
+the k8s Secret needs base64 + `data:` (not `stringData`).
+
+**PR:** Add `docs/runbooks/dr-secrets-bootstrap.md` documenting the exact seed order, the two
+secret shapes/namespaces, and those two gotchas. No manifest change — this is the missing
+"step 0" of every restore.
+
+---
+
+### 7. [MEDIUM — the actual root cause has no in-repo guardrail or runbook] netboot pin default
+
+The disaster trigger (rb5009 per-host netboot pin defaulting to `install-openshift` on a 30s
+timeout against a netboot-first MS-01) lives in `igou-inventory`/`igou-ansible`, not here, so
+the fix is out of scope for this repo — but two things about it are in-scope:
+
+- There is **no DR runbook** in `docs/runbooks/` for "control plane was wiped → reinstall →
+  re-bootstrap GitOps → restore PVs." The entire blow-by-blow exists only in the session memory
+  file. That sequence (regen agent-install PXE artifacts → flip pin to `local` → re-join workers
+  + CSR-approve → `bootstrap_gitops.yaml` → CNPG Barman restore) should be a checked-in runbook,
+  since it's now proven and will be needed again.
+- Worth a one-line note in that runbook cross-referencing `igou-inventory#120` (pin default must
+  be `local`): the highest-leverage prevention for the whole incident is a one-word default in
+  another repo, and this repo's DR doc is the natural place to make that dependency visible.
+
+---
+
+### 8. [LOW — hygiene / consistency]
+
+- **Root-app prune semantics.** `default.app.autoSyncPrune: false` plus the root app's own
+  prune behavior explains why manually-created gated apps got pruned during DR. Document the
+  root-applications prune model so operators don't fight it mid-incident.
+- **Dated serverName is now permanent.** `serverName: <db>-r20260704` is a one-off DR string
+  baked into git; the ObjectStore `destinationPath` prefix now accumulates two server dirs per
+  DB (`…/forgejo-pg` and `…/forgejo-pg-r20260704`). Fine operationally, but note it in the CNPG
+  runbook so the next restore knows which prefix is live.
+- **DR failure-domain caveat is real.** `docs/runbooks/cnpg-backup-restore.md` already flags
+  that the TrueNAS S3 backup target shares a failure domain with primary DB storage (same
+  TrueNAS box). Combined with finding #1, a TrueNAS loss + a `Cluster` recreate is a
+  double-jeopardy path worth an explicit off-box backup consideration.
+
+---
+
+### Fastest wins
+
+If only three PRs get merged: **#1** (stop the CNPG rollback landmine — it's an active
+`OutOfSync` today and a silent data-loss on the next rebuild), **#2** (unique NVMe host
+identity — a confirmed cluster-wide correctness bug), and **#3** (get the ArgoCD repo-server
+tuning + health-checks into git so the next DR converges instead of stalling). #4.1
+(`SkipDryRunOnMissingResource` on operator apps) is the cheapest single change that would have
+saved hours of manual unsticking during this recovery.
+
+---
+
+## Ansible Repository Review
+
+Reviewed against `origin/main` @ `1a341c9` (local checkout was 35 commits stale;
+all findings are on fetched `origin/main`, not the working tree). Scope: the
+GitOps bootstrap, the netboot pin / agent-install PXE flow and its safety
+defaults, the hermes convergence playbooks, and the drift between the *live*
+ArgoCD CR and the playbook that renders it.
+
+Files reviewed:
+- `playbooks/openshift/hub-cluster/bootstrap_gitops.yaml`
+- `playbooks/openshift/bootstrap_openshift_gitops.yaml` (stale duplicate)
+- `playbooks/openshift/agent-install/deploy_pxe_assets.yml`
+- `playbooks/openshift/add_node_iso.yml`, `vm_worker_destroy.yaml`, `vm_worker_reprovision.yaml`
+- `playbooks/openshift/templates/nodes-config.yaml.j2`
+- `playbooks/netboot/deploy_assets.yml` + `tasks/{preflight,render_menu,push_pins_rb5009,verify}.yml` + `templates/{menu,host-mac,entry-chainload}.ipxe.j2`
+- `playbooks/hermes/{setup-os,setup-hermes,configure,provision-vm}.yml` + `templates/hermes-egress.nft.j2`
+- `docs/disaster-recovery.md`, `docs/openshift-operations.md`, `molecule/openshift-bootstrap-crc/converge.yml`
+
+---
+
+### CRITICAL
+
+#### C1 — The DR runbook points operators at the WRONG, stale bootstrap playbook
+`docs/disaster-recovery.md` (step 4, "Rebuild from scratch", line ~255) instructs:
+```
+ansible-playbook playbooks/openshift/bootstrap_openshift_gitops.yaml \
+  -i igou-inventory/inventory.yaml -e target_cluster=<cluster>
+```
+But this session's recovery actually used **`playbooks/openshift/hub-cluster/bootstrap_gitops.yaml`** — which is where the two 1Password-Connect bugs were found and fixed (PR #312). The referenced `bootstrap_openshift_gitops.yaml` was last touched **2026-04-11** (`954320c`) and is a pre-Connect relic. Following the DR doc verbatim during the next disaster fails hard:
+- It has **neither fix**: it seeds a single `onepassword-token` Secret from an **undefined** `onepassword_token` var (no `vars_prompt`, no lookup), and never seeds the Connect `op-credentials` / `onepassword-connect` namespace at all.
+- It parameterizes on **`cluster_name`**, not `target_cluster`; the doc's `-e target_cluster=<cluster>` leaves `cluster_name` undefined → the cluster-config kustomize lookup errors.
+- It applies from the **old repo path** `config/<cluster>/live/base-config/`, not the current `clusters/<cluster>` app-of-apps layout.
+- It puts the OperatorGroup in `openshift-operators`, not `openshift-gitops-operator`.
+
+The same stale playbook is also wired into `molecule/openshift-bootstrap-crc/converge.yml` and cited in `docs/openshift-operations.md`, so CI is validating the wrong artifact.
+**Fix:** delete/redirect `bootstrap_openshift_gitops.yaml` to the hub-cluster playbook, update the DR doc + openshift-operations doc + molecule converge to `playbooks/openshift/hub-cluster/bootstrap_gitops.yaml`, and correct the invocation.
+
+---
+
+### HIGH
+
+#### H1 — Live-only ArgoCD fixes are not folded back into the playbook CR (next bootstrap silently reverts them)
+The ArgoCD CR is created imperatively by `hub-cluster/bootstrap_gitops.yaml` (not GitOps-managed), so any live edit persists only until the playbook is re-run — and the next DR re-runs it. Diffing the live `openshift-gitops` ArgoCD CR against the playbook shows two meaningful live-only deltas:
+
+| Field | Playbook (git) | Live cluster (in-use) |
+|---|---|---|
+| `spec.repo.env` | `KUSTOMIZE_PLUGIN_HOME=/etc/kustomize/plugin` | `ARGOCD_EXEC_TIMEOUT=3m` |
+| `spec.repo.resources.limits` | cpu `1` / mem `1Gi` | cpu `2` / mem `2Gi` |
+| `spec.repo.resources.requests` | cpu `250m` / mem `256Mi` | cpu `500m` / mem `512Mi` |
+
+Both are real reliability fixes for the app-of-apps sync: `ARGOCD_EXEC_TIMEOUT=3m` raises the repo-server's default 90s exec ceiling that the `kustomize build --enable-helm | envsub` CMP pipeline blows through (manifests "context deadline exceeded"), and the bumped repo-server resources prevent OOM during those helm-heavy builds. Note the playbook's `KUSTOMIZE_PLUGIN_HOME` on `repo.env` is largely inert anyway — the CMP **sidecar** already receives it via `envFrom` the `environment-variables` ConfigMap. **Fix:** set `repo.env` to include `ARGOCD_EXEC_TIMEOUT: 3m` (keep KUSTOMIZE_PLUGIN_HOME if desired) and raise `repo.resources` to 2 CPU / 2Gi in the playbook CR. (Minor, same CR: the `resourceCustomizations: | argoproj.io/Application: health.lua: |` block is empty and superseded by `resourceHealthChecks`; live has it empty — drop it.)
+
+#### H2 — netboot per-host pins have no safe-default guard (this is the incident's root cause)
+The shared fallback menu is safe-by-design: `templates/menu.ipxe.j2` uses
+`choose --timeout 30000 --default local target || goto local` and a `:local` label that `sanboot`s the disk. **Per-host pins bypass that entirely** — `templates/host-mac.ipxe.j2` emits raw `{{ pin.fragment }}` from inventory with no wrapping. `tasks/preflight.yml` validates the MAC format and forces "Form 3 (fragment) only", but performs **zero content safety checks** on the fragment. A pin whose fragment auto-selects an install target on a short timeout with no local fallback — exactly what re-imaged MS-01 (`10.10.9.10`) when an unattended reboot hit the 30s install-default — passes every assertion. The recovery's "flip the pin to default-local" is a manual, undefended-in-code convention.
+**Fix (highest-value safety change):** add a preflight assertion that every pin fragment either contains a local-boot default (`sanboot`/`goto local` as the `choose --default`) **or** carries an explicit opt-in like `allow_install: true`. Bonus: for any host that is already a joined cluster node, the pin should default-local — the agent-install/PXE path has no interlock preventing an install→reboot→install loop, which is what turned a single wipe into a loop.
+
+---
+
+### MEDIUM
+
+#### M1 — Pin push is size-only idempotent and verify checks only presence → a corrected same-size pin is silently not deployed
+`tasks/push_pins_rb5009.yml` re-uploads a pin **only when the router file size differs** (`/file print count-only where name=... and size=...`), and `tasks/verify.yml` asserts only that the pin **file exists** and a `/ip tftp` row exists — never that the on-router **content** matches the render cache. An edit that changes a fragment while keeping byte-length identical (plausible for an install↔local swap of similar length — the precise class of change made during recovery) would neither trigger re-upload nor be caught by verify, leaving the dangerous pin live. **Fix:** compare a content hash (fetch + sha256, or push unconditionally on any render change) instead of size, and have verify compare content, not presence.
+
+#### M2 — `hub-cluster/bootstrap_gitops.yaml`: fixed 60s sleep + no-retry ArgoCD create, and unguarded `target_cluster`
+- The play does `pause: seconds: 60` then `Create ArgoCD Object` with **no `retries`**. If the GitOps operator hasn't Established the `argoproj.io/v1beta1 ArgoCD` CRD within 60s (cold catalog pull, slow InstallPlan), the create fails the run. The downstream `root-applications` Application has `retries: 50`, but the CR that everything depends on does not. **Fix:** replace the blind sleep with a `k8s_info` wait for the ArgoCD CRD (or the operator CSV `Succeeded`), and add retries to the CR create.
+- `target_cluster` is defaulted only on the `hosts:` line (`{{ target_cluster | default('all') }}`) but is then referenced **unguarded** in the `environment-variables` ConfigMap (`CLUSTER_NAME: '{{ target_cluster }}'`) and the root Application path (`clusters/{{ target_cluster }}`). Invoked without `-e target_cluster`, `hosts` resolves to `all` while `target_cluster` stays undefined → templating error mid-run. **Fix:** add an early `assert target_cluster is defined`.
+
+#### M3 — The shared NVMe `hostnqn`/`hostid` latent bug is unremediated on the Ansible side
+`git grep` for `hostnqn|hostid|/etc/nvme` across `origin/main` returns nothing, and neither `deploy_pxe_assets.yml`, the `openshift_agent_install` role, nor `nodes-config.yaml.j2` sets a per-node NVMe identity. Because all three nodes PXE/ISO-boot the same RHCOS agent image, they inherit an identical `/etc/nvme/hostnqn`/`hostid` (the `...466937ab...` collision from the incident), which breaks NVMe-oF uniqueness and drives the intermittent democratic-csi nvmeof attach failures. The durable fix is likely a per-node Ignition/MachineConfig in the GitOps repo, but flagging here because the **agent-install flow is where the identity is (not) seeded** — at minimum the nodes-config/agent-install path should regenerate a unique hostnqn per host so a fresh reinstall doesn't reintroduce the collision.
+
+---
+
+### LOW
+
+#### L1 — Play name vs body drift in `hub-cluster/bootstrap_gitops.yaml`
+The play is named *"…add an ansible serviceaccount and save the token to 1password"*, but **no task in it creates an ansible ServiceAccount or writes any token to 1Password**. `docs/disaster-recovery.md` compounds this by claiming the `onepassword-sdk-<cluster>-push-token` item is "written by `bootstrap_openshift_gitops.yaml`" — it is not written by either playbook today. Misleading during a time-pressured recovery. **Fix:** rename the play to match reality, and correct the DR doc's provenance note (or re-add the SA/token task if AAP still depends on it).
+
+#### L2 — `deploy_pxe_assets.yml` copies the admin kubeconfig to a world-readable /tmp path
+Play 1's *"Copy auth files to /tmp/auth"* writes the cluster auth dir (including `kubeconfig` with embedded admin `client-key-data`) to `/tmp/{{ target_cluster }}-auth/` at **`mode: "0644"`**. On a shared host that is a world-readable cluster-admin credential. **Fix:** `0600` and a non-shared destination (or clean it up in an `always`).
+
+---
+
+### Confirmed-correct / positives (no action)
+- **Both session bugs are correctly fixed in `origin/main`:** the Connect JWT is read from the item's `credential` field via the `onepassword` lookup into `stringData.token`; the credentials JSON is read via `onepassword_doc` and, because it returns bytes (ansible-core ≥2.19 won't serialize bytes as module args), correctly placed under `data:` with `| b64encode`. The inline comments capturing *why* are excellent.
+- **Egress SSH keep-alive fix present:** `hermes-egress.nft.j2` includes `tcp sport 22 accept` with a precise comment explaining the mid-run default-drop wedge (matches memory `734f7c1`).
+- **Worker lifecycle safety is solid:** `vm_worker_destroy.yaml` has a pre-drain guard that refuses to touch a node not mapped to a `truenas_vms` entry (prevents draining a mistyped-but-real bare-metal node); `add_node_iso.yml` computes pending-vs-joined workers, validates MAC format, and fails fast on an empty/all-joined group. Both VM-lifecycle playbooks are still marked `!! UNTESTED (2026-07-03)` — de-risk before relying on them in a DR.
+- Hermes convergence phasing (setup-os/setup-hermes in the egress-open window, configure under lock), the pinned-image (`!= latest`) assertions, the `play-vars-outrank-group_vars` shadowing notes, and the tirith SHA-256-verified download are all sound.
+
+---
+
+## Architecture & Environment Review
+
+**Reviewer scope:** live read-only inspection of the rebuilt cluster (2026-07-04), resilience assessment, and verification of the critical shared-NVMe-identity bug. All findings below were confirmed against the running cluster and the three nodes over SSH.
+
+### Current state (healthy, but structurally fragile)
+
+| Property | Observed |
+|---|---|
+| Version | 4.21.9, ClusterVersion `Available=True`, all 34 ClusterOperators `Available`, none `Degraded` |
+| Control plane | **1 node** — `ocp.igou.systems` / MS-01 / 10.10.9.10, role `control-plane,master,worker` |
+| etcd | **single member** `etcd-ocp.igou.systems` (5/5, 11 restarts from the rebuild) — no quorum, no redundancy |
+| Workers | `hpg5.igou.systems` (10.10.9.240 kube-internal / 10.10.9.x mgmt), `truenas-w1` (10.10.9.21, KubeVirt VM on TrueNAS) |
+| p330 | dark permanently (no BMC, cannot be power-cycled) — do not design around it |
+| Machine API | **no `Machine` / `ControlPlaneMachineSet` objects** (agent-based/UPI install); one CAPI `casval-worker` MachineSet scaled to 0 |
+| Default StorageClass | `freenas-nvmeof-ssd-csi` — democratic-csi, RWO, `ext4`, `reclaimPolicy: Delete`, `Immediate` binding, single TrueNAS target |
+| Network | OVNKubernetes; NNCP `mapping`/`mapping-hpg5` Applied |
+
+The cluster is *functionally* healthy. The concern is entirely about resilience: every one of the failure modes that caused the 2026-07-03 disaster (or was uncovered during recovery) is still latent.
+
+---
+
+### 1. CRITICAL — all three nodes share one NVMe host identity (CONFIRMED)
+
+Verified by reading `/etc/nvme/hostnqn` and `/etc/nvme/hostid` on each node:
+
+| Node | `/etc/nvme/hostnqn` | `/etc/nvme/hostid` |
+|---|---|---|
+| 10.10.9.10 (master) | `nqn.2014-08.org.nvmexpress:uuid:466937ab-67bf-4315-971b-bc110d55ce28` | `466937ab-67bf-4315-971b-bc110d55ce28` |
+| hpg5.igou.systems | `nqn.2014-08.org.nvmexpress:uuid:466937ab-67bf-4315-971b-bc110d55ce28` | `466937ab-67bf-4315-971b-bc110d55ce28` |
+| 10.10.9.21 (truenas-w1) | `nqn.2014-08.org.nvmexpress:uuid:466937ab-67bf-4315-971b-bc110d55ce28` | `466937ab-67bf-4315-971b-bc110d55ce28` |
+
+**All three are byte-identical.** The agent-based installer baked a single NVMe host identity into the RHCOS image and every node booted with it. All three nodes then connect as the *same host* to the same TrueNAS NVMe-oF subsystem — confirmed live: each node holds `transport=tcp` controllers to `nqn.2011-06.com.truenas:uuid:116c7577-...` while presenting the identical hostnqn.
+
+**Why this is a correctness/data-integrity bug, not cosmetics:**
+- NVMe-oF requires a globally unique `hostnqn`/`hostid` per initiator. The target (TrueNAS) uses hostnqn for connection tracking, namespace masking, and reservation ownership. Two initiators sharing one hostnqn is undefined behavior.
+- Observed symptom during recovery: the hermes VM's second `nvmeof-ssd` disk failed to attach on hpg5 while its root disk was attached on the master — the target saw a "host" that already held a controller, producing intermittent `Connect command failed` / `unable to attach any nvme devices` / `failed to write to nvme-fabrics device`. It "recovered" only by retry and by recreating the PVC.
+- With RWO volumes and shared identity, the target cannot reliably distinguish which physical node owns a namespace → real risk of a namespace being presented to two nodes at once → **filesystem corruption**, not just attach failures.
+
+This bug is currently masked because workloads are lightly spread and most PVCs happen to bind on the node that first connects. It will resurface on any reschedule, drain, node reboot, or KubeVirt live-migration.
+
+#### Exact remediation — self-generating MachineConfig (day-2) + agent-install day-1
+
+A static Ignition file cannot fix this: a MachineConfig writes *identical* content to every node in a pool, which is exactly how they became identical. The correct pattern is a **systemd oneshot that generates a unique identity at boot** and is idempotent (only rewrites when the value is missing or equals the known-duplicated UUID). MCO reboots the node to apply the unit, and on that boot the unit runs before the NVMe fabric autoconnect, so CSI reconnects with the new identity.
+
+Script `/usr/local/bin/regen-nvme-hostid.sh` (embedded in the MachineConfig):
+
+```bash
+#!/usr/bin/env bash
+set -euo pipefail
+DUP_ID="466937ab-67bf-4315-971b-bc110d55ce28"
+mkdir -p /etc/nvme
+cur_id="$(cat /etc/nvme/hostid 2>/dev/null || true)"
+if [ ! -s /etc/nvme/hostnqn ] || [ ! -s /etc/nvme/hostid ] || [ "$cur_id" = "$DUP_ID" ]; then
+  newid="$(uuidgen)"
+  printf 'nqn.2014-08.org.nvmexpress:uuid:%s\n' "$newid" > /etc/nvme/hostnqn
+  printf '%s\n' "$newid" > /etc/nvme/hostid
+fi
+```
+
+Butane source (transpile with `butane --strict`; produce **one MachineConfig per pool** — `master` and `worker` — since they are separate MachineConfigPools):
+
+```yaml
+variant: openshift
+version: 4.21.0
+metadata:
+  name: 99-worker-unique-nvme-hostid      # + a 99-master-... copy with role: master
+  labels:
+    machineconfiguration.openshift.io/role: worker
+storage:
+  files:
+    - path: /usr/local/bin/regen-nvme-hostid.sh
+      mode: 0755
+      contents:
+        local: regen-nvme-hostid.sh       # or inline data: URL
+systemd:
+  units:
+    - name: regen-nvme-hostid.service
+      enabled: true
+      contents: |
+        [Unit]
+        Description=Generate a unique NVMe host identity (hostnqn/hostid)
+        DefaultDependencies=no
+        After=local-fs.target
+        Before=nvmf-autoconnect.service systemd-udev-settle.service kubelet.service
+        [Service]
+        Type=oneshot
+        RemainAfterExit=yes
+        ExecStart=/usr/local/bin/regen-nvme-hostid.sh
+        [Install]
+        WantedBy=multi-user.target
+```
+
+Rollout notes:
+- Add these to `clusters/ocp/machineconfigs/` and its `kustomization.yaml` (alongside the existing `99-master-load-nvme-tcp`). MCO drains + reboots one node at a time; the master reboot is a brief single-node API blip (unavoidable with one control-plane node — schedule it).
+- **Order matters vs. the shared target:** roll the workers first, then the master, and validate `hostnqn` differs on each node between steps, so you never briefly have two *rebooting* nodes racing new identities against live attachments.
+- **Verify after:** `for n in 10.10.9.10 hpg5.igou.systems 10.10.9.21; do ssh core@$n sudo cat /etc/nvme/hostnqn; done` → three distinct UUIDs; then confirm TrueNAS shows three distinct connected hosts.
+
+**Close the loop for future reinstalls (this is essential):** the disaster proved a full reinstall is a real event here. Bake the *same self-generating oneshot* into the agent-install day-1 manifests (`openshift/` manifests dir consumed by `deploy_pxe_assets.yml` in igou-ansible) so that **every** freshly installed node gets a unique identity from first boot. Otherwise the next DR reinstall silently reintroduces the identical-hostnqn bug.
+
+---
+
+### 2. HIGH — single control-plane topology has zero fault tolerance
+
+One etcd member, one master. There is no quorum, no failover, and (below) no backup. Loss of MS-01 — hardware fault, the exact netboot-reinstall that happened, or a bad disk — is **total, immediate cluster loss**. The 2026-07-03 event only destroyed one host; a 3-node control plane would have kept quorum on the other two and survived it outright.
+
+Recommendation, in priority order:
+1. **Preferred: go to a compact 3-node control plane** (3 schedulable masters). The hardware already exists — MS-01 + hpg5 + truenas-w1 are all cluster members today. Promoting hpg5 and truenas-w1 to control-plane members would have survived this disaster and every future single-host loss. This is the single biggest resilience win available. (Caveat: truenas-w1 is a VM *on* the TrueNAS box that also serves all PV storage — co-locating an etcd member there couples control-plane and storage failure domains; MS-01 + hpg5 + a third bare-metal host is cleaner if one can be found.)
+2. **If single-node is retained as a deliberate homelab tradeoff:** it must be paired with (a) automated etcd backups (section 3), (b) `Retain` reclaim on irreplaceable PVs (section 5), and (c) a rehearsed, IaC-driven rebuild. Recovery here worked but took hours of manual, undocumented-until-now steps.
+
+---
+
+### 3. HIGH — no etcd backup existed, and still does not
+
+Confirmed: **no** etcd-backup CronJob in any namespace, **no** backup PV, nothing. During the disaster etcd state was unrecoverable; the cluster was rebuilt from scratch and PV data survived *only by luck* (see section 5). For a single-member etcd this is the difference between a 10-minute restore and a multi-hour ground-up rebuild.
+
+Recommendation:
+- Enable OpenShift's built-in **automated etcd backup** (`config.openshift.io/v1alpha1 Backup` / periodic backup via cluster-etcd-operator) writing to a dedicated PVC, and manage it in GitOps.
+- The backup destination must be a **different failure domain** than the control-plane host — do not write etcd snapshots to a democratic-csi/TrueNAS volume that itself depends on the cluster being up, and never to MS-01's local disk. Ship snapshots off-cluster to TrueNAS/RustFS on a schedule (the same RustFS bucket pattern already used for CNPG Barman backups), so a snapshot survives even total cluster loss.
+- Document and periodically rehearse `cluster-restore.sh` from a snapshot on this single-node topology.
+
+---
+
+### 4. HIGH — netboot-first boot order is still the loaded gun that caused the disaster
+
+Root cause of 2026-07-03: MS-01 firmware `BootOrder` lists PXE NICs *before* the local disk with a 3s timeout, and the rb5009 served a per-host iPXE pin that defaulted to `install-openshift` on a 30s timeout. An unattended reboot netbooted straight into the agent installer, wiped the disk, and looped (mid-install reboot → PXE → reinstall).
+
+Current mitigation (per recovery notes, inv#120 merged): the router pin now defaults to `local`. That is necessary but **not sufficient** — the firmware still boots PXE first, so cluster safety depends entirely on one router text file never regressing to an install target. This is fragile defense-in-depth-of-one.
+
+Recommendation:
+- **Set MS-01 (and all nodes') firmware to boot the local disk first**; keep PXE available only as a manual, human-selected option. Netboot should never be the default path for an installed production node.
+- Make the netboot menu's default a **no-op / local-disk chainload with a long, human-gated timeout**, and move `install-openshift` behind an explicit, non-default menu entry so an unattended reboot can never trigger a reinstall.
+- Physically/logically separate "install" artifacts from the routine netboot path, and treat arming an install pin as a deliberate, time-boxed action (arm → install → auto-disarm), never a persistent default.
+
+---
+
+### 5. MEDIUM/HIGH — democratic-csi NVMe-oF is a single point of failure with known multi-attach fragility
+
+- **Single target, no multipath:** all nine democratic-csi StorageClasses (iscsi/nfs/nvmeof × cold/fast/ssd) point at one TrueNAS box. TrueNAS down = all persistent storage down cluster-wide. The default class is `nvmeof-ssd`.
+- **RWO multi-attach wedge is a documented, recurring incident** (`docs/runbooks/nvmeof-stuck-multiattach.md`, issue #295, upstream democratic-csi #536/#559): after a transport blip the NVMe controller renumbers, `NodeUnstageVolume` loops on a missing device, the PV sticks in the old node's `volumesInUse`, and a rescheduled pod hangs on `Multi-Attach` — cascading to every app in the namespace. The shared-hostnqn bug (section 1) makes this class of failure *more* likely, not less.
+- **The permanent #295 fix (`ctrl_loss_tmo=-1` via a persistent udev rule/MachineConfig) is NOT deployed.** No `/etc/udev/rules.d/*nvme*` rule exists on any node. Live TCP controllers currently read `ctrl_loss_tmo=off` (set by the driver's connect options), so the *behavior* is partly present at runtime but is **not host-enforced or persistent** — it depends on the driver reconnecting with the right args and is lost on any path that doesn't. Land the #295 MachineConfig so `ctrl_loss_tmo=-1` is guaranteed at the host level (accepting the documented tradeoff: I/O queues indefinitely during a storage outage rather than erroring).
+- **`nvme-tcp` boot-load gap:** the only module-load MachineConfig is `99-master-load-nvme-tcp` — **master role only**. Workers (which do the bulk of nvmeof mounts) have `nvme_tcp` loaded today *only* because democratic-csi modprobes it at runtime. Add a `worker` (or all-role) variant so the module is guaranteed at boot and a worker reboot can't race the driver.
+
+Recommendations: land #295; add the worker `nvme-tcp` MachineConfig; for workloads that reschedule frequently and cannot tolerate the multi-attach wedge, prefer an RWX/NFS class over RWO nvmeof; and treat TrueNAS as the SPOF it is (its own backup/HA story is out of this cluster's scope but should be acknowledged in DR planning).
+
+---
+
+### 6. MEDIUM — PV data survival was luck, not design (`reclaimPolicy: Delete`)
+
+Every democratic-csi StorageClass, including the default, is `reclaimPolicy: Delete`. Deleting a PVC destroys the backing zvol. Data survived the disaster **only because the cluster died without issuing any CSI delete calls** — the old zvols were orphaned, not deleted, and were later re-mounted read-only on TrueNAS to fingerprint and restore them. A "cleaner" failure (e.g., a GitOps prune that deleted PVCs) would have permanently destroyed the data.
+
+Recommendation:
+- Set `reclaimPolicy: Retain` on the classes holding irreplaceable data (or per-PV), so an accidental PVC/namespace deletion or an errant Argo prune leaves the zvol intact.
+- Keep maintaining the application-level backups that actually saved this recovery (CNPG Barman → RustFS for quay/rhdh/forgejo; hermes state tarballs), and keep the PVC→zvol catalog (`/workspace/backups/ocp-pv-catalog-20260703.txt`) current — it was the map that made restore possible.
+
+---
+
+### 7. MEDIUM — CSR auto-approval is not guaranteed for these nodes
+
+`machine-approver` is running, but there are **no `Machine` objects** backing the bare-metal nodes (agent-based install). The standard approver only auto-approves CSRs it can tie to a Machine; during the worker rejoin, node bootstrap/serving CSRs had to be **approved manually** (recovery notes describe 9 `node-bootstrapper` CSRs piling up, and a column-offset gotcha that hid them). There are no pending CSRs right now, but kubelet **serving-certificate CSRs rotate on renewal**, and if they are not approved the node's metrics/logs/`oc exec`/kubelet-serving endpoints silently break, and eventually the node degrades.
+
+Recommendation:
+- Add monitoring/alerting on **pending CSRs** (`oc get csr` with unapproved conditions) so a stuck serving-cert renewal is caught before it degrades a node — remembering the condition is in the last column, not `$5`.
+- Do **not** deploy a blanket auto-approver as a shortcut; auto-approving serving CSRs without Machine backing is a known privilege/impersonation risk. If automation is wanted, scope it tightly to expected node identities.
+
+---
+
+### Summary of recommended hardening (priority order)
+
+1. **Unique NVMe identity** — ship the self-generating `99-*-unique-nvme-hostid` MachineConfig for both pools *and* bake it into agent-install day-1 (fixes the confirmed corruption-risk bug and prevents its reintroduction on the next reinstall).
+2. **Move to a 3-node control plane** (or, if single-node is deliberate, treat it as ephemeral and back it accordingly).
+3. **Enable automated etcd backups** to an off-cluster, different-failure-domain destination.
+4. **Firmware boot-disk-first + human-gated netboot install** so an unattended reboot can never reinstall a node.
+5. **Land the #295 `ctrl_loss_tmo` MachineConfig** and add a **worker `nvme-tcp` load** MachineConfig.
+6. **`reclaimPolicy: Retain`** on irreplaceable-data StorageClasses/PVs; keep app-level backups + PVC→zvol catalog current.
+7. **Alert on pending CSRs**; avoid an unscoped auto-approver.
+
+---
+
+## Perspective: Kubernetes / OpenShift Administrator
+
+**Cluster:** `ocp` (OpenShift 4.21.9), single control-plane on MS-01 (`ocp.igou.systems`, 10.10.9.10) + 2 workers (`hpg5`, `truenas-w1` KubeVirt VM). `p330` permanently dark.
+**Reviewed:** 2026-07-04, read-only. All 33 cluster operators `Available=True, Degraded=False`; ClusterVersion 4.21.9 stable; 3/3 nodes Ready, no node pressure. The restore landed the cluster in a genuinely healthy baseline. The findings below are about making it *easier and safer to run*, ranked by operational risk.
+
+---
+
+### 1. The control plane is schedulable AND unguarded — highest structural risk
+
+- `ocp.igou.systems` carries roles `control-plane,master,worker` with **no taints**. User workloads co-schedule with etcd and kube-apiserver on the *single* control-plane node. It is already carrying real load (`oc adm top`: 35% mem / 13% cpu, 32 GiB used), while the two workers sit at 9–11% mem — the scheduler is packing the worst-possible node.
+- **Zero `ResourceQuota` and zero `LimitRange` on every user namespace** checked (hermes, jellyfin, quay, rhdh, forgejo, llmkube, searxng, gotify, firecrawl — all `quota=0 limitrange=0`). CNPG DB pods (`rhdh-pg`, `forgejo-pg`) set requests but **no memory limits**.
+- **Why this matters:** on a single-member etcd cluster there is no quorum to absorb a stumble. One bursty/leaky workload (llmkube model cache, quay GC, a firecrawl queue) can drive `MemoryPressure`/`DiskPressure` on the etcd node → etcd fsync stalls → API latency and evictions → cascading control-plane instability. Nothing today prevents an unbounded pod from starving the API server.
+- **Recommendations:**
+  - Preferred: taint the master `NoSchedule` and run user workloads only on `hpg5`/`truenas-w1`. If capacity genuinely requires scheduling on the master, then at minimum:
+  - Add a per-namespace `ResourceQuota` + default `LimitRange` (default requests/limits) via a namespace template so *nothing* runs unbounded; set explicit memory limits on CNPG/quay/registry pods.
+  - Confirm the `kubeletconfig` app (it exists in the app-of-apps) sets `system-reserved`/`kube-reserved` on the master so kubelet protects the control plane from workload memory.
+  - Add a `PriorityClass` split (control-plane-adjacent vs. best-effort user apps) so the node-pressure evictor sacrifices user apps first.
+
+### 2. etcd: single member, no automated backup — the disaster is a coin-flip from repeating
+
+- One etcd member (expected for single control plane), DB 786 MB, healthy. But there is **no automated etcd backup**: no `EtcdBackup`, no `etcd.spec.backup`, no backup CronJob, nothing shipping snapshots off-node.
+- The whole incident was triggered by etcd/disk state being wiped and **unrecoverable**. A single-member etcd with no scheduled snapshot means the *next* disk/node loss is again a full rebuild — the exact multi-hour path just walked.
+- **Recommendation:** enable OpenShift 4.21's built-in scheduled etcd backups to a PVC backed by the TrueNAS CSI (lands off the etcd node), or a CronJob running `cluster-backup.sh` shipped to RustFS/TrueNAS. Pair with a written `quorum-restore` runbook. This is the single cheapest change that would convert a repeat of this event from a rebuild into a ~20-minute restore.
+
+### 3. Nodes are not Machine-API managed → CSR auto-approval is a recurring landmine
+
+- `oc get machines` returns none; workers are agent/PXE (UPI-style). The only MachineSet is `casval-worker` (scaled to 0). `machine-approver` only auto-approves CSRs for **Machine-backed** nodes.
+- Consequence: kubelet-client and kubelet-**serving** CSRs for `hpg5` and `truenas-w1` never auto-approve. This is precisely what produced the 9 piled-up `node-bootstrapper` CSRs during recovery. Kubelet serving certs rotate on a schedule; when they do, `oc logs/exec/adm top` against that node silently starts failing with x509 until a human approves the serving CSR.
+- **Recommendation:** deploy a scoped auto-approver for the known, static node set — a small controller/CronJob that approves only `Pending` CSRs whose CN matches `system:node:<one-of-the-3-known-hostnames>` from the expected requester. At absolute minimum, alert on `Pending` CSRs and document the *correct* approval one-liner from the postmortem (`go-template` on `not .status`; remember the CSR CONDITION is **column 6**, not 5 — the naive `awk '$5=="Pending"'` silently matches nothing and cost ~40 min during recovery).
+
+### 4. The ArgoCD instance is un-versioned and carries load-bearing hand-patches
+
+- The `ArgoCD` CR has **no GitOps tracking annotation** — it is created by an Ansible playbook and then hand-patched live. Confirmed load-bearing live-only patches present on the running CR:
+  - `repo.resources` cpu 2 / mem 2Gi + `ARGOCD_EXEC_TIMEOUT=3m` — the fix for the `DeadlineExceeded` wave stalls caused by heavy Helm render of `clusters/ocp/` on 1 CPU.
+  - `resourceHealthChecks` Lua for `PushSecret` (+ `ExternalSecret`, `Subscription`, `InstallPlan`, `ClusterSecretStore`) — the `PushSecret` check is what un-gates every wave > 40 despite the intentionally read-only push token.
+- These are the exact settings that make the cluster *operable*, yet they exist only in the running cluster and a playbook (the postmortem lists "fold live-only ArgoCD CR patches into bootstrap_gitops.yaml" as an **open** TODO). If the playbook re-runs or the CR is recreated, the cluster silently reverts to the hard-to-operate state: repo-server timeouts return and the wave gate wedges on `service-accounts` being Degraded.
+- **Recommendation:** make the ArgoCD CR first-class version-controlled config — bake the resources/timeout/health-checks into the idempotent bootstrap playbook, and ideally have Argo self-manage its own CR (an app-of-apps entry that owns the ArgoCD CR) so drift on these operability-critical settings is *visible* instead of tribal.
+
+### 5. App-of-apps sync-wave model is brittle on a 3-node cluster
+
+- The model gates wave N+1 on wave N being Synced **and Healthy**. During recovery this repeatedly stalled the whole chain when a transient operator-install Degrade (service-accounts, grafana, cluster-api) flapped at a lower wave.
+- Compounded by the recurring **operator-then-CR ordering** friction: operator installs are async, so operand CRs fail dry-run until the CSV lands (CNV `StorageProfile` needs the `cdi` CRD from `HyperConverged`; quay needs its operator first). Recovery had to repeatedly hand-apply `Namespace`+`OperatorGroup`+`Subscription`, wait for CSV `Succeeded`, then sync with `SkipDryRunOnMissingResource=true`.
+- **Recommendations:**
+  - Structurally split "install the operator" (Subscription/OG in an earlier wave) from "apply the operand CR" (later wave) and set `SkipDryRunOnMissingResource=true` + ServerSideApply on operand apps, so a not-yet-present CRD stops *gating* the whole cluster.
+  - Gate operator apps on CSV `Succeeded` (the InstallPlan/Subscription health checks already exist) rather than broad app health that flaps mid-install.
+  - Decouple independent user apps from one long linear wave chain so a single flapping app doesn't block unrelated ones.
+  - Keep the repo-server perf patch (item 4) — it was the root cause of many `Unknown`/`DeadlineExceeded` stalls.
+
+### 6. Live/git drift on the CNPG databases = latent data-loss landmine
+
+- `forgejo`, `rhdh`, `quay-operator`, `openshift-pipelines`, `pac-tenants`, and `root-applications` are **OutOfSync** (`root-applications` also Progressing). The DB apps' `syncPolicy.automated.selfHeal=true`.
+- Root cause for the DBs: **git still declares `bootstrap.recovery`** (restore-from-Barman) with an in-file comment "Revert to the initdb block below once recovered and verified," while the live archiving `serverName` was patched to a new value during recovery. The child apps are stuck OutOfSync and not converging — self-heal is silently failing on the immutable `bootstrap` field, which *masks* the drift rather than resolving it.
+- **Danger:** git is committed in one-shot RECOVERY mode. If any CNPG `Cluster` CR is recreated or force-synced from git, CNPG will re-run a full Barman recovery **over the now-live database**. Leaving a stateful DB's git source in recovery mode is a data-loss trap.
+- **Recommendation (matches the postmortem's own open TODO):** once DBs are verified healthy, change git back to steady-state (drop the `recovery` block / represent the already-bootstrapped cluster) and reconcile the live archiving `serverName` into git so the apps go Synced. Add guards on CNPG `Cluster` CRs: `argocd.argoproj.io/sync-options: Prune=false` and treat `bootstrap` as `ignoreDifferences` so an accidental sync can never re-bootstrap a live DB.
+
+### 7. Operator lifecycle: mixed approval strategies + entangled global namespace
+
+- Most Subscriptions are `Automatic`. `servicemeshoperator3` is `Manual` with **two pending unapproved InstallPlans** for `v3.3.5` while `v3.2.0` runs — this is why `openshift-pipelines` shows OutOfSync/stuck.
+- `servicemesh` and `pipelines` share the global `openshift-operators` OperatorGroup, and InstallPlan `install-khg9h` bundles **both** CSVs (`servicemeshoperator3.v3.3.5` + `openshift-pipelines-operator-rh.v1.22.4`). Approving/upgrading one entangles the other — the worst kind of coupling for upgrades on a cluster with no test tier.
+- Several subs float on unpinned channels (`openshift-gitops-operator=latest`, `openshift-pipelines=latest`, `rhdh=fast`). Floating channel + `Automatic` approval = surprise operand migrations with no staging.
+- **Recommendations:**
+  - Pick one policy and hold it: pin channels to specific streams; commit to `Automatic` (accept auto-upgrades) *or* `Manual` and actually process the queue — a half-approved Manual queue is the worst of both and is currently wedging pipelines.
+  - Move workload operators out of the shared `openshift-operators` global namespace into their own namespace+OperatorGroup (single-/own-namespace install mode) so their InstallPlans don't co-mingle. Pipelines and ServiceMesh must not share an InstallPlan.
+  - Resolve the stuck `servicemesh` InstallPlan (approve or decline) so `openshift-pipelines` stops flapping OutOfSync.
+
+### 8. Root-cause of the incident, from a day-2 lens
+
+- The self-destruct latch was **netboot-first boot order + a stale per-host PXE pin defaulting to `install-openshift` on a 30 s timer**, plus an installer path that re-enters on a mid-install reboot (loop). `inv#120` (pin default=local) is merged, but the durable invariant to enforce is: *an unattended reboot must never be able to reinstall a node.* That means disk-first boot order with PXE as an explicitly, manually-armed one-shot that disarms after first boot, and a fail-safe pin (`local` default). Treat "can a reboot wipe this node?" as a design gate, not a config detail.
+
+### 9. Housekeeping / smaller items
+
+- **RBAC posture is actually good** and worth preserving: purpose-scoped SAs (`cluster-read-only`→`cluster-reader`, `cluster-edit`→`edit` scoped to one ns, `virtualmachine-*` custom roles, `ansible-molecule`→`node-reader`). The **only** non-system SA at `cluster-admin` is the ArgoCD application-controller (`gitops-cluster-admin`) — standard for an app-of-apps that installs operators, but it is the largest blast radius on the cluster; consider constraining via AppProject destination/namespace/resource allow-lists even if the cluster-admin binding stays.
+- **PushSecrets all `Errored` by design** (read-only push token — an accepted choice). Side effect: the 6 minted SA tokens (`cluster-edit`, `cluster-read-only`, `claude-edit`, `ns-agent`, `virtualmachine-ops`, `ansible-molecule`) are **not** published to 1Password, so there is no out-of-band copy. Document that they are on-cluster-only, or fix the token.
+- **Leftover installer static pods** in `openshift-kube-{apiserver,controller-manager,scheduler}` (7 in `Error`/`ContainerStatusUnknown`) — cosmetic residue of control-plane rollouts; they accumulate. Harmless but worth periodic GC/awareness.
+- **PDBs on single-replica components** (`image-registry`, `nmstate-webhook` minAvailable semantics; `console` maxUnavailable=1) can block `oc adm drain` on a 3-node cluster during maintenance — verify a planned drain doesn't wedge before you need it in an emergency.
+- **NVMe hostnqn/hostid collision** (from the postmortem: all 3 nodes share `nqn…466937ab…`) is a correctness bug that intermittently fails volume attach cluster-wide; it belongs on this list as an open day-2 item — resolve via a MachineConfig that regenerates unique `/etc/nvme/hostnqn`+`hostid` per node, then roll reboots. Until fixed, avoid stop/start of KubeVirt VMs on nvmeof-backed volumes.
+
+---
+
+### Priority summary
+
+| # | Change | Why | Effort |
+|---|--------|-----|--------|
+| 1 | Taint master / add ResourceQuota+LimitRange to user namespaces | Stop workloads from starving the single control plane | Low–Med |
+| 2 | Enable scheduled etcd backup off-node + restore runbook | Turn the next etcd loss into a restore, not a rebuild | Low |
+| 3 | Scoped CSR auto-approver (or alert + runbook) for the 3 static nodes | Serving-cert rotation silently breaks node access | Med |
+| 4 | Version-control the ArgoCD CR + its health-check/perf patches | The settings that make the cluster operable are tribal/live-only | Low |
+| 5 | Revert CNPG git bootstrap out of recovery mode + `Prune=false`/ignore `bootstrap` | selfHeal + committed recovery mode risks re-nuking live DBs | Low |
+| 6 | Split operator-install from operand-CR waves; de-couple global-namespace operators | Ends the recurring operator-then-CR gate stalls | Med |
+| 7 | Resolve/settle the Manual servicemesh InstallPlan; pin channels | Unwedge pipelines; stop surprise upgrades | Low |
+| 8 | Fix NVMe hostnqn/hostid uniqueness (MachineConfig) | Correctness — intermittent volume-attach failures | Med |
+
+---
+
+## Perspective: Site Reliability Engineer
+
+**Reviewer role:** Site Reliability Engineer
+**Scope:** Detection, blast radius, backup/restore coverage, observability/alerting gaps, recovery toil, runbook readiness, MTTR/MTTD, and prioritized reliability improvements.
+**Verdict:** The cluster was fully recovered and no committed data was permanently lost — a credit to zvol persistence and Barman. But recovery succeeded *despite* the design, not because of it. The incident exposed a self-amplifying destroy path (netboot-first + install-default pin + reinstall loop), a total absence of cluster-state backup (no etcd snapshot, no OADP), an alerting pipeline that dies with the cluster it monitors, and a recovery that was almost entirely manual and improvised. Every one of these is fixable with low-to-moderate effort.
+
+---
+
+### 1. Incident reconstruction: MTTD and MTTR
+
+| Phase | Approx. time (UTC) | Elapsed | Notes |
+|---|---|---|---|
+| Trigger: unattended reboot → PXE → agent installer wipes 990 PRO | ~17:00 | T+0 | Disk wiped; install then *loops* (mid-install reboot → PXE → reinstall) |
+| Detection | (operator-noticed) | **unbounded** | No external alert fired — see §2 |
+| Pin flipped to `local`, disk boot | 18:24–18:31 | ~T+1h30m | Loop broken manually |
+| Master `Ready`, ClusterVersion `Available` 4.21.9 | 18:38–19:20 | ~T+2h20m | Control plane back |
+| GitOps bootstrapped, 21 essential apps Synced | evening | ~T+3h | Secrets seeded out-of-band by human |
+| Both workers re-joined (hpg5 PXE, truenas-w1 ISO) | ~21:51 | ~T+5h | CSR-approval gotcha cost ~40 min |
+| DB restores (rhdh/forgejo/quay Barman) + hermes state | overnight → 2026-07-04 | **T+12h+** | Multi-step, manual, spanned into next day |
+
+**MTTR ≈ 2.3h** to a live control plane, **~5h** to workers + core apps, **12h+** to substantially-restored data — all with a skilled operator working the problem continuously.
+
+**MTTD is the more alarming metric: effectively unbounded.** There is no external heartbeat (see §2). Detection depended on a human noticing a service was down. Had this happened while unattended, the cluster could have sat destroyed — and *looping through reinstall attempts* — for hours or days.
+
+---
+
+### 2. Detection & observability gaps (the alerting pipeline dies with the cluster)
+
+The entire alert path is **in-cluster and self-referential**:
+
+- Alertmanager (`alertmanager-main`), UWM Prometheus + thanos-ruler, and the `alertmanager-gotify-bridge` push relay all run **on the cluster being monitored**.
+- The EDA→AAP→GitHub-issue pipeline runs on **AAP, which is on the same cluster**.
+- Slack is reached via `slack.com`, but the *sender* (Alertmanager) is in-cluster.
+- `blackbox-exporter` exists but is **in-cluster** (`Active 3h22m`) — it probes outward; it cannot report that the cluster itself is dead.
+- The standard `Watchdog` alert is `null`-routed (correct for its usual purpose) but there is **no external consumer** turning Watchdog silence into a page.
+
+**Consequence:** the failure mode that matters most (whole-cluster loss) is precisely the one that produces **zero alerts**. This is the classic "who watches the watcher" gap, and it is the direct cause of the unbounded MTTD.
+
+Additional observability gaps found live:
+
+- **Platform Prometheus has no persistent storage** (`prometheus/k8s .spec.storage` empty → emptyDir). All platform metric history is lost on every reboot/reschedule — so there is no post-mortem telemetry across the very reboot that destroyed the cluster.
+- UWM Prometheus/thanos-ruler retention is only **15d**, and their PVCs sit on `freenas-nvmeof-fast-csi` — the same NVMe-oF stack carrying the shared-hostnqn attach bug (§4).
+- **The push receiver is currently down post-recovery:** namespace `gotify` is `NotFound`, so the Alertmanager `gotify` / `gotify-and-slack-*` webhook targets (`alertmanager-gotify-bridge.gotify.svc`) have no backend right now. The cluster is presently running with its primary push-notification path broken.
+
+---
+
+### 3. Single points of failure (blast radius)
+
+**3a. Netboot-first boot + install-default pin = a single router file can wipe the cluster.**
+MS-01 firmware BootOrder is PXE→PXE→disk on a 3s timeout (a *firmware* setting, not in git). The rb5009 per-host pin defaulted to `install-openshift` on a 30s timeout, armed since 2026-05-11 and sitting latent for ~2 months. A routine unattended reboot was sufficient to trigger a **full disk-wipe reinstall**. The blast radius of one stale iPXE file on the router is *the entire cluster*.
+
+The fix applied (pin default `local`, inv#120) removes the immediate trap, but the underlying foot-guns remain:
+- The netboot template **still contains an `install-openshift` menu that defaults to install on a 30s timeout** (`group_vars/all/netboot.yml`: `choose --timeout 30000 --default install-openshift target || goto local`). Any future pin pointed at that menu re-arms the bomb. The guardrail is "which menu the pin references," not "install menus can never be the unattended default."
+- MS-01 firmware is still **netboot-first with disk last**, so every boot depends on the router serving a *safe* pin. Router misconfig, TFTP drift, or a re-added stale pin reproduces the disaster.
+
+**3b. The reinstall loop is self-amplifying.** The mid-install reboot re-enters PXE and reinstalls again — a failure that *repairs itself into permanence*. Without a human flipping the pin at exactly the "installing" moment, the box never escapes.
+
+**3c. Single control-plane node — no etcd quorum, no auto-repair.** Confirmed: `1 members are available`, no `controlplanemachineset`. Losing MS-01's disk = losing the whole cluster with no HA fallback. There is no Machine-API-managed control plane to auto-reprovision.
+
+**3d. Single TrueNAS holds all persistent state.** Every PV zvol, every Barman bucket, the boot artifacts (nginx), and truenas-w1 itself live on one TrueNAS box. DR worked *only* because MS-01's local disk was wiped while TrueNAS survived. A TrueNAS-side failure would have been unrecoverable — there is no offsite replication of the zvols documented.
+
+**3e. Shared NVMe host identity (latent, still unfixed).** All 3 nodes carry the identical `hostnqn`/`hostid` (`...466937ab...`) baked in by the agent installer. This violates NVMe-oF uniqueness and already caused intermittent "unable to attach nvme" failures during recovery, with a **data-corruption risk** on the shared democratic-csi NVMe-oF target. This is an active reliability + correctness landmine across all NVMe-oF volumes.
+
+---
+
+### 4. Backup / restore coverage
+
+| Data class | Backup mechanism | Gap |
+|---|---|---|
+| **etcd / cluster state** | **NONE** | No etcd snapshot cronjob, no OADP. DR = full reinstall. `openshift-adp` ns absent; `redhat-oadp-operator` component exists in-repo but is **not enabled** in `clusters/ocp/values.yaml`. |
+| Namespaces / PVs / app CRs as a set | **NONE** | No Velero/OADP → no consistent point-in-time restore of app resources + PVs together. |
+| CNPG databases (quay/rhdh/forgejo) | Barman → RustFS-cold | Backup target is on **spinning rust that was recently wedged** (`rustfs-cold-disk-health-wedge`); had to be un-wedged mid-incident before restores could run. quay base backup was from **2026-06-10** (~3 weeks stale) — recovered only because WAL replay covered the gap. |
+| hermes agent state | **Ad-hoc tar taken during the incident** from a zvol snapshot | No scheduled hermes backup existed. Recoverable purely because the zvol survived and an operator manually snapshotted/tar'd it. |
+| PV zvols (jellyfin, app data) | Implicit — zvols persisted on TrueNAS | No snapshot *schedule* and no offsite replication documented. "It survived because only the other machine got wiped" is not a backup strategy. |
+
+**Bottom line:** RPO for cluster state is effectively "since last GitOps commit" (config is reconstructable) but RPO for *data* ranged from good (DB WAL) to "whatever happened to still be on a zvol." There was **no designed, tested, scheduled DR backup** — recovery leaned on luck (zvols survived, RustFS could be un-wedged, an operator was available to improvise).
+
+---
+
+### 5. Recovery toil & manual steps
+
+The recovery was a tour de force of manual operations. Each of these is a place where a tired or less-expert operator would have added hours or lost data:
+
+- **Secrets bootstrap chicken-and-egg:** AAP, 1Password Connect, and ESO all ran *on* the destroyed cluster, so every `op` lookup was dead. A human had to hand-seed `op-credentials` + the Connect token out-of-band. One 1P view-once share link was **burnt by a headless-browser preload**; the replacement SA was deleted server-side — nearly blocking recovery entirely.
+- **Manual pin flips at exact install phases** (per host: MS-01, hpg5, truenas-w1) with "verify pin content on the router after every deploy."
+- **Manual CSR approval** with a silent gotcha (`oc get csr` condition is column 6, not 5) that cost ~40 min while bootstrapper CSRs piled up.
+- **Manual per-operator subscription bootstraps** (CNV, loki) to break app-of-apps wave-gate deadlocks.
+- **Live-only ArgoCD CR patches** (repo-server cpu/timeout, PushSecret health-check) that are **not in git** and will be lost on the next `bootstrap_gitops.yaml` run — the recovery hardening itself is undocumented drift.
+- **Manual zvol fingerprinting** (mount-ro-and-inspect) to map old PVCs→apps.
+- **Barman `serverName` juggling** (must bump to a new value or recovery fails "Expected empty archive"; must delete the stuck full-recovery Job).
+- **Flaky data transfer:** hermes state moved via `virtctl port-forward` which dropped (~1006 websocket) on multi-GB streams, forcing manual exclusion of the `containers` dir to fit.
+- **VM clock bug:** truenas-w1's `time: LOCAL` put the guest RTC ~4h behind → Ignition x509 "cert not yet valid" until manually set to UTC.
+
+None of this was automated. The MTTR was low *only because* a single expert operator held the entire runbook in their head in real time.
+
+---
+
+### 6. Runbook readiness
+
+There was **no pre-existing DR runbook.** The `project-ocp-cluster-reinstall.md` memory file is an excellent *post-hoc* record, but it was written *during* the fire. Nearly every gotcha (CSR column, cert rotation x509, VM UTC clock, Barman serverName, secrets bootstrap order, wave-gate deadlocks, repo-server timeout) was discovered live. There is:
+
+- No documented, tested recovery procedure.
+- No DR drill / game-day history.
+- No verified RTO/RPO targets to design toward.
+
+---
+
+### 7. Prioritized reliability recommendations
+
+Priorities: **P0** = do before the next reboot (prevents recurrence / detects loss); **P1** = weeks; **P2** = quarter.
+
+#### P0 — Stop the bleeding
+
+1. **Kill the netboot-first destroy path (defense in depth).**
+   - Set MS-01 (and hpg5) firmware BootOrder to **disk-first, PXE fallback** so a reboot never depends on the router serving a safe pin. Netboot only when deliberately re-imaging.
+   - In `group_vars/all/netboot.yml`, make **`local` the hard default of every menu**; require an explicit, short-lived, deliberately-armed pin to install. Never ship an install-default-on-timeout menu that a pin can point at by accident.
+   - Add a CI/lint check that fails if any committed per-host pin defaults to an install target.
+2. **External dead-man's-switch / heartbeat.** Stand up an off-cluster watchdog (e.g. Uptime-Kuma or a healthchecks.io push) on TrueNAS or a Pi that (a) probes the OpenShift API + a canary Route every 60s and (b) expects a periodic Watchdog-derived heartbeat *from* the cluster; page (Gotify/Slack/Telegram) on silence. This closes the unbounded-MTTD gap — the single highest-leverage fix.
+3. **Fix the shared NVMe hostnqn/hostid** via MachineConfig (systemd oneshot: regen `/etc/nvme/hostnqn` + `hostid` where == `466937ab`, then rolling reboot). Removes an active data-corruption + attach-failure risk.
+4. **Restore the push path:** namespace `gotify` is currently `NotFound` — the primary Alertmanager push receiver has no backend. Get gotify healthy (or repoint the bridge) so alerts are actually deliverable.
+
+#### P1 — Backups you can trust
+
+5. **Enable OADP/Velero** (the `redhat-oadp-operator` component is already in-repo, just unenabled) targeting RustFS/S3 — scheduled backups of namespaces, app CRs, and PV data as consistent sets. Define and **test** restore.
+6. **Scheduled etcd backups.** A cluster-etcd-operator `PeriodicBackup` (or a simple cronjob running `cluster-backup.sh`) to TrueNAS/S3. Even for a single-node cluster this converts "full reinstall" into "restore state," and enables rebuild-onto-new-disk without total data reconstruction.
+7. **Scheduled hermes + PV-zvol snapshots with retention**, plus **offsite/second-target replication** of the TrueNAS zvols and Barman buckets so TrueNAS is not a single DR SPOF. Move Barman off the flaky cold/spinning-rust RustFS to an ssd-backed target; add a backup-liveness/credential check (per the `rustfs-declarative-state` spec) so a stale key or wedged pool is detected *before* a DR event.
+8. **Persist platform Prometheus** (add `prometheusK8s` storage) so telemetry survives reboots and post-mortems have data.
+9. **Fold the live-only ArgoCD CR hardening into git** (`bootstrap_gitops.yaml`): repo-server cpu/timeout bump and the ExternalSecret + PushSecret health-checks. Recovery hardening must not live only in a running cluster.
+
+#### P2 — Make recovery boring
+
+10. **Write and drill a DR runbook.** Codify the reinstall→GitOps→workers→data-restore sequence with every gotcha (CSR column, cert x509 rotation, VM UTC clock, Barman serverName, secrets bootstrap order, wave-gate operator nudges). Run a **game-day** at least quarterly; set explicit RTO (target < 2h to API, < 4h to data) and RPO (< 24h, ideally < 1h for DBs) and design toward them.
+11. **Automate the manual recovery steps:** an idempotent recovery playbook that regenerates PXE artifacts, seeds bootstrap secrets from a break-glass store, auto-approves scoped CSRs (using the correct `.status`-absent selector), and drives the wave-gate operator bootstraps.
+12. **Break-glass secrets store off-cluster.** Because Connect/ESO/AAP all die with the cluster, keep a minimal, documented out-of-band copy of the seed secrets (`1password-credentials.json`, Connect token, pull secret) so recovery never stalls on a burnt view-once link.
+13. **Consider control-plane resilience.** A single etcd member means any master-disk event is a full rebuild. If the workload warrants it, evaluate a 3-node control plane; at minimum, treat etcd backup (rec. 6) as mandatory compensation for the single-node topology.
+
+---
+
+### 8. Summary scorecard
+
+| Dimension | State | Target |
+|---|---|---|
+| MTTD (whole-cluster loss) | **Unbounded** (no external heartbeat) | < 5 min via off-cluster watchdog |
+| MTTR (to API) | ~2.3h, expert-dependent, manual | < 1h, playbook-driven |
+| etcd backup | **None** | Scheduled to S3/TrueNAS |
+| App/PV backup (OADP) | **None** (operator in-repo, disabled) | Enabled + restore-tested |
+| DB backup (Barman) | Present but on flaky target, stale base | ssd-backed, liveness-checked |
+| Guardrails vs. destroy path | 1 router file (now local) + latent install menu + netboot-first firmware | Disk-first firmware + hard-local menus + CI lint |
+| Runbook | Post-hoc only | Written + quarterly drilled |
+| Config drift (recovery hardening) | Live-only ArgoCD patches | In git |
+
+The cluster is back and the data was saved, but the same unattended reboot could recur, and the *detection* of it would still be a human noticing. Prioritize the P0 items — firmware boot order, an external dead-man's-switch, the hostnqn fix, and restoring the push path — before anything else.
+
+---
+
+## Perspective: Software Engineer
+
+Scope: code/config quality of the scripts, playbooks, kustomize/helm, and ad-hoc tooling
+touched during the 2026-07-03 `ocp` cluster reinstall. Focus areas: correctness,
+maintainability, idempotency, testing, error handling, secret handling, and the tech
+debt introduced under pressure. Everything below was read from the live repos
+(`/workspace/igou-openshift` @ `59a2bc7` local / `origin/main` @ `d81e454`,
+`/workspace/igou-ansible` @ `78e40b1`) and the incident scratchpad.
+
+### TL;DR verdict
+
+The recovery got the cluster back, but it was carried by **one genuinely good playbook
+(`add_node_iso.yml`) plus a pile of throwaway shell/python glue and live-only cluster
+patches that are not in git.** The two highest-severity engineering problems are (1) the
+NVMe `hostnqn`/`hostid` collision has **zero codified remediation** — no MachineConfig
+exists in the repo — and (2) **two performance/gating fixes to the ArgoCD CR live only on
+the cluster** and will be silently reverted the next time the bootstrap playbook runs,
+re-introducing the exact stalls that cost time this incident. Underneath sits config
+drift (three different GitOps-bootstrap artifacts, two PXE-publish playbooks one of which
+targets dead infra) and a stale local checkout that already produced one wrong apply.
+
+---
+
+### 1. `recomment.py` — the values-toggler (disposable, but risky on the wrong file)
+
+`/tmp/.../scratchpad/recomment.py` (33 lines) comments out deferred app blocks in
+`clusters/ocp/values.yaml` so the app-of-apps skips them during the staged wave restore.
+
+Correctness / robustness problems:
+
+- **Silent no-match = wrong deploy.** The script builds `commented` from apps it actually
+  matched, but never asserts that every name in the `defer-*.txt` input was found. A typo
+  in a defer list (or an app whose key isn't lowercase-`[a-z0-9-]` at exactly 2-space
+  indent, per `app_re = ^  ([a-z0-9-]+):\s*$`) means the app is **silently left enabled** —
+  during a staged restore that means a workload you intended to hold offline comes up. On
+  the single file that controls what the whole cluster deploys, silent partial failure is
+  the worst failure mode.
+- **Lossy one-way transform.** It rewrites each block line to `"  # " + line.strip()`,
+  discarding original indentation ("cosmetic, ArgoCD ignores comments"). Restoration is
+  therefore impossible from the output alone — it depends on keeping a pristine
+  `values-original.yaml` / `git show <commit>^:...values.yaml` around. That's a manual
+  round-trip contract, not a reversible tool.
+- **Brittle block-consumption heuristic** (the 4-space / blank-line / peek-next-app logic,
+  lines 19-28) is ad hoc and unscoped — it happens to work only because the file is flat.
+- **No error handling:** positional `sys.argv[1..3]`, no `argparse`, no file-existence or
+  encoding handling, no `with`; a missing arg is an unhelpful `IndexError`.
+
+Testing: the only evidence of validation is the **no-op path** — `test-out.yaml` is
+byte-identical to `values-original.yaml` (I diffed them; `dn.txt`/`defer-none.txt` were
+empty). The actual commenting path was never unit-tested; verification was eyeballing the
+ArgoCD app list.
+
+Recommendation: **retire the text-mutator.** "What deploys" should be *data*, not a lossy
+regex edit — a per-app `enabled: true|false` flag consumed by the app-of-apps helm/kustomize
+template, or an ApplicationSet list generator gated on a boolean. If a scripted toggle must
+survive, it should (a) parse YAML with a real parser (ruamel round-trip preserves comments),
+(b) hard-fail if any requested name isn't present, and (c) be idempotent + reversible.
+
+### 2. GitOps bootstrap — three artifacts, one source of truth needed
+
+There are **three** things that bootstrap GitOps, and they disagree:
+
+- `playbooks/openshift/hub-cluster/bootstrap_gitops.yaml` — the **good, current** one
+  (creates the fully-configured ArgoCD CR: Lua health-checks, setenv CMP plugin, RBAC,
+  resource tuning, ESO-scoped `resourceIgnoreDifferences`). This is what was actually used.
+- `playbooks/openshift/bootstrap_openshift_gitops.yaml` — **drifted/broken**: points its
+  kustomize lookup at `config/<cluster>/live/base-config/` (a path that no longer exists;
+  the repo moved to `clusters/<cluster>/`) and references an undefined `onepassword_token`
+  var with no prompt/default. It will fail if run. Dead and actively confusing mid-incident.
+- `/tmp/.../scratchpad/bootstrap-gitops.sh` — an ad-hoc shell reimplementation written to
+  work around the drifted playbook. It has real bugs:
+  - `until oc get clusterversion` and the two `until oc get ...` waits are **unbounded** —
+    no timeout, can hang forever.
+  - The apply loop (`for i in $(seq 1 20)`) logs `retry` on failure but **falls through
+    without `exit 1`** if all 20 attempts fail → the script reports success even when the
+    app-of-apps never applied (silent failure under `set -euo pipefail`, which the loop
+    defeats).
+  - It **never creates an ArgoCD CR** — it relies on the operator's default ArgoCD, so had
+    it been the path taken, the cluster would have come up missing every Lua health-check,
+    the CMP plugin, and the resource tuning that the playbook carries. Heredoc-inlined
+    Namespace/OG/Subscription/CRB duplicate the playbook = two sources of truth.
+
+Recommendation: **delete `bootstrap_openshift_gitops.yaml` and `bootstrap-gitops.sh`;
+keep `hub-cluster/bootstrap_gitops.yaml` as the single entry point** and add a smoke +
+idempotence test (re-run must be a no-op).
+
+### 3. Live-only ArgoCD CR patches — the biggest "fix not in code" debt
+
+`argocd-patch.json` in the scratchpad captures two changes applied **directly to the live
+ArgoCD CR** (which is playbook-created, not GitOps-managed) and **confirmed absent from git
+and from the bootstrap playbook**:
+
+1. `spec.resourceHealthChecks += external-secrets.io/PushSecret` → a Lua check that always
+   returns `Healthy` (so the deliberately read-only Connect token's failing PushSecrets stop
+   blocking the wave gate).
+2. `spec.repo` resources bumped to cpu=2 / mem=2Gi + `ARGOCD_EXEC_TIMEOUT=3m` (heavy helm
+   render of `clusters/ocp/` exceeded the default 90s on 1 CPU, causing the recurring
+   `Unknown`/`DeadlineExceeded` wave stalls). I verified the playbook's ArgoCD CR still
+   ships `repo.resources.limits` = cpu:"1"/mem:1Gi and has **no** PushSecret check and **no**
+   `ARGOCD_EXEC_TIMEOUT`.
+
+Because the CR is recreated by `bootstrap_gitops.yaml`, **any future DR re-run wipes both
+patches and re-introduces the exact wave-gate stall and repo-server timeout that cost time
+this incident.** Fold both into the playbook's ArgoCD CR. Note the patch was hand-assembled
+as a *full* `resourceHealthChecks` array (re-listing every existing check plus the new one) —
+brittle to keep in sync; a strategic-merge/JSON-patch that adds *only* the PushSecret entry
+is safer than replacing the whole array.
+
+### 4. `deploy_pxe_assets.yml` — wrong destination + CLI-arg secrets
+
+`playbooks/openshift/agent-install/deploy_pxe_assets.yml` re-generated the control-plane PXE
+artifacts (good), but:
+
+- **Delivers to retired infra.** Play 2 ("Copy boot artifacts to TrueNAS netbootxyz
+  directory") writes to `/mnt/ssd/containers/netbootxyz/{assets,config/menus}` — the
+  netbootxyz container was retired post-2026-05-11; serving moved to public nginx at
+  `/mnt/ssd/public/boot-files/`. During recovery the operator had to **manually** `chmod 755`
+  + upload to the correct path (memory + open ansible#311). A publish playbook that writes to
+  a dead path is worse than no playbook.
+- **Secrets on the command line.** The `op item create ... kubeconfig[password]={{ ... |
+  b64encode }} client_key_data[password]={{ ... }}` task passes the cluster-admin kubeconfig
+  and client key as **shell argv**. `no_log: true` only hides it from Ansible output — the
+  values are visible in the host process table (`ps aux`) for the command's lifetime. Also
+  `op item create` is Connect-mode-incompatible, so this task was `--skip-tags op-save`'d
+  during the very scenario it exists for (a task you must skip during DR is a smell). Use
+  stdin/templated input or the `community.general.onepassword*` modules; never argv.
+- **Auth dir copied to `/tmp/<cluster>-auth/` mode 0644** → cluster-admin kubeconfig
+  world-readable in a shared tmp.
+- **Item name is minute-timestamped** (`%Y%m%d%H%M`) → every re-run mints a new 1P item;
+  append-only sprawl, not idempotent (acceptable for audit trails but undocumented/unpruned).
+
+Contrast with **`add_node_iso.yml`, which is the model to converge everyone on** (see §5).
+
+### 5. `add_node_iso.yml` — the good example, use it as the bar
+
+`playbooks/openshift/add_node_iso.yml` is genuinely well-engineered and should be the
+template the other netboot/publish plays are lifted to:
+
+- Strong fail-fast preflight: KUBECONFIG asserted, worker group non-empty, **MAC regex-
+  validated**, already-joined nodes discovered and **excluded so re-runs are idempotent**,
+  at-least-one-pending assert.
+- `no_log` on the pull-secret fetch + `chmod 0600` lockdown of the written `auth.json`.
+- **Correct** public-nginx destination *and* the `--chmod=F0644,D0755` rsync workaround with
+  an inline comment explaining the 403/boot-loop it prevents.
+- Monitor task tagged `[monitor, never]` (opt-in), thorough header runbook.
+
+The delta between this and `deploy_pxe_assets.yml` is exactly the drift that hurt during
+recovery. Recommend factoring the shared "render assets → publish to public nginx with the
+world-readable chmod" logic into one role/task file both plays import.
+
+### 6. NVMe `hostnqn`/`hostid` collision — real bug, no code fix yet
+
+The cluster-wide latent bug (all 3 nodes share
+`nqn...uuid:466937ab-...` in `/etc/nvme/hostnqn` + `/etc/nvme/hostid`) has **no codified
+remediation**. I confirmed the only NVMe MachineConfig in git is
+`clusters/ocp/machineconfigs/99-master-load-nvme-tcp-machineconfig.yaml` (loads the module) —
+nothing regenerates the identity. The only session artifacts are the throwaway
+`nvme-test.sh` / `nvme-clean.sh` (hardcoded NQNs/UUIDs/target IP `10.10.9.213`;
+`nvme-clean.sh` actually `nvme disconnect`s subsystems ad hoc on a node with a crude
+`grep -c csi-pvc` success signal). These are diagnostics, not a fix.
+
+Highest-priority hardening: a MachineConfig applying a systemd oneshot (guarded on
+`hostid == 466937ab`) that runs `nvme gen-hostnqn > /etc/nvme/hostnqn` + `uuidgen >
+/etc/nvme/hostid` then reboots, committed to `clusters/ocp/machineconfigs/`. Better still,
+fix the **root cause** — the agent-based install / golden image is baking a fixed NVMe host
+identity into every node — so fresh installs never collide. Add a CI/molecule assertion (or a
+node-diff check) that the three nodes' `hostnqn` are distinct.
+
+### 7. CNPG recovery bootstrap is now the committed steady state (DR footgun)
+
+`quay-pg-recovery.yaml` in the scratchpad is well-commented and thoughtful (`enablePDB:
+false` with rationale, control-plane `nodeSelector` pin to dodge the Multi-Attach bug,
+"declared to avoid ArgoCD drift" defaults — good SSA hygiene). But I confirmed that #387/#388
+committed **`bootstrap.recovery` (not `initdb`)** into all three CNPG cluster CRs on
+`origin/main`:
+
+- `components/quay-operator/quay-pg-cluster.yaml` (recovery, serverName `quay-pg-r20260704`)
+- `components/rhdh/rhdh-pg-cluster.yaml` (recovery, `rhdh-pg-r20260704`)
+- `applications/forgejo/forgejo-pg-cluster.yaml` (recovery, `forgejo-pg-r20260704`)
+
+CNPG only runs `bootstrap` at cluster *creation*, so this is inert on the live cluster — but
+the desired state now encodes a **one-time point-in-time restore as permanent config**, with
+a date-stamped magic serverName. If these manifests are ever replayed to stand up a fresh
+cluster (the exact DR path just exercised), they'll attempt recovery from an
+ever-staler backup. Per the memory's own follow-up #5: **revert `recovery`→`initdb` now that
+the DBs are verified** (keep the recovery block commented, as done), and move the restore
+into the existing `docs/runbooks/cnpg-backup-restore.md` + a parameterized restore playbook
+rather than leaving recovery hot in the desired state.
+
+### 8. Cross-cutting: stale checkout, secrets on disk, un-codified steps
+
+- **Stale local checkout caused a wrong apply.** `/workspace/igou-openshift` local `HEAD` is
+  `59a2bc7`, well behind `origin/main` (`d81e454`). `kustomize build | oc apply` from it
+  rendered *old* manifests (quay came up with `initdb` instead of `recovery`), per memory.
+  `bootstrap-gitops.sh` also `cd`s into this local tree. Hardening: recovery tooling must
+  `git fetch && git reset --hard origin/main` (or clone fresh) before any local render, or —
+  better — apply **only through ArgoCD** (which pulls the remote) and never local
+  `kustomize | oc apply`. Add a preflight that aborts if `HEAD != origin/main`.
+- **Long-lived secrets persisted in cleartext.** The scratchpad holds
+  `agent-install-override.yml` (the **full pull secret** incl. `registry.redhat.io` /
+  `quay.io` tokens), `pull-secret.json`/`.yaml`, `op-sa-token`, `connect-token`,
+  `agent-auth-token`, `1password-credentials.json`; plus the DR SA token was written to
+  `~/.secrets/op-dr-sa-token`. The pull secret is a durable credential. Recommend: stream
+  secrets from `op` at point-of-use (the `-e @override.yml` inline-literal pattern that
+  bypassed op is convenient but leaves the crown jewels on disk), and `shred` the incident
+  scratch at close.
+- **Recovery was hand-run one-liners, not codified.** Worker re-join, CSR approval (the
+  `awk '$5=="Pending"'` bug — CSR CONDITION is column 6 — silently matched nothing and cost
+  ~40 min; correct form is the `go-template ... if not .status` approve), the truenas-w1 VM
+  quirks (`time: UTC` to fix the Ignition x509 "cert not yet valid", CDROM device order
+  1000→1010, full QEMU restart), and the NVMe cleanup were all ad hoc. Fold the CSR-approve
+  idiom and the VM-clock/CDROM ordering into `add_node_iso.yml` / a truenas-vm playbook so
+  they can't recur.
+- **Root cause is itself a config choice.** The disaster trigger — the rb5009 per-host pin
+  defaulting to `install-openshift` on a 30s timeout with MS-01 netboot-first — is a
+  netboot-pin *template* default. inv#120 (pin default `local`) is merged; also ensure the
+  pin generator never defaults to `install` and that MS-01 UEFI de-prioritizes PXE. This is
+  the single change that most reduces blast radius.
+
+### 9. What's already good (keep / build on)
+
+- `add_node_iso.yml` — defensive, idempotent, documented (the standard to converge on).
+- The `david-igou.openshift_agent_install` role **has molecule coverage**
+  (`molecule/default/{converge,verify}.yml` + CI) — the install layer is tested even though
+  the publish plays around it drifted.
+- Runbooks exist: `docs/runbooks/nvmeof-stuck-multiattach.md` and
+  `docs/runbooks/cnpg-backup-restore.md`.
+- CNPG CRs show real SSA-drift discipline (operator-defaulted fields declared explicitly).
+
+### Prioritized hardening backlog
+
+1. **P0 — NVMe hostnqn/hostid:** commit a per-node identity-regen MachineConfig (or fix the
+   install media) + a node-diff assertion. Real correctness/corruption risk, zero code today.
+2. **P0 — fold the live ArgoCD patches into `bootstrap_gitops.yaml`** (PushSecret health-check
+   + repo-server cpu=2/timeout=3m) so DR re-runs don't reintroduce the wave stalls.
+3. **P1 — fix `deploy_pxe_assets.yml`** destination path (public nginx) and remove CLI-arg
+   secrets; lift it to `add_node_iso.yml`'s bar; share a common publish task file.
+4. **P1 — consolidate GitOps bootstrap to one playbook**; delete
+   `bootstrap_openshift_gitops.yaml` and `bootstrap-gitops.sh`; add smoke + idempotence tests.
+5. **P1 — revert CNPG `recovery`→`initdb`** in git now DBs are verified; keep restore as a
+   parameterized runbook/playbook.
+6. **P2 — replace `recomment.py`** with a declarative per-app `enabled` flag / ApplicationSet
+   generator; if scripted, YAML-parse + hard-fail on unmatched names.
+7. **P2 — staleness guard + secret hygiene:** recovery tooling fetches/pins `origin/main`
+   (or applies only via ArgoCD); stream secrets from `op`, shred incident scratch, remove the
+   persisted pull secret and SA tokens.
+8. **P2 — codify worker re-join quirks** (CSR go-template approve, VM `time: UTC`, CDROM
+   ordering) into playbooks.
+
+---
+
+## Perspective: Virtualization Administrator
+
+Scope: the Hermes KubeVirt VM rebuild, the storage-attach failures rooted in the shared NVMe host NQN plus democratic-csi nvmeof multi-attach, VM clock/UTC correctness, boot/firmware configuration, the golden-image / DataVolume strategy, RWO PVC placement and affinity, and VM lifecycle / HA on a three-node cluster. All findings below are backed by live inspection of the recovered cluster (`ocp.igou.systems`, CNV 4.21.10, 3 nodes) and the `origin/main` GitOps + Ansible sources on 2026-07-04.
+
+### Current state (verified)
+
+- CNV `kubevirt-hyperconverged.v4.21.10` Succeeded; HCO Available, all virt pods Running across the 3 nodes.
+- One workload VM: `hermes/hermes`, `runStrategy: Always`, Running on `hpg5.igou.systems`, VMI Ready, `AgentConnected: True` (qemu-guest-agent up).
+- Disks: `hermes-root` (DataVolume clone of DataSource `centos-stream10`, 30Gi) and `hermes-state` (Argo-owned blank DataVolume, 30Gi) — **both RWO, Block, on `freenas-nvmeof-ssd-csi`** (the default StorageClass).
+- Golden images: 6 auto-imported DataSources (centos-stream9/10, fedora, rhel8/9/10) all bound on `freenas-nvmeof-ssd-csi`, RWO/Block, refreshed by DataImportCrons (`33 10/12 * * *`, `garbageCollect: Outdated`).
+- `hermes-vm-hardening` ValidatingAdmissionPolicy is deployed and enforcing (masquerade-exclusive networking, no hostDevices, no GPUs).
+
+---
+
+### Findings
+
+#### 1. CRITICAL — NVMe-oF host NQN is shared across all nodes at *two* layers; the memory's proposed MachineConfig fix is necessary but **not sufficient**
+
+The incident record correctly flags that all three RHCOS nodes were baked with the identical `/etc/nvme/hostnqn` + `/etc/nvme/hostid` `...466937ab...` and prescribes a MachineConfig to regenerate them. Live inspection shows the problem is deeper and the prescribed fix alone will **not** cure the nvmeof attach failures:
+
+- Host files, all 3 nodes: `/etc/nvme/hostnqn` = `/etc/nvme/hostid` = `466937ab-67bf-4315-971b-bc110d55ce28` (still shared — unfixed).
+- **But every live democratic-csi nvmeof connection on every node uses a *different* host NQN: `941e4f03-2cd6-435e-86df-731b1c573d86`** — and that value is *also identical on all three nodes* (verified on master, hpg5, and truenas-w1 via `nvme list-subsys`).
+- Source confirmed: the `csi-driver` container in each `democratic-csi-nvmeof-ssd-config-node-*` pod ships its **own image-baked `/etc/nvme/hostnqn` = `941e4f03...`** (`oc exec ... cat /etc/nvme/hostnqn`). The node plugin does **not** bind-mount the host's `/etc/nvme`, so `nvme connect` runs with the container's constant NQN, identical for every pod on every node.
+
+Consequence: NVMe-oF host uniqueness is violated for the volumes that actually matter (all VM disks + all os-image golden PVCs), and rewriting `/etc/nvme/hostnqn` on the host will change nothing for CSI traffic — the driver overrides it with `941e4f03`. This is precisely the failure window that bit the Hermes rebuild ("2nd nvmeof-ssd disk failed to attach on hpg5 while root attached"): with one shared host NQN, the TrueNAS target sees the same host identity from multiple node IPs, and during any reattach/failover window (node down → force-detach → reattach elsewhere, or an RWX multi-attach) associations collide and connects are rejected.
+
+Recommended fix (ordered, all three parts required):
+1. MachineConfig (all roles, not just master) with a systemd oneshot that writes a unique `/etc/nvme/hostnqn` (`nvme gen-hostnqn`) and `/etc/nvme/hostid` (`uuidgen`) when the current value equals the shared `466937ab`, `Before=` the kubelet/CSI node plugin starts, then reboot in a controlled rolling fashion.
+2. **Make democratic-csi use the host value**: bind-mount host `/etc/nvme` (hostPath) into the `csi-driver` container so `nvme connect` inherits the now-unique per-node NQN/hostid instead of the image constant `941e4f03`. Without this step the OS fix is cosmetic. This is a change to the democratic-csi Helm values / node-plugin pod spec in the GitOps repo.
+3. Drain/tear down existing controllers (the reboot in step 1 does this) so live associations re-establish under the unique NQN; verify with `nvme list-subsys` that each node now shows a distinct `hostnqn=`.
+
+Until fixed, treat every VM as pinned: **do not** stop/start, migrate, or trigger a failover of the Hermes VM (the memory's "don't stop/start until hostnqn fixed" is correct and should be a hard gate).
+
+#### 2. HIGH — Hermes VM is not live-migratable, so node drains / MCO updates on its host will not evict it cleanly
+
+`oc get vmi hermes` reports `LiveMigratable: False` — "PVC hermes-root is not shared, live migration requires ReadWriteMany". There are in fact **two** independent migration blockers:
+- Storage: root and state are RWO (not RWX), so no shared-disk migration; `migrationMethod` resolves to `BlockMigration` which is gated off for these disks.
+- CPU: the VMI runs with `cpu.model: host-model` (KubeVirt default; the Ansible role sets no model and HCO sets no `defaultCPUModel`). host-model bakes the source host's CPU flags into the domain, which would block migration to a *different* CPU anyway — and MS-01 (control plane) and hpg5 are dissimilar hardware.
+
+Meanwhile the cluster-wide `evictionStrategy: LiveMigrate` (HCO default) is inherited by the VMI (`spec.evictionStrategy: LiveMigrate`), and the Ansible role never overrides it. For a VMI that *cannot* migrate, this combination means an `oc adm drain` / MCO reboot of the hosting node will not gracefully evict the VM — virt-api refuses the launcher eviction and the drain stalls until the VM is manually `virtctl stop`-ed. (Confirmed there is currently no KubeVirt disruption-budget PDB in the `hermes` namespace, because KubeVirt only creates one for migratable VMIs — so the block is enforced by the eviction webhook, not a PDB, but the operational result is the same: node maintenance on hermes' host is not hands-off.)
+
+Recommendation for this small, RWO-backed cluster: set `evictionStrategy: None` explicitly on the VM (add it to the `kubevirt_vm_provision` role's VM spec). With `runStrategy: Always`, a drain then simply shuts the VM down and it restarts on the other eligible node — deterministic maintenance instead of a hung drain. If live migration for HA is genuinely wanted later, it requires *both* RWX shared-block storage (see finding 3) *and* a common named CPU model (set HCO `defaultCPUModel` to a baseline both hosts share, or pin `cpu.model` on the VM) — not just one.
+
+#### 3. HIGH — All VM disks and all golden images sit in a single storage failure domain on the fragile transport
+
+Every VM disk and every os-image DataSource PVC is on `freenas-nvmeof-ssd-csi` — one TrueNAS box, over the exact NVMe-oF transport implicated in finding 1. If TrueNAS is unavailable, no VM can boot *and* no golden image is present to clone a rebuild from. Note also `truenas-w1` (a KVM guest on that same TrueNAS) is correctly excluded from VM scheduling by HCO `workloads.nodePlacement` (NotIn truenas-w1) — good — which leaves only the control-plane node and hpg5 able to host VMs; one of those two is the single control plane and thus a cluster-wide SPOF.
+
+The `ctrl-loss-tmo=-1` / `reconnect-delay=10` tuning in the nvmeof driver config is a sound, deliberate choice for a single-target no-multipath topology (I/O queues rather than errors during a blip → the VM freezes and resumes instead of corrupting), and the `docs/runbooks/nvmeof-stuck-multiattach.md` runbook is thorough. Recommendations:
+- Accept the single-target reality but make golden-image availability independent of live TrueNAS health where cheap: the DataImportCron-imported DataSources are already PVC-backed, so a TrueNAS outage does strand them — consider a second StorageClass/backend (even node-local LVMS `lvms-lvm-local-storage`, which exists) for at least the golden images or a boot-critical VM, so a rebuild isn't fully gated on TrueNAS.
+- The nvme-tcp kernel module is declaratively loaded only on `master` (`99-master-load-nvme-tcp` MachineConfig targets role master). Workers currently get it only because the CSI node plugin modprobes via its host mount. Add a worker (or all-roles) `modules-load.d/nvme-tcp.conf` MachineConfig so worker nvmeof does not silently depend on CSI-pod side effects.
+
+#### 4. MEDIUM — No protected backup/restore path for `hermes-state` (the only irreplaceable VM data)
+
+`hermes-state` holds the agent's identity/config (`auth.json`, `SOUL.md`, `config.yaml`, memory) and during recovery it was restored **by hand** — `dd`/`tar` of an old zvol clone into a blank Block PVC. There is no scheduled backup of it in GitOps and no automated restore. The root disk is disposable (cloned from the golden DataSource), so state is the whole game.
+
+The building blocks exist and are underused: `roles/kubevirt_vm_snapshot` + `playbooks/hermes/snapshot-vm.yml` are present, the guest agent is connected (so online, filesystem-quiesced VirtualMachineSnapshots work), and `volumeSnapshotStatuses` shows both `root` and `state` are snapshot-capable. Recommend a scheduled VirtualMachineSnapshot (or at minimum a VolumeSnapshot of `hermes-state`) plus an off-cluster export (the existing TrueNAS/RustFS pattern), and document the block-device restore procedure as a runbook so the next recovery isn't improvised.
+
+#### 5. MEDIUM — Golden image for the security-sensitive agent is an unpinned moving target
+
+`hermes-root` clones via `sourceRef: DataSource centos-stream10`, and that DataSource is continuously re-imported from `docker://quay.io/containerdisks/centos-stream:10` by the DataImportCron (12-hourly, `garbageCollect: Outdated`). Every VM rebuild therefore picks up whatever the latest upstream Stream 10 containerdisk happens to be — non-deterministic and an unpinned supply-chain surface for a VM that runs an autonomous agent with credentialed egress. Recommend either pinning the Hermes root clone to a specific image digest / a dedicated frozen DataSource that is updated deliberately, or at least recording the imported digest so a rebuild is reproducible and auditable. The `cloneStrategy: snapshot` smart-clone itself is correct and efficient (verified working: hermes-root DV Succeeded from the snapshot clone) — keep it.
+
+#### 6. LOW — Clock is correct-by-default but not explicit; and BIOS boot is a hardening step backward
+
+- **Clock/UTC**: the KubeVirt VM has no `spec.domain.clock` stanza, so libvirt defaults to `<clock offset='utc'>` — which is correct. (The `time: LOCAL` RTC bug called out in the incident was the *TrueNAS-hosted* worker VM `truenas-w1`, a KVM guest, not a KubeVirt VM — a different code path; that fix `midclt vm.update 5 {"time":"UTC"}` was right and does not apply here.) Still, for determinism I recommend setting `clock.utc: {}` with an explicit `timer` block on the VM and confirming `chronyd` is active in the guest (the centos-stream10 cloud image ships it) so agent timestamps and any TLS/token validity are anchored.
+- **Firmware**: the VM boots `firmware.bootloader.bios: {}` (SeaBIOS, no UEFI, no Secure Boot). The provisioning role already supports `vm_firmware: efi`. For a security-boundary VM, UEFI (and evaluating Secure Boot re-enablement, which the memory notes was dropped) is the stronger posture; at minimum revisit why BIOS was chosen and whether EFI is now viable on the current golden image.
+
+#### 7. LOW — VM-hardening VAP is good but leaves firmware/eviction/storage unconstrained
+
+`hermes-vm-hardening` correctly forbids non-masquerade interfaces, hostDevices, and GPUs (so the EgressFirewall/NetworkPolicy boundary can't be bypassed). Gaps a future iteration could close, given this is a policy-guarded security VM: assert `firmware`/bootloader shape, forbid `evictionStrategy` values that reintroduce the stuck-drain behavior, and constrain the disk StorageClass, so a hand-edited or drifted VM can't quietly weaken the intended shape.
+
+---
+
+### Prioritized recommendations
+
+| # | Priority | Action | Why it matters |
+|---|----------|--------|----------------|
+| 1 | Critical | Give each node a unique `/etc/nvme/hostnqn`+`hostid` **and** bind-mount host `/etc/nvme` into the democratic-csi `csi-driver` container so CSI stops using its image-baked shared `941e4f03` NQN | Both layers are currently shared; the memory's host-only fix does not touch CSI traffic. This is the direct cause of VM disk-attach failures and blocks safe failover/migration |
+| 2 | High | Set `evictionStrategy: None` on the Hermes VM (role default) while it is RWO/non-migratable | Turns a hung `oc adm drain`/MCO reboot into a clean stop-and-reschedule; makes node maintenance hands-off |
+| 3 | High | Keep the Hermes VM pinned (no stop/start/migrate) until recommendation 1 lands | Every lifecycle op currently risks the multi-attach collision |
+| 4 | High | Put at least the golden images (or a boot-critical VM) on a second backend; add a worker/all-roles nvme-tcp `modules-load.d` MachineConfig | Removes total dependence of VM boot + rebuild on one TrueNAS box and on CSI-pod modprobe side effects |
+| 5 | Medium | Schedule VirtualMachineSnapshots of Hermes (guest-agent quiesced) + off-cluster export of `hermes-state`; write the block-PVC restore runbook | `hermes-state` is the only irreplaceable data and was restored by hand last time |
+| 6 | Medium | Pin/record the centos-stream10 golden image digest used for the Hermes root | Reproducible, auditable rebuilds of a credentialed agent VM |
+| 7 | Low | Move Hermes to UEFI (`vm_firmware: efi`), add explicit `clock.utc`/timer, verify chronyd; extend the hardening VAP to cover firmware/eviction/storage | Consistency, hardening, and drift protection |
+| 8 | Low | For any future live-migration HA: adopt RWX shared-block storage *and* a common `defaultCPUModel` together | host-model + RWO are two independent migration blockers; fixing one alone does nothing |
+
+---
+
+## Perspective: Database Administrator
+
+**Scope:** the three CloudNativePG (CNPG) `Cluster` databases restored after the 2026-07-03
+disaster — `rhdh-pg` (namespace `rhdh`, database `backstage`), `forgejo-pg` (namespace
+`forgejo`, database `forgejo`), and `quay-pg` (namespace `quay-enterprise`, databases `quay`
++ `clair`). Assessed live against the cluster (read-only) and against `origin/main` of
+`igou-io/igou-openshift`.
+
+**Bottom line:** the restore worked. Two of three databases are fully recovered, healthy, and
+already taking fresh backups on a new timeline; the third (quay) is mid-recovery and progressing
+normally. The backup design is solid and well-documented, but it carries **one critical DR gap
+(backups share a failure domain with primary storage)** and **one latent footgun (a Cluster
+recreate would silently roll back to the pre-disaster snapshot)** that should be closed.
+
+---
+
+### 1. Restore verification (read-only table counts via `oc exec … psql`)
+
+Non-system tables = `information_schema.tables` excluding `pg_catalog` / `information_schema`,
+`table_type='BASE TABLE'`.
+
+| Cluster | DB | Non-system tables | Extra signal | State |
+|---|---|---|---|---|
+| `rhdh-pg` (rhdh) | `backstage` | **119** across 18 Backstage schemas (catalog 17, adoption-insights 13, auth 12, events 10, permission 9, search 9, …) | — | **Ready**, timeline 2, read-write primary `rhdh-pg-1` |
+| `forgejo-pg` (forgejo) | `forgejo` | **128** | **356 repositories, 6 users** — real data present | **Ready**, timeline 2, read-write primary `forgejo-pg-1` |
+| `quay-pg` (quay-enterprise) | `quay` | **103** (+ `clair` **31**) | repository 3 / user 4 at current replay point | **In recovery** — `quay-pg-1-full-recovery` pod replaying WAL, `pg_is_in_recovery()=t`, queryable read-only |
+
+All three counts meet or exceed the restore-time baselines recorded in the incident memory
+(rhdh 111 → now 119 as RHDH ran its startup migrations post-recovery; forgejo 128 matches
+exactly; quay confirmed at 103 via the in-recovery instance's local socket). **The restores are
+correct** — schema and data are intact, not empty shells.
+
+Quay was verified by connecting read-only to the still-recovering instance (it reached
+"consistent recovery state" so it accepts read-only queries). Its table structure is fully
+present; row counts will settle at final values once WAL replay completes and it promotes.
+
+---
+
+### 2. Quay recovery status — progressing, not stuck (do not intervene)
+
+`quay-pg` has been in `Setting up primary` / `full-recovery` for ~45 min. This is expected, not a
+hang:
+
+- Base backup restored: "database system … last known up at **2026-07-02 03:33:46 UTC**"
+  (the last daily base before the disaster).
+- Redo starts `1B2/62000028`; consistent recovery state reached at `1B3/A6016BC0` (base
+  end); now replaying continuous WAL forward toward the last archived segment (~`1B8/3A…`).
+- That is roughly **37 hours / ~20 GB of WAL** being fetched **one 16 MB segment at a time**
+  from the RustFS S3 endpoint and gunzipped — inherently slow but the LSN is advancing steadily
+  and `restartpoint` checkpoints are pruning replayed WAL.
+- PVC headroom is fine: 40 Gi PVC at **51% (20 G used / 20 G free)** mid-replay; no risk of
+  filling.
+
+`recovery_target_action = promote` with no explicit target → it will recover to the end of the
+archived WAL, promote to timeline 2, and become the read-write primary. **Expected outcome:
+completes on its own.** After promotion, verify `quay`/`clair` final table+row counts, that the
+quay app connects, and that quay's first ScheduledBackup + WAL archiving to `quay-pg-r20260704`
+succeed (see §5).
+
+---
+
+### 3. Backup architecture — as designed
+
+- **CNPG operator 1.29.1** + first-party **Barman Cloud Plugin v0.12.0** (`barman-cloud` Deployment
+  in `cloudnative-pg` ns, 1/1 Available). This is the supported replacement for the deprecated
+  in-tree `.spec.backup.barmanObjectStore` — good forward choice.
+- **Per-DB `ObjectStore`** → `s3://cnpg-backups/<db>` on the TrueNAS S3 endpoint
+  `https://truenas.igou.systems:20292` (RustFS), gzip compression on both `wal` and `data`,
+  `retentionPolicy: 30d` (recovery-window, correctly set at ObjectStore top-level per the runbook's
+  field-trap notes).
+- **Continuous WAL archiving** via the cluster's `plugins[].isWALArchiver: true`.
+- **Daily base backups** via `ScheduledBackup` (method `plugin`, `immediate: true`), staggered:
+  forgejo 03:00, quay 03:15, rhdh 03:45. forgejo and rhdh both show
+  `lastScheduleTime 2026-07-04 01:52` and a `completed` Backup object.
+- **PITR capability: yes.** Base + continuous WAL = recover to any point in the 30d window.
+  The DR bootstrap used "recover to end of archive"; a point-in-time restore is available by adding
+  `bootstrap.recovery.recoveryTarget` (targetTime/targetLSN) on a restore Cluster.
+
+The runbook (`docs/runbooks/cnpg-backup-restore.md`) is genuinely good — it documents the exact
+field traps (retention location, empty `serverName` on ObjectStore, same-namespace ObjectStore,
+plugin-in-operator-namespace, SCC `runAsUser` strip, sync-wave ordering of the S3-creds
+ExternalSecret) that make this setup fragile if mis-copied.
+
+---
+
+### 4. Recovery-bootstrap flow + the archive-serverName conflict fix — correct
+
+The restore pattern used on all three:
+
+```
+bootstrap.recovery.source: <db>-pg
+externalClusters[<db>-pg].plugin.parameters: { barmanObjectName: <db>-pg-backup, serverName: <db>-pg }   # ORIGINAL serverName → finds pre-disaster data
+plugins[barman-cloud].parameters.serverName: <db>-pg-r20260704                                            # NEW serverName → post-recovery archiving
+```
+
+The **serverName fix is the crux and it is verified working.** If the recovered cluster archived
+WAL back to the same `serverName` it recovered from, CNPG refuses with
+*"WAL archive check failed: Expected empty archive."* Setting the archiver's `serverName` to a
+fresh value (`<db>-r20260704`) sends the new timeline's WAL/backups to a clean path. Confirmed live:
+
+- rhdh-pg and forgejo-pg archive to `rhdh-pg-r20260704` / `forgejo-pg-r20260704`.
+- `ContinuousArchiving=True (ContinuousArchivingSuccess)` and `LastBackupSucceeded=True` on both —
+  i.e. the post-recovery archive path is not just configured, it has already taken a successful
+  fresh base backup. **The recovered databases are already protected on the new timeline.**
+- `cnpg-s3-credentials` ExternalSecret is `SecretSynced=True` in all three namespaces.
+
+---
+
+### 5. Risks & concerns
+
+**CRITICAL**
+
+1. **Backups share a failure domain with primary storage.** The `cnpg-backups` bucket lives on the
+   same TrueNAS box (RustFS + `freenas-nvmeof-ssd` pools) that hosts the primary DB PVCs. A TrueNAS
+   loss destroys primary **and** every backup simultaneously — this exact recovery only worked
+   because the disaster hit the *cluster*, not TrueNAS. The runbook itself flags this. This is the
+   single biggest reliability gap.
+
+2. **Latent re-bootstrap footgun — a Cluster recreate silently rolls back to the pre-disaster
+   snapshot.** `origin/main` still carries `bootstrap.recovery` with `externalClusters.serverName`
+   pointed at the **pre-disaster** paths (`rhdh-pg` / `forgejo-pg` / `quay-pg`). Bootstrap is a
+   no-op on an already-initialized cluster, so nothing breaks today. But if the Cluster CR is ever
+   deleted and recreated by ArgoCD (a prune, a PVC loss, a manual delete/resync), it will
+   re-bootstrap from the **frozen 2026-07-02/03 backup**, silently discarding everything written
+   since go-live. The incident memory's follow-up "revert bootstrap recovery→initdb" is **not yet
+   done** — and reverting to `initdb` is the *wrong* fix (a recreate would then come up **empty**).
+
+**HIGH / MEDIUM**
+
+3. **Single-instance on SNO — no HA, RPO/RTO exposure.** All three are `instances: 1`,
+   `enablePDB: false`, RWO NVMe-oF, pinned to the control-plane host. There is no standby to fail
+   over to; any primary/PVC loss is downtime until a restore. RPO is effectively near-zero *if* the
+   WAL archive survives (last archived WAL), but up to ~24 h if only a base survives. RTO is
+   material — quay's replay is demonstrating a **45 min+** restore time.
+
+4. **Daily-only base backups drive long RTO on large/high-churn DBs.** Quay must replay ~37 h of
+   WAL because its only base is the prior 03:15 run. A second daily base (or a post-change on-demand
+   base) for quay would cut restore time dramatically.
+
+5. **Quay currently has no fresh backup coverage.** Until it promotes and its ScheduledBackup +
+   archiving to `quay-pg-r20260704` go active, quay is unprotected on the new timeline. Watch it to
+   completion and confirm the first quay backup + `ContinuousArchiving=True`.
+
+6. **Frozen pre-disaster backup paths are now unmanaged by retention.** 30d retention
+   (`barman-cloud-backup-delete`) runs against the *archiving* serverName (`<db>-r20260704`). The
+   old `<db>` paths are no longer written to, so they will never be auto-pruned — they persist
+   indefinitely (useful as a cold DR restore point, but unbounded in size and untracked).
+
+7. **Monitoring gaps / inconsistency.** `rhdh-pg` sets `monitoring.enablePodMonitor: true`;
+   `forgejo-pg` and `quay-pg` do not — inconsistent metrics coverage. No backup-health alerting was
+   evident. Note also that `.status.lastSuccessfulBackup` is empty on the clusters (cosmetic — the
+   plugin path surfaces success via the `LastBackupSucceeded` condition + the `Backup` CR, both
+   green); any alerting must key off the condition, not that legacy field.
+
+8. **Cross-cutting NVMe-oF hostnqn bug.** The cluster-wide duplicate `hostnqn`/`hostid` across all
+   three nodes (documented in the incident memory) degrades volume-attach reliability for exactly
+   these RWO NVMe-oF DB PVCs. Pinning CNPG pods to the control-plane host mitigates reschedule
+   churn, but the underlying identity collision should be fixed so a DB pod reschedule can't hit
+   "unable to attach" storms.
+
+---
+
+### 6. Recommendations (prioritized)
+
+1. **Break the backup failure domain (DR-critical).** Add a second `ObjectStore` per DB pointed at
+   an **off-box / off-site** S3 (Backblaze B2, Wasabi, or a second TrueNAS with replication) so a
+   TrueNAS loss no longer takes primary and backups together. The plugin supports multiple stores.
+
+2. **Close the re-bootstrap footgun.** Do **not** revert to `initdb`. Instead, on each recovered
+   cluster repoint `externalClusters[].parameters.serverName` from the pre-disaster path
+   (`<db>-pg`) to the **live** archive (`<db>-pg-r20260704`), so that a Cluster recreate recovers
+   the *current* data, not the frozen snapshot. Add a code-comment/runbook warning that these
+   Clusters are recovery-bootstrapped and must never be blindly pruned/recreated.
+
+3. **Finish + validate quay.** Let recovery complete; then verify final `quay`/`clair` counts, quay
+   app connectivity, and that quay's first ScheduledBackup and WAL archiving to `quay-pg-r20260704`
+   succeed.
+
+4. **Add backup-health alerting.** Prometheus alerts on `ContinuousArchiving=False`,
+   `LastBackupSucceeded=False`, and last-backup-age > ~26 h. Add `enablePodMonitor: true` to
+   `forgejo-pg` and `quay-pg` for parity with rhdh.
+
+5. **Shorten RTO on quay.** Add a second daily base backup (or twice-daily) for the 40 Gi
+   high-churn quay cluster so WAL-replay windows stay small.
+
+6. **Manage the orphaned pre-disaster backup paths.** Once confident the new timeline is the source
+   of truth, plan a retention/cleanup (or explicit archival) of the old `s3://cnpg-backups/<db>`
+   base+WAL sets so they don't grow unbounded.
+
+7. **Longer term (HA).** Single-instance is the right call on SNO with RWO NVMe-oF today. Once there
+   is a second durable, non-ephemeral node with appropriate storage, consider `instances: 2` (and
+   re-enabling PDB) for the highest-value DBs (quay, forgejo) to remove the single-primary downtime
+   window. Also fix the NVMe-oF `hostnqn` collision so DB-volume attach is reliable under reschedule.
+
+---
+
+### 7. Verdict
+
+- **Restores correct:** yes — backstage (119 tables), forgejo (128 tables, 356 repos), quay
+  (103 tables + clair 31) all verified with real data. quay finishing WAL replay.
+- **Backup strategy:** sound and well-documented (plugin-based, per-DB stores, daily base +
+  continuous WAL, 30d retention, PITR-capable). The serverName-conflict fix is correct and already
+  producing fresh backups on the new timeline.
+- **Must-fix before calling DR "done":** (1) off-box backup replica to escape the shared TrueNAS
+  failure domain, and (2) neutralize the recovery-bootstrap footgun so a future recreate can't roll
+  the databases back to the pre-disaster snapshot.
+
+---
+
+## Perspective: Code & Process Readability
+
+Scope: readability and process-clarity of the recovery itself — how discoverable, unambiguous, and repeatable the runbooks, playbooks, naming, and decision-log are for *a second engineer who was not in the room*. Assessed the operational runbooks in `igou-ansible/docs/`, the recovery playbooks, the two OpenShift runbooks in `igou-openshift/docs/runbooks/`, and the incident record `project-ocp-cluster-reinstall.md` plus the `MEMORY.md` index as documentation artifacts. Repos were fetched from `origin/main` because the local `igou-openshift` checkout is 100+ commits stale (a hazard in its own right — see F5).
+
+### Verdict
+
+The homelab is *better documented than most*. There is a real disaster-recovery runbook (`docs/disaster-recovery.md`), a netboot runbook, an OpenShift-operations runbook, and symptom-keyed component runbooks — and the best of them (`nvmeof-stuck-multiattach.md`, `hermes-vm-lifecycle.md`) are genuinely excellent: symptom → confirm → remediate → verify structure, explicit blockquote danger callouts, and stated trade-offs. That baseline is the reason recovery was possible at all.
+
+But this incident exposed a consistent failure mode: **the knowledge that actually saved the cluster lived in the operator's head (and now in a dense memory file), not in the runbooks — and in two places the runbooks actively point a follower at the wrong thing.** A second engineer executing the committed DR runbook literally, without the memory file, would have run a stale playbook and would not have known the one timing-sensitive step that breaks the reinstall loop. The single most important lesson of the whole incident — that a netboot pin can silently wipe a production cluster — is not written down anywhere an operator would look.
+
+---
+
+### Critical findings
+
+#### F1 — The DR runbook sends you to the *wrong, drifted* GitOps-bootstrap playbook (CONFIRMED)
+
+The recovery used `playbooks/openshift/hub-cluster/bootstrap_gitops.yaml` and the memory file is emphatic about it: *"GitOps FULLY bootstrapped via `hub-cluster/bootstrap_gitops.yaml` (the CURRENT one, NOT the drifted `bootstrap_openshift_gitops.yaml`)"* — and two real bugs had to be fixed in it mid-incident (ansible#312).
+
+But both committed runbooks tell an operator to run the *other* file:
+- `docs/disaster-recovery.md` → "OCP cluster / Rebuild from scratch" step 4 runs `bootstrap_openshift_gitops.yaml`.
+- `docs/openshift-operations.md` → "GitOps bootstrap / Run" runs `bootstrap_openshift_gitops.yaml`, and frames `hub-cluster/bootstrap_gitops.yaml` as a "near-identical playbook for a hub cluster pattern… use it instead when bringing up the hub" — i.e. explicitly *not* for `ocp`.
+
+Evidence of the drift:
+
+| Playbook | Lines | Last touched |
+|---|---|---|
+| `bootstrap_openshift_gitops.yaml` (what the docs say to run) | 96 | 2026-04-11 (lint pass) |
+| `hub-cluster/bootstrap_gitops.yaml` (what recovery actually used) | 623 | 2026-07-03 (#312, during this incident) |
+
+The doc-endorsed playbook is a 3-month-stale 96-line stub; the working one is a 623-line actively-maintained playbook. A follower doing exactly what the runbook says gets a broken bootstrap and no signal as to why. The operator only avoided this from prior memory.
+
+**Recommendation:** Pick one bootstrap playbook as canonical for `ocp`, delete or clearly deprecate the other (a header comment `# DEPRECATED — superseded by hub-cluster/bootstrap_gitops.yaml, do not run`), and update both runbooks to name the real one. This is the highest-value single fix in this review.
+
+#### F2 — The root cause (a netboot pin that silently reinstalls) is undocumented; there is no danger callout and no mid-install pin-flip step
+
+The entire incident was: MS-01 is netboot-first, a per-host pin defaulted to `install-openshift` on a 30s timeout, an unattended reboot wiped the disk, and the mid-install reboot re-entered the installer in a loop that only breaks if you flip the pin to `local` *during* the install.
+
+None of that is in the runbooks:
+- No doc warns that a per-host pin defaulting to an installer is destructive on an unattended reboot. `docs/netboot-operations.md` line 51 *reassures* the reader that the fallback menu "offers localboot (default after 30s)" — the destructive install-defaulting host pin is never flagged as dangerous. The only PXE-wipe warning in the whole repo is buried in a 2026-05-06 *superpowers plan* about hpg5's k3s teardown, about a different host.
+- The mid-install "flip the pin to `local` or it loops forever" step appears nowhere. The `docs/openshift-operations.md` install flow is just "PXE-boot the rendezvous host" → "watch progress." Grepping the three runbooks for `flip`/`mid-install`/`default local` returns only an unrelated HTTPS↔HTTP note.
+
+The repo already has the right pattern for this — `docs/hermes-vm-lifecycle.md` uses blockquote **"Fully destructive"** callouts. It just was never applied to the netboot install pin, which is the most destructive lever in the whole system.
+
+**Recommendation:** Add a prominent danger callout to `netboot-operations.md` and `disaster-recovery.md`: which hosts are netboot-first, that an install-defaulting pin wipes disk on any reboot, that pins must default to `local` at rest, and the exact "flip to local at status=installing to break the reinstall loop" procedure with the `scp -O …/per-host/MAC-*.ipxe` command. This is a safety writeup, not a nicety.
+
+#### F3 — The shared nvme hostnqn/hostid bug is a latent cluster-wide correctness defect recorded only in the memory file
+
+The recovery found all three nodes baked with the *identical* `/etc/nvme/hostnqn`+`hostid` (`…466937ab…`), which violates NVMe-oF uniqueness and causes intermittent volume-attach failures cluster-wide. This will recur on every future agent-based reinstall.
+
+There is an nvmeof runbook — `docs/runbooks/nvmeof-stuck-multiattach.md` — and it is well-written, but it covers a *different* failure mode (Multi-Attach after a transport drop / `ctrl_loss_tmo`). It contains no mention of `hostnqn`, `hostid`, or `466937ab` (grep: no match). An engineer who hits the shared-hostnqn attach failure and lands on this runbook will follow a remediation that does not fix their problem.
+
+**Recommendation:** File the fix (a MachineConfig regenerating unique hostnqn/hostid per node) and, until then, add a short runbook or a "known latent issue" section to the DR runbook and the nvmeof runbook cross-linking it, with the symptom string ("unable to attach any nvme devices", "Connect command failed error 6") so it's discoverable by search.
+
+#### F4 — Live-only cluster state diverges from git and is recorded only in the memory file
+
+Several load-bearing changes exist *only* on the running cluster, not in git, and are tracked solely as memory-file TODOs:
+- ArgoCD CR `spec.resourceHealthChecks` PushSecret Lua health-check (opens the wave gate).
+- ArgoCD repo-server `cpu=2 / mem=2Gi` + `ARGOCD_EXEC_TIMEOUT=3m` (the fix for recurring wave stalls).
+- `kustomizeBuildOptions --enable-helm` sourced from a playbook-created CR.
+
+The memory file itself flags these as "⚠ live-only (CR playbook-managed) — fold into bootstrap_gitops.yaml." Until that happens, anyone who re-runs the bootstrap playbook silently reverts them, and anyone comparing git to the cluster cannot tell intentional drift from accident.
+
+**Recommendation:** Track these as explicit issues (not memory bullets) and fold them into the bootstrap playbook / GitOps so the cluster is reconcilable from source. This is both a readability (single source of truth) and a durability problem.
+
+#### F5 — The stale-local-checkout hazard is a process footgun with no documented convention
+
+The memory file repeatedly warns that the local `igou-openshift` checkout is stale, so `oc kustomize` renders *old* manifests (it nearly redeployed the pre-recovery quay `initdb` instead of the recovery config). The mitigation the operator adopted — "fetch origin and `git show origin/main:<path>`" — is nowhere in a runbook or the repo's `CLAUDE.md`. This is exactly the kind of trap a second engineer would fall into.
+
+**Recommendation:** Add a one-line convention to the DR runbook and `CLAUDE.md`: "During recovery the control-node checkout may be stale; always `git fetch` and apply from `origin/main`, never from the working tree."
+
+#### F6 — CSR-approval guidance is fragile; the robust method found under fire wasn't captured
+
+A ~40-minute stall during worker re-join came from CSR filtering on the wrong column (`CONDITION` is column 6, not 5), so `awk '$5=="Pending"'` silently matched nothing while bootstrapper CSRs piled up. `docs/openshift-operations.md` offers `oc get csr | awk '/Pending/{print $1}' | …`, which is column-fragile in the same family. The robust approach the operator settled on — approve any CSR with no `.status` via `-o go-template='{{range .items}}{{if not .status}}…'` — is not in the docs.
+
+**Recommendation:** Replace the awk one-liner in the runbook with the status-based go-template form and a one-line note on why (unacted CSRs have empty `.status`, and node re-join issues two rounds per node).
+
+---
+
+### The incident memory file as a documentation artifact
+
+`project-ocp-cluster-reinstall.md` is the de-facto decision log for the whole recovery, so it deserves assessment on its own terms.
+
+**As a personal recall tool it is excellent.** It captures exact commands, file paths, PR numbers, PVC UUIDs, and — importantly — the *why* behind decisions and the operator directives that shaped them ("user CHOSE to leave publishing broken," "GO-LIVE DEFERRED per operator," "p330 stays dark per user"). That decision-provenance is genuinely good practice and better than most human runbooks.
+
+**As a shared artifact for a second engineer it has real readability problems:**
+
+- **Structure is a flat append-only timeline.** ~40 bullets, some 300+ words each, no sub-headings. There is no separation between "current state / what's left" and "narrative of what happened." To answer "is hermes restored?" you must read the whole thing and reconcile three bullets (state PV restored, VM provisioned, convergence still TODO).
+- **Durable lessons are buried mid-timeline.** The three highest-value, reusable facts — the destructive-pin root cause, the shared-hostnqn bug, and the three gotchas that each cost 40+ minutes — are scattered in the middle, marked with the same status emoji as ephemera. A reader cannot skim to "what must I never repeat."
+- **High cognitive load from unexpanded shorthand.** `zvol`, `CSS`, `HCO`, `CDI`, `MCS`, `OG`, `CVO`, `MCO`, `SSA`, `WAL`, `barman` appear without expansion, mixed with nested parentheticals and stacked status emoji (✅ ⏳ ⚠ 🚨🚨🚨). Fine for the author; a wall for a newcomer.
+- **The `MEMORY.md` index has the same trait at the top level** — each entry is a single run-on line packed with abbreviations and PR numbers. It optimizes for the author's grep-and-recall, not for a newcomer's orientation.
+
+**Recommendation:** When this incident closes, promote it from a chronological memory into a short structured post-incident record with four fixed sections: **Root cause** (2–3 sentences), **Timeline** (the existing bullets, unchanged), **Durable lessons / never-again** (the pin hazard, the hostnqn bug, the gotchas — the reusable core, surfaced), and **Follow-ups** (the open TODOs, ideally as tracked issues). The memory file is where reusable operational knowledge is *born*; the gap is that little of it graduates into the runbooks where the next operator will actually look.
+
+---
+
+### Naming and cognitive-load nits
+
+- **Two near-identical playbook names invite exactly the F1 mistake:** `bootstrap_openshift_gitops.yaml` vs `hub-cluster/bootstrap_gitops.yaml`. Whatever the outcome of F1, these two names are too close to sit side by side.
+- **`.yml` vs `.yaml` is inconsistent** across sibling playbooks (`add_node_iso.yml`, `deploy_pxe_assets.yml` vs `bootstrap_openshift_gitops.yaml`, `hub-cluster/bootstrap_gitops.yaml`). Trivial, but it costs a second of "which one" every time and breaks tab-completion muscle memory.
+- **`sync_1pasword_secrets.yml` has a typo in the filename** — and the runbook *documents the typo* ("fix in a future cleanup pass") rather than fixing it. Documenting a broken name normalizes it.
+- **The VM-name-must-be-alphanumeric footgun** (`truenasw1` the VM vs `truenas-w1` the hostname) is a genuine trap; it lives in memory but not in `hermes-vm-lifecycle.md` / the scaffold docs where someone would hit it.
+
+---
+
+### Prioritized recommendations
+
+| # | Action | Type | Priority |
+|---|---|---|---|
+| 1 | Fix both runbooks to name the correct GitOps-bootstrap playbook; deprecate/delete the drifted 96-line stub (F1) | Correctness of docs | **P0** |
+| 2 | Add a netboot-pin danger callout + the mid-install "flip to local" step to netboot/DR runbooks (F2) | Safety writeup | **P0** |
+| 3 | Document + track the shared nvme hostnqn/hostid bug and its fix; cross-link from the nvmeof runbook (F3) | Latent correctness | **P0** |
+| 4 | Fold the live-only ArgoCD CR patches into git/playbook; track as issues, not memory bullets (F4) | Single source of truth | P1 |
+| 5 | Add the "recovery uses origin/main, not the stale working tree" convention to DR runbook + CLAUDE.md (F5) | Process convention | P1 |
+| 6 | Replace the fragile awk CSR filter with the status-based go-template form (F6) | Runbook accuracy | P1 |
+| 7 | Convert the incident memory into a 4-section post-incident record (root cause / timeline / never-again / follow-ups) | Doc structure | P1 |
+| 8 | Normalize playbook extensions, fix the `1pasword` typo, disambiguate the two bootstrap names | Naming hygiene | P2 |
+
+**One-line takeaway:** the runbooks are good but *lagging* — recovery succeeded on operator memory that the committed docs contradict in two places (F1) and omit entirely for the two most important lessons (F2, F3); closing that gap is the difference between "one person can do this" and "any engineer can safely repeat it."
+
+---
+
+## Consolidated Action Items
+
+De-duplicated and prioritized merge of every recommendation across the six persona sections, the four repo/architecture reviews, and the 46 component reviews. **P0** = do before the next reboot (prevents recurrence, active correctness/data-loss, or closes the detection gap); **P1** = weeks (backups, drift, restore-completion, missing capability); **P2** = quarter (hardening, hygiene, cost). Where reviewers disagreed the row notes it.
+
+### P0 — stop the bleeding
+
+| Priority | Item | Rationale | Rough effort | Source reviewer(s) |
+|---|---|---|---|---|
+| P0 | **Fix the shared NVMe hostnqn/hostid at both layers.** Ship a MachineConfig for *both* master and worker pools with a self-generating oneshot (regenerate `/etc/nvme/hostnqn` + `hostid` only when `==466937ab`, ordered before nvmf-autoconnect/kubelet), roll workers-then-master, **and** bind-mount host `/etc/nvme` into the democratic-csi `csi-driver` container so CSI stops using its image-baked shared `941e4f03` NQN. Bake the same oneshot into agent-install day-1 manifests. | NVMe-oF host-uniqueness violation across all 3 nodes → intermittent volume-attach failures and filesystem-corruption risk on the default StorageClass; already paused the Hermes VM once. Host-only fix is insufficient — CSI overrides it. Reintroduced on every reinstall unless day-1. | Med | Virtualization Admin, Architecture, GitOps Repo, Ansible Repo, K8s Admin, SRE, machineconfigs, democratic-csi (+ echoed by ~15 component reviews) |
+| P0 | **Fold the live-only ArgoCD CR patches into git.** Self-manage the ArgoCD CR via a wave-0 GitOps app (preferred) or codify in `bootstrap_gitops.yaml`: repo-server `cpu=2`/`mem=2Gi` + `ARGOCD_EXEC_TIMEOUT=3m`, and the `PushSecret`/`ExternalSecret` Lua health-checks. Add only the PushSecret entry via merge/JSON-patch, not a full-array replace. | These are the exact patches that un-stalled the wave gate and repo-server timeouts during DR; they exist only on the running cluster and are wiped the next time bootstrap runs — reintroducing the stalls during the *next* DR. | Low | K8s Admin, SRE, SWE, Readability, GitOps Repo, Ansible Repo, Incident |
+| P0 | **Neutralize the CNPG recovery-bootstrap footgun on all 3 DBs** (quay / rhdh / forgejo). Revert `bootstrap.recovery` to a steady-state (`initdb` for the cheaply-reseedable DBs, per K8s-admin/SWE/GitOps) **or** repoint the recovery `serverName` to the live `-r20260704` archive (DBA's preference, so a recreate restores *current* data rather than empty), and add `ignoreDifferences` on `/spec/bootstrap`. | Git currently encodes a one-shot point-in-time restore as permanent desired state pinned to the pre-disaster archive; a Cluster recreate silently rolls back to the 2026-07-02 snapshot, and the immutable field holds all three apps permanently OutOfSync today. | Low | K8s Admin, SWE, DBA, GitOps Repo, Incident, cloudnative-pg, quay/rhdh/forgejo |
+| P0 | **Kill the netboot-first destroy path (defense in depth).** Set MS-01 (and all nodes) firmware to disk-first with PXE as a manual-only option; make `local` the hard default of every netboot menu and move `install-openshift` behind an explicitly-armed, auto-disarming pin; add a CI/lint check that fails on any committed per-host pin defaulting to an install target; make pin push/verify content-hash based (not size-only). | Root cause. `inv#120` (pin default `local`) removed the immediate trap, but firmware is still netboot-first and the install menu still defaults to install on a 30s timeout, so any re-added stale pin re-arms the wipe. | Low–Med | SRE, Architecture, Ansible Repo, Incident, K8s Admin, Readability |
+| P0 | **Enable scheduled etcd backups** to an off-cluster / different-failure-domain target (TrueNAS/RustFS S3), managed in GitOps, plus a written+rehearsed single-node quorum-restore runbook. | Single etcd member with zero backup means the next disk/node loss is again a multi-hour ground-up rebuild instead of a ~20-min restore; the cheapest change that converts a repeat event from rebuild → restore. | Low | K8s Admin, SRE, Architecture |
+| P0 | **Stand up an external dead-man's-switch / heartbeat** (off-cluster watchdog on TrueNAS or a Pi that probes the API + a canary Route and expects a periodic Watchdog-derived heartbeat; page Gotify/Slack/Telegram on silence). | Whole-cluster loss produces zero alerts because the entire alert pipeline is in-cluster; this is the direct cause of the unbounded MTTD — the single highest-leverage detection fix. | Low–Med | SRE |
+
+### P1 — backups you can trust, and finish the restore
+
+| Priority | Item | Rationale | Rough effort | Source reviewer(s) |
+|---|---|---|---|---|
+| P1 | **Fix the 1Password Connect write grant** on vaults `claude` + `ocp-push`, then drain the 6 `service-accounts` PushSecrets. | Reinstall minted new SA tokens; 6 automation consumers (claude, molecule, ns-agent, vm-ops, cluster-read-only/edit) still read stale/invalid tokens from 1Password because write-back 403s; ArgoCD "Healthy" masks it. | Low | service-accounts, onepassword-connect, external-secrets-operator, molecule, K8s Admin |
+| P1 | **Recover Forgejo correctly.** Re-run recovery with `database: forgejo, owner: forgejo` so the `-app` secret points at the restored DB (currently serving an empty `app` DB); locate + restore the 100Gi `forgejo-shared-storage` git repo filesystem (orphaned zvol / gitea-mirror / GitHub mirrors); add a filesystem backup for it. | forgejo is Running but functionally empty — 356 repos orphaned in the wrong DB and the git objects were never restored and have no backup; also breaks PaC tenants. Active data-loss exposure. | Med | forgejo, DBA |
+| P1 | **Restore the alert-delivery path:** deploy the `gotify` bridge and the AAP/EDA event-stream endpoint. | Default Alertmanager receiver NXDOMAINs (gotify ns absent) so push/Watchdog delivery fails and fans out retry-storms to Slack; `eda-github-issue` 503s so no auto-issues are filed. | Low | SRE, alertmanager-config, gotify, ansible-automation-platform |
+| P1 | **Unblock the OpenShift Pipelines operator** (delete the stuck shared InstallPlan `install-khg9h` so OLM regenerates a pipelines-only auto plan, preserving ServiceMesh's Manual gate), and move workload operators out of the shared `openshift-operators` OperatorGroup. | Pipelines never installed post-rebuild — its Automatic install is co-bundled with a Manual servicemesh CSV; cascades to `pac-tenants` (all tenant CI down). | Low–Med | openshift-pipelines, pac-tenants, K8s Admin |
+| P1 | **Enable OADP/Velero** (operator already in-repo, unenabled) targeting RustFS/S3 for scheduled, restore-tested backups of namespaces + app CRs + PV data as consistent sets; add scheduled Hermes-state + PV-zvol snapshots with retention and an off-box replica. | No consistent point-in-time backup of app resources + PVs exists; Hermes state and forgejo git were recovered by hand/luck. | Med | SRE, Virtualization Admin, Architecture |
+| P1 | **Break the backup failure domain.** Add a second off-box/off-site S3 target (Backblaze/Wasabi or a replicated TrueNAS) for the CNPG Barman stores and etcd/PV snapshots; move Barman off the flaky cold RustFS to SSD; add a backup-liveness/credential check. | Every zvol, every Barman bucket, the boot artifacts, and truenas-w1 all live on one TrueNAS — a TrueNAS loss destroys primary + all backups together; the RustFS target was wedged mid-incident and the quay base was ~3 weeks stale. | Med | DBA, SRE, Architecture, GitOps Repo, cloudnative-pg |
+| P1 | **Fix the DR runbook to name the correct bootstrap playbook** (`hub-cluster/bootstrap_gitops.yaml`); delete/deprecate the stale 96-line `bootstrap_openshift_gitops.yaml` and the ad-hoc `bootstrap-gitops.sh`; update the molecule converge that validates the wrong artifact. | Both committed runbooks and CI point at a 3-month-stale drifted stub that fails hard on a real DR; recovery only avoided it from memory. Highest-value single doc fix. | Low | Readability, Ansible Repo, SWE |
+| P1 | **Write and check in the DR runbook gaps:** netboot-pin danger callout + the mid-install "flip to local" step; the shared-hostnqn known issue cross-linked from the nvmeof runbook; the out-of-band secrets seed order (Connect JWT is the `credential` field; `onepassword_doc` returns bytes → base64/`data:`); the stale-checkout "apply from origin/main" convention; the status-based go-template CSR approve (condition is column 6, not 5). | Nearly every gotcha was rediscovered live; the two most important lessons (destructive pin, hostnqn) are in no runbook an operator would search. | Med | Readability, SRE, GitOps Repo, external-secrets-operator, onepassword-connect, Incident |
+| P1 | **Codify the CAPI burst-worker restore.** Reconcile `clusterName` `ocp-hb42r → ocp-m97rd` (in `cluster-config-configmap.yaml` *and* the autoscaler's discovery arg atomically); re-copy `worker-user-data-managed`; recreate the `ocp-m97rd-kubeconfig` secret and patch `ControlPlaneInitialized=True`; fold these one-time steps into GitOps/DR automation. | Reinstall regenerated the infra name; the burst-scale path is broken (latent only because MachineSet is at 0) and the manual bootstrap steps were silently skipped during recovery. | Med | cluster-api, cluster-api-operator, cluster-api-autoscaler |
+| P1 | **Fix the llmkube p330 node-pin.** Repoint or `replicas: 0` the `qwen35-2b` InferenceService currently pinned to the dead `p330.igou.systems`. | It will be permanently `Pending` the moment llmkube deploys — stale-hardware config that survived the rebuild. | Low | llmkube |
+| P1 | **Correct the openshift-virt placement guard.** Change the virt-handler `NotIn` value from `truenas-w1.igou.systems` to `truenas-w1` (the real hostname label). | The guard meant to keep VMs off the nested-KVM/storage-colocated worker is a silent no-op; virt-handler runs on truenas-w1 today. | Low | openshift-virt |
+| P1 | **Guard the single control plane against workload starvation.** Taint the master `NoSchedule` (run user workloads on hpg5/truenas-w1) or, if it must stay schedulable, add per-namespace `ResourceQuota` + default `LimitRange` and explicit memory limits on CNPG/quay/registry pods; confirm system/kube-reserved via kubeletconfig. | No quota/limits on any user namespace; one leaky pod can drive MemoryPressure on the single etcd node → fsync stalls → cascading control-plane instability. | Low–Med | K8s Admin |
+| P1 | **Finish app-of-apps convergence and de-couple it.** Split the monolithic health-gated root into a few independent roots (platform/services/apps); add `SkipDryRunOnMissingResource=true` on operator/operand apps; gate operator apps on CSV `Succeeded` rather than broad health. | One monolithic wave ladder serialized the whole recovery — a single degraded low-wave app (quay/service-accounts) froze 7 unrelated apps (firecrawl, searxng, jellyfin, llmkube, gotify, gitea-mirror, AAP). | Med | K8s Admin, GitOps Repo, firecrawl/searxng/jellyfin/llmkube/gotify/gitea-mirror/AAP |
+| P1 | **Set `reclaimPolicy: Retain`** on the democratic-csi StorageClasses holding irreplaceable data (or per-PV), and keep the PVC→zvol catalog current. | Every class is `Delete` today; data survived only because the cluster died without issuing CSI deletes — a clean prune would have destroyed the zvols permanently. | Low | Architecture |
+| P1 | **Break-glass off-cluster secrets store.** Keep a minimal, documented out-of-band copy of the seed secrets (`1password-credentials.json`, Connect token, pull secret) and codify the seed as a checklisted DR step. | Connect/ESO/AAP all die with the cluster, so every `op` lookup was dead during recovery; a burnt view-once share link nearly blocked the whole restore. | Low | SRE, external-secrets-operator, onepassword-connect |
+| P1 | **Add CSR-pending alerting + a tightly-scoped auto-approver** for the 3 known static nodes (select on absent `.status`, not `awk $5`). | Nodes are not Machine-backed, so kubelet serving-cert CSRs never auto-approve; rotation silently breaks `oc logs/exec/adm top`. The column bug cost ~40 min during recovery. | Med | K8s Admin, Architecture, SRE |
+| P1 | **Land the nvme-tcp worker/all-roles module-load MachineConfig and the `ctrl_loss_tmo=-1` (#295) udev MachineConfig.** | nvme-tcp is boot-loaded only on master; workers depend on a CSI modprobe side-effect (first-attach-after-reboot race). The #295 multi-attach fix is not host-persistent. | Low | Architecture, machineconfigs, Virtualization Admin |
+| P1 | **Add backup-health alerting** (`ContinuousArchiving=False`, `LastBackupSucceeded=False`, last-backup-age > ~26h) and `enablePodMonitor` parity across all 3 CNPG DBs; alert on `PushSecret Ready=False`. | No backup-liveness alerting exists; ArgoCD Healthy masks Errored PushSecrets and stale backups. | Low | DBA, service-accounts |
+| P1 | **Persist platform Prometheus** (add `prometheusK8s` storage; the chart already parameterizes `freenas-nvmeof-fast-csi`). | Platform metrics are emptyDir → all history lost on reboot, so there was no telemetry across the very reboot that destroyed the cluster. | Low | SRE, ocp-base-config |
+
+### P2 — make recovery boring / hardening / hygiene
+
+| Priority | Item | Rationale | Rough effort | Source reviewer(s) |
+|---|---|---|---|---|
+| P2 | **Write and quarterly-drill a full DR runbook / game-day**; set explicit RTO (<2h API, <4h data) and RPO (<24h, <1h DBs); automate the manual recovery steps (idempotent recovery playbook: regen PXE, seed break-glass secrets, scoped CSR approve, drive wave-gate operator bootstraps). | There was no pre-existing tested runbook; MTTR was low only because one expert improvised the whole thing. | Med–High | SRE, Readability, Incident |
+| P2 | **Fix `deploy_pxe_assets.yml`:** correct the dead netbootxyz destination → public nginx (with the `chmod 755`/`--chmod=F0644,D0755` fix), remove CLI-argv secrets, `0600` + non-shared the /tmp auth copy; factor a shared publish task with the model `add_node_iso.yml`. | The publish playbook writes to retired infra and leaks the cluster-admin kubeconfig via argv/world-readable tmp; recovery had to hand-upload. | Med | Ansible Repo, SWE |
+| P2 | **Consolidate GitOps bootstrap to one playbook** (delete the stale duplicate + the shell reimplementation) and add smoke + idempotence tests; add early `assert target_cluster is defined` and replace the blind 60s sleep with a CRD/CSV wait + retries on the ArgoCD CR create. | Three disagreeing bootstrap artifacts (one drifted, one buggy shell) invited the wrong path mid-incident; the good one has a no-retry create and unguarded vars. | Med | SWE, Ansible Repo, Readability |
+| P2 | **Move to a compact 3-node control plane** (or explicitly accept single-node as ephemeral and back it accordingly). | One etcd member / one master = total, immediate cluster loss on any MS-01 event; a 3-node plane would have survived this disaster outright. | High | Architecture, SRE |
+| P2 | **Harden the Hermes VM:** set `evictionStrategy: None` while RWO/non-migratable; pin/record the centos-stream10 golden-image digest; schedule guest-agent-quiesced VirtualMachineSnapshots + off-cluster export of `hermes-state` with a block-PVC restore runbook; move to UEFI + explicit `clock.utc`; extend the hardening VAP to firmware/eviction/storage. | Non-migratable VM hangs node drains; the only irreplaceable VM data was restored by hand; the agent's root image is an unpinned moving target. | Med | Virtualization Admin, hermes-agent |
+| P2 | **Put golden images (or a boot-critical VM) on a second backend** (node-local LVMS exists) so VM boot + rebuild is not fully gated on live TrueNAS. | Every VM disk and every os-image DataSource is on one TrueNAS over the fragile nvmeof transport. | Med | Virtualization Admin |
+| P2 | **Replace `recomment.py` with a declarative per-app `enabled` flag / ApplicationSet generator**; if a scripted toggle survives, YAML-parse + hard-fail on unmatched names + make it reversible. | The lossy regex text-mutator on the single file that controls the whole cluster can silently leave a workload enabled during a staged restore. | Med | SWE |
+| P2 | **Staleness guard + secret hygiene:** recovery tooling must `git fetch`/pin `origin/main` (or apply only via ArgoCD) with a preflight that aborts if `HEAD != origin/main`; stream secrets from `op` at point-of-use and `shred` the incident scratch (persisted pull secret + SA tokens). | A stale local checkout already produced one wrong apply (quay `initdb` vs `recovery`); crown-jewel credentials were left in cleartext on disk. | Low | SWE, Readability, Incident |
+| P2 | **Codify worker re-join quirks** into playbooks: status-based CSR approve, truenas-w1 VM `time: UTC` (Ignition x509), CDROM device ordering + node-image ISO path (RAW `.dsk` is non-viable), and de-risk the `!! UNTESTED` VM-lifecycle playbooks. | These ad-hoc one-liners each cost debug cycles and will recur on the next worker rebuild. | Med | SWE, Ansible Repo, Incident |
+| P2 | **Resolve operator-lifecycle drift:** settle the Manual servicemesh InstallPlan queue, pin floating channels (`gitops`/`pipelines`=latest, `rhdh`=fast), and decide one approval policy per operator. | Half-approved Manual queue + floating Automatic channels = surprise operand migrations with no test tier on a cluster that just proved it has no staging. | Low | K8s Admin, openshift-pipelines, several operator components |
+| P2 | **Make the service-accounts PushSecrets honest** (set `enabled: false` on the 6 doomed read-only pushes, or grant a write-scoped token) so git isn't papering over a permanent 403 with a live-only health-check; split read-only vs write Connect tokens per store class. | Two layers of hidden state (live-only Lua check + broken-by-design pushes) mask a permanent failure; single shared token spans read+write across all vaults. | Low | GitOps Repo, external-secrets-operator, service-accounts |
+| P2 | **Decide durability posture for ephemeral components:** back the internal image-registry (emptyDir today) with S3/PVC or document it as a deliberate cache; flip lvms `forceWipeDevicesAndDestroyAllData` back to `false`; decide jellyfin `/config` and gitea-mirror SQLite restore (or accept fresh) and add both to a backup routine; guard gitea-mirror's auto-cleanup (`CLEANUP_DRY_RUN`) against the freshly-restored Forgejo. | Assorted per-component durability gaps that will surface on the next restart/rebuild. | Low–Med | image-registry, lvms-operator, jellyfin, gitea-mirror |
+| P2 | **Config-quality / drift cleanup:** add a `letsencrypt-staging` ClusterIssuer (rebuild-loop rate-limit safety); prune the stale `automation.apps` blackbox probe; add the `firecrawl` namespace to the searxng NetworkPolicy; add a LokiStack+ClusterLogForwarder or document logging as intentionally idle; wire or delete the orphaned nvidia time-slicing ConfigMap; bump nfd operand to v4.21; label `node-role.kubernetes.io/tenant` durably for remote-tenants; remove the dead `certManager` block from `ocp-base-config`; normalize `.yml`/`.yaml` + fix the `sync_1pasword` typo. | Long tail of misleading/dead config and cosmetic drift that raises cognitive load and invites wrong "fixes" during the next incident. | Low (each) | cert-manager-config, user-workload-monitoring, searxng, loki/openshift-logging, nvidia-gpu-operator, openshift-nfd, remote-tenants, ocp-base-config, Readability |
+| P2 | **Optional posture decisions:** etcd encryption-at-rest (`identity → aescbc`); quay `FEATURE_USER_CREATION` on its public route; MetalLB BGP MD5/BFD; audit the Tailscale API-server-proxy ACL grants and version them alongside the repo. | Deliberate security/resilience choices worth an explicit decision now that the cluster is stable. | Low (each) | apiserver, quay-operator, metallb, tailscale-operator |
+| P2 | **Promote the incident memory into a structured post-incident record** (Root cause / Timeline / Never-again / Follow-ups) and graduate the durable lessons into the runbooks. | The knowledge that saved the cluster lives in a dense append-only memory file, not where the next operator will look. | Low | Readability |

--- a/docs/runbooks/cnpg-barman-recovery.md
+++ b/docs/runbooks/cnpg-barman-recovery.md
@@ -1,0 +1,321 @@
+## Recover a CloudNativePG database from Barman on RustFS
+
+> Operational runbook. Derived verbatim from the 2026-07-03 `ocp.igou.systems` reinstall,
+> in which the `quay-pg`, `rhdh-pg`, and `forgejo-pg` CloudNativePG (CNPG) databases were
+> restored from Barman Cloud backups on the RustFS S3 endpoint after the cluster's disks
+> were wiped. All three came back healthy: `forgejo` (128 tables), `backstage` (119 tables
+> across its per-plugin schemas), `quay` (103 tables). Corresponds to merged PRs
+> [igou-openshift#387](https://github.com/igou-io/igou-openshift/pull/387) (recovery bootstrap)
+> and [#388](https://github.com/igou-io/igou-openshift/pull/388) (the serverName fix).
+
+### Purpose
+
+Rebuild a CNPG `Cluster`'s data from its Barman Cloud backup (base backup + WAL replay)
+when the underlying Postgres storage is gone — e.g. after a full cluster reinstall, a
+destroyed PVC, or an unrecoverable corruption. This switches the cluster's `bootstrap`
+stanza from `initdb` (create empty DB) to `recovery` (restore from object store), then
+puts the recovered cluster back onto a fresh WAL-archiving timeline so it keeps making
+its own backups.
+
+### When to use
+
+Use this when **all** of the following hold:
+
+- A CNPG `Cluster` on `ocp` needs its data recreated and there is no live Postgres
+  instance to `pg_dump` from (the volume is blank or gone).
+- A Barman Cloud backup for that cluster exists on RustFS. Confirm before starting:
+  the base backups used in this incident lived under
+  `s3://cnpg-backups/<cluster>` on `https://truenas.igou.systems:20292`, with the
+  latest base backups dated **2026-07-02** (the day before the disaster). On TrueNAS the
+  same data is browsable at `/mnt/cold/apps/rustfs-cold/cnpg-backups/{quay-pg,rhdh-pg,forgejo-pg}`.
+- The RustFS-cold instance is **up and serving** (see Gotchas — it wedges and masks all
+  buckets as `InvalidAccessKeyId`). If restores can't reach the bucket, unwedge RustFS first.
+
+Do **not** use this for a routine point-in-time rollback of a *running* database — that is
+a different (and destructive) operation. This runbook is for rebuild-from-nothing DR.
+
+### Prerequisites
+
+1. **Cluster + GitOps healthy.** `KUBECONFIG` points at the reinstalled cluster:
+   ```bash
+   export KUBECONFIG=$HOME/openshift-agent-install/ocp/cluster-manifests/auth/kubeconfig
+   ```
+   OpenShift GitOps (ArgoCD), 1Password Connect, and External Secrets are all up so the
+   `cnpg-s3-credentials` ExternalSecret can resolve.
+
+2. **CNPG operator + Barman Cloud plugin installed** in the `cloudnative-pg` namespace
+   (CNPG 1.29.1 in this incident). Verify:
+   ```bash
+   oc get crd objectstores.barmancloud.cnpg.io
+   oc get deploy -n cloudnative-pg barman-cloud        # Available
+   ```
+   For an app whose operator/CRDs are not yet present (quay, CNV), apply the namespace +
+   OperatorGroup + Subscription + ObjectStore + ExternalSecret + Cluster **directly first**,
+   let the operator install, then let ArgoCD sync the rest.
+
+3. **S3 credentials reachable.** The `cnpg-s3-credentials` Secret is produced by an
+   ExternalSecret (`applications/<app>/cnpg-s3-credentials-externalsecret.yaml`) from the
+   1Password item **`cnpg-s3-backup`** in vault **`ocp-pull`** (fields `access_key_id` /
+   `secret_access_key` → keys `ACCESS_KEY_ID` / `ACCESS_SECRET_KEY`). Confirm it exists in
+   the app namespace:
+   ```bash
+   oc get externalsecret,secret cnpg-s3-credentials -n <app-namespace>
+   ```
+
+4. **The ObjectStore CR exists** in the app namespace and points at the pre-disaster
+   backup path. It is intentionally left with `serverName` **omitted** (defaults to the
+   cluster name), e.g. `applications/forgejo/forgejo-pg-objectstore.yaml`:
+   ```yaml
+   apiVersion: barmancloud.cnpg.io/v1
+   kind: ObjectStore
+   metadata:
+     name: forgejo-pg-backup
+     namespace: forgejo
+   spec:
+     configuration:
+       destinationPath: s3://cnpg-backups/forgejo-pg
+       endpointURL: https://truenas.igou.systems:20292
+       s3Credentials:
+         accessKeyId:    { name: cnpg-s3-credentials, key: ACCESS_KEY_ID }
+         secretAccessKey: { name: cnpg-s3-credentials, key: ACCESS_SECRET_KEY }
+   ```
+
+5. **Fresh repo checkout.** Work from `origin/main`, not the local tree — see the
+   stale-checkout gotcha below.
+   ```bash
+   cd /workspace/igou-openshift
+   SSH_AUTH_SOCK= git fetch origin main
+   ```
+
+Namespace / cluster / database map for this cluster (for reference):
+
+| ArgoCD source path                          | Namespace         | Cluster      | Database    |
+| ------------------------------------------- | ----------------- | ------------ | ----------- |
+| `applications/forgejo/forgejo-pg-cluster.yaml` | `forgejo`         | `forgejo-pg` | `forgejo`   |
+| `components/rhdh/rhdh-pg-cluster.yaml`          | `rhdh`            | `rhdh-pg`    | `backstage` |
+| `components/quay-operator/quay-pg-cluster.yaml` | `quay-enterprise` | `quay-pg`    | `quay`      |
+
+### Step-by-step
+
+Below uses `forgejo-pg` as the worked example. Repeat per cluster, substituting from the
+table above. `<db>` is the CNPG cluster name (`forgejo-pg`), `<ns>` its namespace.
+
+#### 1. Switch `bootstrap.initdb` → `bootstrap.recovery` + add `externalClusters`
+
+Edit the cluster manifest (e.g. `applications/forgejo/forgejo-pg-cluster.yaml`). **Comment
+out** the existing `initdb` block (keep it in the file for the later revert) and replace it
+with a `recovery` bootstrap plus an `externalClusters` entry that names the Barman source:
+
+```yaml
+  # 2026-07-03 disaster recovery: restore from the Barman Cloud backup on RustFS
+  # instead of initdb. Revert to the initdb block below once recovered and verified.
+  #   bootstrap:
+  #     initdb:
+  #       database: forgejo
+  #       owner: forgejo
+  bootstrap:
+    recovery:
+      source: forgejo-pg          # must match an externalClusters[].name below
+  externalClusters:
+    - name: forgejo-pg
+      plugin:
+        name: barman-cloud.cloudnative-pg.io
+        parameters:
+          barmanObjectName: forgejo-pg-backup   # the ObjectStore CR name
+          serverName: forgejo-pg                # READ side: the ORIGINAL (pre-disaster) serverName
+```
+
+`serverName: forgejo-pg` here is the **read/recover** side — it tells CNPG which historical
+server's base+WAL to replay (the pre-disaster archive, which defaults to the cluster name).
+
+#### 2. CRITICAL — archive the recovered cluster to a NEW serverName
+
+In the **same** manifest, the live WAL-archiving plugin (`spec.plugins[]`,
+`isWALArchiver: true`) **must** use a *different, empty* `serverName`. If you leave it at
+the default (cluster name = the same server you just recovered from), CNPG refuses to start
+archiving and the recovery never completes:
+
+```
+WAL archive check failed: Expected empty archive
+```
+
+CNPG will not archive a new timeline into an object-store prefix that already holds another
+server's WAL (that would corrupt the source you recovered from). Point archiving at a fresh
+name — the convention used here is `<db>-r<YYYYMMDD>`:
+
+```yaml
+  plugins:
+    - name: barman-cloud.cloudnative-pg.io
+      enabled: true
+      isWALArchiver: true
+      parameters:
+        barmanObjectName: forgejo-pg-backup
+        serverName: forgejo-pg-r20260704       # WRITE side: NEW, empty prefix for the post-recovery timeline
+```
+
+Net effect: recover **from** `s3://cnpg-backups/forgejo-pg/forgejo-pg/…` (old, populated),
+archive **to** `s3://cnpg-backups/forgejo-pg/forgejo-pg-r20260704/…` (new, empty). The
+ObjectStore `destinationPath` is unchanged.
+
+#### 3. Apply the change
+
+Commit + push and let ArgoCD sync (the normal path — this is how #387/#388 landed), **or**
+for a direct DR apply pull the manifest straight from `origin/main` so a stale local
+checkout can't render the wrong thing (see gotcha):
+
+```bash
+SSH_AUTH_SOCK= git show origin/main:applications/forgejo/forgejo-pg-cluster.yaml | oc apply -f -
+```
+
+Deleting the old `Cluster`/PVC first (if a half-created one exists) forces CNPG to run the
+recovery bootstrap from scratch. Bootstrap only runs at cluster **creation**, so recovery
+must be in place *before* the cluster object is first created.
+
+#### 4. If the recovery Job is already stuck, delete it to force a retry
+
+If the cluster was already created and its full-recovery Job failed the archive check
+**before** you fixed the serverName (very common — this is the exact #387→#388 sequence),
+CNPG will not re-run it on its own after you edit the manifest. Delete the failed Job so
+CNPG recreates it with the corrected config:
+
+```bash
+oc delete job -n forgejo -l cnpg.io/jobRole=full-recovery
+```
+
+CNPG immediately spawns a fresh `<db>-full-recovery-*` Job. Watch it:
+
+```bash
+oc get pods -n forgejo -l cnpg.io/jobRole=full-recovery -w
+oc logs -n forgejo -l cnpg.io/jobRole=full-recovery -f
+```
+
+#### 5. Wait for recovery to finish
+
+Recovery = restore base backup, then replay WAL forward. Small DBs finish in minutes;
+**quay took ~1.5 days of WAL replay** because of its WAL volume, so do not assume a hang —
+tail the logs. When done, the recovery Job completes and the primary pod goes `Running` /
+`Ready 2/2`:
+
+```bash
+oc get cluster forgejo-pg -n forgejo
+# NAME         INSTANCES  READY  STATUS                     PRIMARY
+# forgejo-pg   1          1      Cluster in healthy state   forgejo-pg-1
+```
+
+### Verification
+
+For each restored cluster, confirm it is healthy, on a new timeline, archiving to the new
+serverName, and — most importantly — that the **data is actually there**.
+
+```bash
+# 1. Cluster healthy, no leftover recovery jobs
+oc get cluster -A
+oc get jobs -A -l cnpg.io/jobRole=full-recovery      # expect: No resources found
+
+# 2. New timeline opened (recovery bumps timeline_id past 1)
+oc exec -n forgejo forgejo-pg-1 -c postgres -- \
+  psql -U postgres -tAc "SELECT timeline_id FROM pg_control_checkpoint();"     # e.g. 2
+
+# 3. Table counts match the pre-disaster database
+oc exec -n forgejo forgejo-pg-1 -c postgres -- \
+  psql -U postgres -d forgejo -tAc \
+  "SELECT count(*) FROM information_schema.tables WHERE table_schema='public';"   # 128
+
+oc exec -n quay-enterprise quay-pg-1 -c postgres -- \
+  psql -U postgres -d quay -tAc \
+  "SELECT count(*) FROM information_schema.tables WHERE table_schema='public';"    # 103
+```
+
+**Backstage / rhdh is a trap:** `backstage` stores each plugin in its own schema
+(`catalog`, `scaffolder`, `auth`, `search`, …), so counting only `public` returns **0**
+even on a perfectly good restore. Count across all non-system schemas instead:
+
+```bash
+oc exec -n rhdh rhdh-pg-1 -c postgres -- \
+  psql -U postgres -d backstage -tAc \
+  "SELECT count(*) FROM information_schema.tables
+   WHERE table_type='BASE TABLE'
+     AND table_schema NOT IN ('pg_catalog','information_schema');"                 # 119
+```
+
+Also confirm the live archive is writing to the **new** serverName (not the source):
+
+```bash
+oc get cluster forgejo-pg -n forgejo \
+  -o jsonpath='{range .status.conditions[*]}{.type}={.status}{"\n"}{end}' | grep -i archiv
+# ContinuousArchiving=True
+```
+
+Finally, exercise the app itself (log in to Forgejo, push/pull an image to Quay, load the
+Backstage catalog) to confirm the app is happy with its restored schema.
+
+### Rollback / post-recovery cleanup
+
+Two distinct "reverts" apply here — do not confuse them:
+
+1. **Revert `bootstrap` recovery → initdb in git (required follow-up).** Once the DBs are
+   verified healthy, change the `bootstrap` stanza back to the original `initdb` block
+   (uncomment it; remove `recovery` + `externalClusters`) and merge. `bootstrap` is only
+   honored at *initial* cluster creation, so this is a no-op on the running cluster — but it
+   is essential hygiene: it stops a future ArgoCD re-sync or a fresh cluster recreation from
+   silently re-triggering a recovery from a now-stale backup. This was tracked as an explicit
+   remaining item after #389.
+
+2. **Keep the archiving `serverName` at `<db>-r20260704` — do NOT roll it back.** That new
+   prefix is now the cluster's live WAL timeline. Reverting it to the base cluster name would
+   re-collide with the old archive and re-trigger `Expected empty archive`. Leave the
+   `spec.plugins[].parameters.serverName` at the recovery value permanently. (When you next
+   need to restore, the recover-from `externalClusters` serverName is what changes, not this.)
+
+If a recovery goes wrong mid-flight (wrong source, corrupt base, wrong serverName), the safe
+reset is: delete the `Cluster` and its PVC, correct the manifest, and re-apply so bootstrap
+runs cleanly from scratch — recovery cannot be "resumed" on a half-built cluster, only
+restarted (via the Job delete in step 4, or a full cluster recreate).
+
+### Gotchas & pitfalls (from this incident)
+
+- **`WAL archive check failed: Expected empty archive` is the #1 failure.** It is *not* an
+  S3/credential problem — it means your archiving `serverName` still points at a populated
+  prefix. Fix = new serverName (step 2). This was the entire content of PR #388.
+
+- **Editing the manifest is not enough to un-stick a failed recovery.** CNPG will not
+  re-run a failed full-recovery Job automatically. You must
+  `oc delete job -l cnpg.io/jobRole=full-recovery -n <ns>` to force a retry (step 4).
+
+- **Stale local checkout renders the wrong manifest.** The local `/workspace/igou-openshift`
+  tree was ~100 commits behind (`59a2bc7`). Running `oc kustomize` from it rendered the
+  **old `initdb`** for `quay-pg` instead of the recovery bootstrap, silently undoing the fix.
+  Always `git fetch origin main` and apply via `git show origin/main:<path> | oc apply -f -`
+  (or let ArgoCD sync from `main`) — never `oc kustomize .` from an unfetched tree.
+
+- **Backstage table count in `public` is 0 by design.** Its data is in per-plugin schemas;
+  count across all non-system schemas (see Verification) or you will wrongly conclude the
+  restore failed.
+
+- **Quay's WAL replay took ~1.5 days.** A long-running recovery Job is normal for a
+  WAL-heavy DB. Tail the logs; don't kill it as "hung."
+
+- **RustFS-cold wedges and hides every bucket.** The alpha RustFS instance
+  (`ix-rustfs-cold-rustfs-1` on TrueNAS) can flip its in-memory disk-health monitor to
+  "faulty," after which *all* S3 auth returns `InvalidAccessKeyId` / `InsufficientReadQuorum`
+  and buckets appear empty even though the data is intact on disk. If restores can't see the
+  backup, unwedge it first (`sudo docker restart ix-rustfs-cold-rustfs-1` on
+  `truenas.igou.systems`) before assuming the backup is missing.
+
+- **DR failure-domain caveat.** The RustFS S3 endpoint and the primary DB storage are the
+  *same* TrueNAS box / `freenas-nvmeof-*` pools. This restore works for a cluster wipe (disks
+  intact on TrueNAS) but a TrueNAS loss takes out primary **and** backups. Off-box replication
+  of `cnpg-backups` is the real DR gap.
+
+- **Operator/CRD ordering for quay & CNV apps.** If the target app's operator isn't installed
+  yet, `oc apply` the Namespace + OperatorGroup + Subscription + ObjectStore + ExternalSecret
+  + Cluster directly first, wait for the CSV to reach `Succeeded`, then let ArgoCD sync the
+  rest. A `Cluster` applied before its CRDs/operator will fail dry-run.
+
+- **RWO NVMe-oF pin.** These clusters pin to the control-plane node
+  (`nodeSelector: node-role.kubernetes.io/control-plane: ""`) so a rolling restart never
+  migrates the RWO NVMe-oF PVC to an ephemeral worker and trips the democratic-csi
+  Multi-Attach bug. Keep that affinity on the recovered cluster. (Separately, all three nodes
+  currently share one NVMe `hostnqn`/`hostid` — an unrelated latent bug that can cause
+  intermittent volume-attach failures; noted here only so an attach failure isn't mistaken
+  for a backup problem.)

--- a/docs/runbooks/gitops-bootstrap-from-scratch.md
+++ b/docs/runbooks/gitops-bootstrap-from-scratch.md
@@ -1,0 +1,359 @@
+## Bootstrap OpenShift GitOps + 1Password Connect/ESO after a rebuild
+
+Reusable runbook derived from the 2026-07-03 `ocp.igou.systems` cluster reinstall.
+Every command, path, host, and gotcha below was executed or observed during that
+recovery — nothing is aspirational.
+
+### Purpose
+
+After a full agent-based reinstall the control plane comes up with **no in-cluster
+secret machinery**: OpenShift GitOps (ArgoCD), 1Password Connect, and External
+Secrets Operator (ESO) are all gone, and every `op://` lookup that used to run
+on-cluster (AAP, ESO) is dead. This runbook performs the **chicken-and-egg
+bootstrap**: it seeds the two Secrets that Connect + ESO need, stands up ArgoCD with
+the correct health-check / plugin configuration, and hands the cluster over to the
+app-of-apps so ArgoCD can reconcile `clusters/ocp/` from git. It ends with the two
+live-only ArgoCD tweaks that the rebuild proved are required for the wave march to
+finish.
+
+The seed is done **out-of-band** using a 1Password *service-account* token
+(authenticating directly against 1Password SaaS, bypassing Connect — which is not up
+yet), because Connect itself cannot supply its own credentials.
+
+### When to use
+
+- Immediately after `ClusterVersion` reports `Available` on a freshly reinstalled
+  cluster (control plane MS-01 = `10.10.9.10`), before any application data restore.
+- Any time OpenShift GitOps must be re-bootstrapped from zero and the on-cluster
+  1Password lookups are unavailable.
+
+Do **not** use this to "repair" a running GitOps — re-running the playbook overwrites
+the live-only ArgoCD CR patches (see Step 5 / Gotchas).
+
+### Prerequisites
+
+- **API reachable** and the kubeconfig exported:
+  `export KUBECONFIG=$HOME/openshift-agent-install/ocp/cluster-manifests/auth/kubeconfig`
+  (this is the NEW kubeconfig minted by the agent installer; `oc get clusterversion`
+  must succeed).
+- **ocp-bootstrap 1Password service-account token** (a.k.a. the "dr" token), format
+  `ops_...`. It needs read access to at least the `ocp-connect-bootstrap` vault. In
+  the rebuild it was persisted at `~/.secrets/op-dr-sa-token` (mode 0600). This token
+  authenticates the `community.general.onepassword*` lookups directly against
+  1Password SaaS — Connect is not running, so it cannot be used.
+- **Repos present** (local checkouts are STALE — always `git fetch origin main` and
+  read with `git show origin/main:<path>`):
+  - `/workspace/igou-ansible` — the bootstrap playbook.
+  - `/workspace/igou-openshift` — the GitOps repo (`github.com/igou-io/igou-openshift`),
+    app-of-apps source at `clusters/ocp/`.
+- **Tooling**: `ansible-navigator` (or `ansible-playbook`) with `community.general` +
+  `kubernetes.core`; `oc`; `kustomize` + `helm` (the app-of-apps renders with
+  `--enable-helm`).
+- Data-restore backups (TrueNAS Barman on RustFS, hermes tars) reachable only if you
+  will proceed to the staged app restore (Step 4) — not required to stand up GitOps.
+
+### Step-by-step
+
+#### Step 0 — Environment + the kubeconfig CA-rotation fix
+
+```bash
+export KUBECONFIG=$HOME/openshift-agent-install/ocp/cluster-manifests/auth/kubeconfig
+oc get clusterversion            # must show 4.21.9 Available
+```
+
+**Kubeconfig CA-rotation gotcha (do this first, it bites early):** once the Machine
+Config Operator settles after install, the **API serving cert rotates to a new CA**.
+The `certificate-authority-data` embedded in the freshly generated kubeconfig then no
+longer matches, and every `oc` call fails with `x509: certificate signed by unknown
+authority`. Fix by **stripping `certificate-authority-data`** so `oc` falls back to
+the host's system trust store (the serving cert is publicly trusted):
+
+```bash
+cp "$KUBECONFIG" "${KUBECONFIG%/*}/kubeconfig_self_signed"   # backup FIRST
+# remove the certificate-authority-data line(s) from the cluster stanza
+# result: `grep -c certificate-authority-data "$KUBECONFIG"` must return 0
+```
+
+Verified end state: `kubeconfig` has 0 `certificate-authority-data` lines; the
+original is preserved at `.../auth/kubeconfig_self_signed`.
+
+#### Step 1 — Provide the service-account token to the lookups
+
+The playbook prompts for the token (`vars_prompt: op_bootstrap_sa_token`). Because the
+`community.general.onepassword*` lookups will otherwise try to reach a (dead) Connect
+server, make sure no Connect env vars are set and the SA token is exported:
+
+```bash
+unset OP_CONNECT_HOST OP_CONNECT_TOKEN
+export OP_SERVICE_ACCOUNT_TOKEN=$(cat ~/.secrets/op-dr-sa-token)   # ops_... token
+```
+
+#### Step 2 — Run the bootstrap playbook
+
+Use the **current** playbook — NOT the drifted one:
+
+- USE: `playbooks/openshift/hub-cluster/bootstrap_gitops.yaml`
+- AVOID: `playbooks/openshift/bootstrap_openshift_gitops.yaml` (its `config/` path is
+  stale; it will render old manifests).
+
+```bash
+cd /workspace/igou-ansible
+git fetch origin main
+ansible-navigator run playbooks/openshift/hub-cluster/bootstrap_gitops.yaml \
+  -e target_cluster=ocp \
+  -e kubeconfig="$KUBECONFIG"
+# (paste the ocp-bootstrap SA token at the vars_prompt)
+```
+
+What the play creates, in order:
+1. `openshift-gitops-operator` namespace + OperatorGroup + Subscription (channel
+   `latest`, `redhat-operators`).
+2. `external-secrets-operator` namespace.
+3. `onepassword-connect` namespace.
+4. **Seed Secret `op-credentials`** (ns `onepassword-connect`) — the Connect server's
+   `1password-credentials.json`.
+5. **Seed Secret `onepassword-connect-token`** (ns `external-secrets-operator`, key
+   `token`) — the Connect access JWT that ESO's ClusterSecretStores use.
+6. `gitops-cluster-admin` ClusterRoleBinding (argocd application-controller SA →
+   cluster-admin).
+7. The `ArgoCD` CR `openshift-gitops` (health checks, CMP setenv plugin, RBAC, repo
+   sidecar).
+8. `setenv-cmp-plugin` ConfigMap + `environment-variables` ConfigMap (derives
+   `CLUSTER_BASE_DOMAIN` / `PLATFORM_BASE_DOMAIN` from the `Ingress` config).
+9. `root-applications` Application → `clusters/ocp` (the app-of-apps root).
+
+**The two seed-Secret fixes (already merged into the playbook via igou-ansible#312 —
+do not regress them):**
+
+- **FIX 1 — the Connect JWT is in the `credential` field, not `token`.** The
+  `onepassword-connect-token` Secret pulls from the `ocp-connect-token` item using
+  `field='credential'`. The item's `token` field is an unrelated **83-char stub**; the
+  real Connect JWT (with `aud=com.1password.connect`, ~1762 chars) lives in
+  `credential`. Using `token` yields a Connect server that never authenticates.
+
+  ```yaml
+  token: "{{ lookup('community.general.onepassword', 'ocp-connect-token',
+             field='credential', vault='ocp-connect-bootstrap',
+             service_account_token=op_bootstrap_sa_token) }}"
+  ```
+
+- **FIX 2 — `onepassword_doc` returns bytes → use `data:` + `| b64encode`, not
+  `stringData`.** `community.general.onepassword_doc` returns raw bytes, which
+  ansible-core ≥ 2.19 refuses to serialize into module args. Put the value under
+  `data:` (base64) instead of `stringData:`:
+
+  ```yaml
+  data:
+    1password-credentials.json: "{{ lookup('community.general.onepassword_doc',
+      'ocp-connect-credentials', vault='ocp-connect-bootstrap',
+      service_account_token=op_bootstrap_sa_token) | b64encode }}"
+  ```
+
+Both Secrets are annotated `managed-by: ansible` and set `no_log: true`.
+
+#### Step 3 — Let the app-of-apps take over
+
+`root-applications` renders `clusters/ocp/` (Helm values → ~48 `Application`s) and
+orders them by `argocd.argoproj.io/sync-wave`. Foundation is **wave 0**:
+`external-secrets-operator` + `onepassword-connect`. The wave ladder observed:
+
+```
+ 0  external-secrets-operator, onepassword-connect
+ 1  lvms-operator
+ 2  machineconfigs        3  kubeletconfig
+ 5  nmstate, openshift-nfd
+ 6  metallb, udn, cert-manager-config, nvidia-gpu-operator, user-workload-monitoring
+ 7  democratic-csi        8  image-registry, ocp-base-config
+ 9  apiserver(+certs), ingresscontroller-certs
+10  cluster-api-operator, gateway-api, grafana, loki-operator, openshift-logging,
+    openshift-pipelines, tailscale-operator, intel-device-plugins-operator
+11  cluster-api           12  cluster-api-autoscaler
+19  firecrawl
+20  cloudnative-pg, hermes-agent, jellyfin, llmkube, searxng, gotify,
+    pac-tenants, remote-tenants
+22  forgejo, quay-operator, rhdh          23  gitea-mirror
+25  alertmanager-config   30  ansible-automation-platform   39  molecule
+40  service-accounts      50  openshift-virt
+```
+
+Note: `kustomizeBuildOptions` / `--enable-helm` come from the **ArgoCD CR the playbook
+created** (and the setenv CMP plugin's `kustomize build ... --enable-helm`). If you
+change plugin/build options live, the **repo-server must be restarted** to pick them up.
+
+#### Step 4 — Staged restore via sync-waves (DR only)
+
+In a full rebuild you do **not** enable all apps at once — a data-less app that lands
+before its PV/DB is restored goes Degraded and (because of the wave gate, below) wedges
+every higher wave. The rebuild deferred apps by **commenting them out in
+`clusters/ocp/values.yaml`** and uncommenting per wave (ArgoCD ignores comment
+indentation, so block-commenting an app entry is a clean defer).
+
+- Rebuild-from-original technique: `git show <defer-commit>^:clusters/ocp/values.yaml`
+  to recover the full list, then re-comment only the still-deferred apps. Scratchpad
+  helpers used: `recomment.py` + `values-original.yaml`.
+- Order actually used (each a merged PR): essential/stateless first
+  (igou-openshift#383/#384 — operators, CAPI, CNV-operator, tenants, pipelines,
+  tailscale) → observability (#385 — loki/logging/grafana/alertmanager) → stateful
+  wave 3 (#386 hermes-agent; #387/#388 the CNPG DBs quay/rhdh/forgejo restored from
+  Barman) → everything enabled (#389, values.yaml back to full).
+
+**Wave-gate behavior (the recurring trap):** the app-of-apps gates wave *N+1* on wave
+*N* being **Synced AND Healthy**. A single Degraded app in a low wave blocks all higher
+waves. Transient operator-install degrades (`service-accounts`, `grafana`,
+`cluster-api`) each stall the march — nudge by manually applying the operator's
+`ns + OperatorGroup + Subscription` from its component, wait for the CSV to Succeed,
+then hard-refresh.
+
+#### Step 5 — Codify the two live-only ArgoCD CR patches
+
+Both were applied **live** during the rebuild and are **not** in git yet. The ArgoCD CR
+is created by the playbook (NOT GitOps-managed), so re-running the playbook **wipes
+them** — they must be re-applied, and the standing TODO is to fold them into
+`hub-cluster/bootstrap_gitops.yaml`.
+
+**Patch A — lenient PushSecret health check (unblocks the wave gate).**
+`service-accounts` (wave 40) went Degraded because 6 PushSecrets returned 403 — the
+Connect token is **read-only** on the `claude` + `ocp-push` vaults, and the operator
+chose to leave outbound 1P publishing broken rather than widen the token. That Degraded
+wave-40 app gated `openshift-virt` (wave 50) and every wave > 40. The durable fix that
+honors "leave publishing broken" is a health-check override that reports PushSecrets
+Healthy:
+
+```bash
+# add an external-secrets.io/PushSecret entry to spec.resourceHealthChecks
+oc -n openshift-gitops patch argocd openshift-gitops --type=merge \
+  --patch-file /path/to/argocd-patch.json     # full resourceHealthChecks array
+# the change only takes effect after a controller restart + hard refresh:
+oc -n openshift-gitops rollout restart statefulset openshift-gitops-application-controller
+```
+
+The health-check body to embed in the ArgoCD CR `spec.resourceHealthChecks`:
+
+```yaml
+- group: external-secrets.io
+  kind: PushSecret
+  check: |
+    hs = {}
+    hs.status = "Healthy"
+    hs.message = "PushSecret present; outbound 1P publish may fail (read-only Connect token) but is non-blocking for GitOps"
+    return hs
+```
+
+(Manually force-creating a gated wave > 40 Application instead does NOT work —
+`root-applications` has `prune: true` and treats a not-yet-due app as extraneous, so it
+gets pruned. Open the gate with the health check; do not force-create.)
+
+**Patch B — repo-server performance (cpu=2 / mem=2Gi + `ARGOCD_EXEC_TIMEOUT=3m`).**
+Heavy Helm render of `clusters/ocp/` (app-of-apps with `--enable-helm`) exceeded the
+default 90s exec timeout on 1 CPU, producing recurring `Unknown` / `DeadlineExceeded`
+states that stalled the wave march. Fix:
+
+```bash
+oc -n openshift-gitops patch argocd openshift-gitops --type=merge -p \
+'{"spec":{"repo":{"resources":{"limits":{"cpu":"2","memory":"2Gi"}},
+"env":[{"name":"ARGOCD_EXEC_TIMEOUT","value":"3m"}]}}}'
+```
+
+The equivalent YAML to fold into the playbook's ArgoCD CR under `spec.repo`
+(the committed playbook currently sets `cpu: "1" / memory: 1Gi` and no env):
+
+```yaml
+repo:
+  resources:
+    limits:
+      cpu: "2"
+      memory: 2Gi
+  env:
+    - name: ARGOCD_EXEC_TIMEOUT
+      value: 3m
+```
+
+### Verification
+
+```bash
+# 1) Seed Secrets present, annotated by ansible
+oc -n onepassword-connect get secret op-credentials \
+  -o jsonpath='{.metadata.annotations.managed-by}{"\n"}'          # -> ansible
+oc -n external-secrets-operator get secret onepassword-connect-token \
+  -o jsonpath='{.metadata.annotations.managed-by}{"\n"}'          # -> ansible
+
+# 2) ESO ClusterSecretStores Valid + Ready (Connect JWT is good)
+oc get clustersecretstore
+#   onepassword-sdk-claude / -ocp-pull / -ocp-push  =>  Valid  ReadWrite  True
+
+# 3) App-of-apps converging (a few OutOfSync/Progressing during the march is normal)
+oc -n openshift-gitops get applications \
+  -o custom-columns=NAME:.metadata.name,SYNC:.status.sync.status,HEALTH:.status.health.status
+#   observed at hand-off: 42 Synced / 43 Healthy of 48
+
+# 4) The two live patches are in effect
+oc -n openshift-gitops get argocd openshift-gitops \
+  -o jsonpath='{.spec.repo.resources.limits}{"  "}{.spec.repo.env[*].name}={.spec.repo.env[*].value}{"\n"}'
+#   {"cpu":"2","memory":"2Gi"}  ARGOCD_EXEC_TIMEOUT=3m
+oc -n openshift-gitops get argocd openshift-gitops \
+  -o jsonpath='{range .spec.resourceHealthChecks[*]}{.group}/{.kind}{"\n"}{end}' | grep PushSecret
+#   external-secrets.io/PushSecret
+
+# 5) Kubeconfig CA stripped
+grep -c certificate-authority-data "$KUBECONFIG"                  # -> 0
+```
+
+Connect pod `Running` in `onepassword-connect` and the `onepassword-sdk-*` stores
+`Valid` are the true green light: from here ExternalSecrets resolve and the wave march
+proceeds.
+
+### Rollback
+
+This is an additive bootstrap onto an empty cluster; git is the source of truth, so
+"rollback" means tearing the bootstrap down and re-running — with care not to delete
+namespaces that hold restored data.
+
+- **Re-bootstrap cleanly:** delete `root-applications`
+  (`oc -n openshift-gitops delete application root-applications`; if it hangs on the
+  `resources-finalizer.argocd.argoproj.io` finalizer, remove the finalizer), then
+  re-run the Step 2 playbook.
+- **After ANY playbook re-run, re-apply Patch A + Patch B** (Step 5) — the re-created
+  ArgoCD CR does not contain them, so the wave gate will re-wedge on `service-accounts`
+  and the repo-server will re-hit `DeadlineExceeded`.
+- A gated (wave > 40) app that keeps disappearing was **pruned** by `root-applications`,
+  not failed — do not re-create it by hand; open its wave gate instead.
+
+### Gotchas & pitfalls (from this incident)
+
+1. **Right playbook.** Use `playbooks/openshift/hub-cluster/bootstrap_gitops.yaml`, NOT
+   the drifted `playbooks/openshift/bootstrap_openshift_gitops.yaml`.
+2. **Connect JWT field.** The real Connect JWT is in the item's `credential` field; the
+   `token` field is an 83-char stub. Wrong field = Connect never authenticates.
+3. **`onepassword_doc` bytes.** Returns bytes → `data:` + `| b64encode`, never
+   `stringData:` (ansible-core ≥ 2.19 refuses to serialize bytes to module args).
+4. **Kubeconfig CA rotation.** After the MCO settles, the API serving cert's CA rotates;
+   strip `certificate-authority-data` (back up to `kubeconfig_self_signed`) so `oc`
+   uses system trust. Symptom: sudden `x509: unknown authority` on a kubeconfig that
+   worked minutes earlier.
+5. **SA token bypasses Connect (chicken-and-egg).** `unset OP_CONNECT_HOST
+   OP_CONNECT_TOKEN` and set `OP_SERVICE_ACCOUNT_TOKEN` so the lookups hit 1Password
+   SaaS, not the not-yet-running Connect.
+6. **Wave gate.** app-of-apps gates wave N+1 on wave N being Synced **and** Healthy. One
+   Degraded low-wave app blocks everything above it.
+7. **PushSecret 403 wedge.** Read-only Connect token → 6 PushSecrets 403 →
+   `service-accounts` (wave 40) Degraded → blocks `openshift-virt` (wave 50) and all
+   wave > 40. Fix with the lenient PushSecret health check + controller restart +
+   hard-refresh.
+8. **repo-server perf.** Default 90s / 1 CPU is too small for the Helm app-of-apps
+   render → `Unknown` / `DeadlineExceeded` stalls. Bump `cpu: 2 / memory: 2Gi` and
+   `ARGOCD_EXEC_TIMEOUT=3m`.
+9. **Live-only patches are ephemeral.** The ArgoCD CR is playbook-managed, not
+   GitOps-managed — Patch A + Patch B are lost on any re-run. Codify them into
+   `bootstrap_gitops.yaml`; until then, re-apply after every run.
+10. **Stale local checkouts.** `/workspace/igou-openshift` (and `igou-ansible`) local
+    HEAD lags origin by 100+ commits. `oc kustomize` / `kustomize build` from a stale
+    checkout renders OLD manifests (e.g. CNPG `initdb` instead of `recovery`). Always
+    `git fetch origin main` and apply with `git show origin/main:<path>`.
+11. **`--enable-helm` origin.** It comes from the ArgoCD CR / setenv CMP plugin — change
+    it live and you must restart the repo-server.
+12. **Operator-CRD ordering during the march.** Some wave apps need their CRDs to exist
+    before ArgoCD's dry-run: apply `ns + OperatorGroup + Subscription` from the
+    component, wait for the CSV to Succeed, then sync the app (CNV needs
+    `SkipDryRunOnMissingResource=true` — StorageProfiles depend on the `cdi.kubevirt.io`
+    CRD that only appears after the HyperConverged CR). Not part of GitOps bootstrap
+    proper, but it recurs on every wave that installs an operator.

--- a/docs/runbooks/ocp-agent-reinstall-netboot-safety.md
+++ b/docs/runbooks/ocp-agent-reinstall-netboot-safety.md
@@ -1,0 +1,284 @@
+## Agent-based reinstall, netboot pin safety & worker re-join
+
+Operational runbook derived verbatim from the 2026-07-03 `ocp.igou.systems` cluster-destruction incident and its recovery. Every command, host, and path below is what was actually used (or, where noted, the durable fix that replaced it). Cluster is a **single control-plane OpenShift 4.21.9** cluster: control plane `ocp.igou.systems` (MS-01, `10.10.9.10`); workers `hpg5.igou.systems` (`10.10.9.240`, bare metal) and `truenas-w1` (`10.10.9.21`, a KubeVirt/KVM VM on TrueNAS, VM id `5` / `5_truenasw1`); `p330` is permanently dark (no BMC — excluded from all rejoin).
+
+---
+
+### Purpose
+
+Reinstall the MS-01 control plane from agent-based PXE artifacts after a catastrophic wipe, **without falling into the reinstall loop** that the netboot infrastructure creates, and re-join the two workers. It documents the exact failure mode (a stale rb5009 per-host netboot pin defaulting to `install-openshift`), how to regenerate the agent-install PXE assets and publish them to the public nginx, how to flip the per-host pin to `default local` mid-install to break the loop, and the two distinct worker re-join methods (bare-metal PXE vs. KubeVirt-VM node-image ISO) plus correct CSR approval.
+
+---
+
+### When to use
+
+- The MS-01 control-plane disk has been wiped / the cluster is unrecoverable (etcd overwritten) and you must reinstall RHCOS + OpenShift from scratch via the agent-based PXE flow.
+- You need to re-join `hpg5` and/or `truenas-w1` to a freshly reinstalled cluster.
+- **Preventatively**: after ANY agent-based install, to confirm the per-host pin default is `local` (not `install-openshift`/`ocp-node`) so an unattended reboot can never re-trigger an install.
+
+Do NOT use this to rebuild GitOps, restore PVs, or restore databases — those are separate runbooks. This one stops at "all 3 nodes `Ready`".
+
+---
+
+### Prerequisites
+
+- Ansible control node with the two repos checked out: `/workspace/igou-ansible` and `/workspace/igou-inventory`. Both local checkouts may be STALE — reconcile with `git fetch origin main` and read canonical files via `git show origin/main:<path>`.
+- The agent-install role `david-igou.openshift_agent_install` is available to `playbooks/openshift/agent-install/deploy_pxe_assets.yml`.
+- **Pull secret**, recovered out-of-band. During the incident it was pulled off the live installer host into the scratchpad before the wipe completed; it also lands inside the freshly generated `cluster-manifests/`. You need it as a literal because 1Password/Connect/ESO all ran ON the destroyed cluster and were dead.
+- SSH to rb5009 (RouterOS): `ssh -i ~/.ssh/id_ed25519 -o IdentitiesOnly=yes igou@rb5009.igou.systems -p 3480`. File push for pins used `scp -O igou+cet1024w@rb5009.igou.systems:netboot/per-host/<file>`.
+- SSH to nodes/TrueNAS for read-only inspection (agent SSH cannot sign here — use the local key with `SSH_AUTH_SOCK=` unset):
+  - `SSH_AUTH_SOCK= ssh -i ~/.ssh/id_ed25519 -o StrictHostKeyChecking=accept-new core@10.10.9.10` (or `core@hpg5.igou.systems`, `core@10.10.9.21`)
+  - `SSH_AUTH_SOCK= ssh -i ~/.ssh/id_ed25519 truenas_admin@truenas.igou.systems`
+- `KUBECONFIG` — once the install produces one, use ONLY the file the install wrote:
+  `export KUBECONFIG=$HOME/openshift-agent-install/ocp/cluster-manifests/auth/kubeconfig` (never anything under `~/.kube`, all stale).
+
+---
+
+### Root cause — how the stale rb5009 netboot pin caused the disaster
+
+Understand this before touching anything; the whole runbook is shaped around not repeating it.
+
+- MS-01 is **netboot-first by firmware**: UEFI BootOrder is `PXE I226-V → PXE I226-LM → disk LAST`, with a 3-second timeout. Every power event tries PXE first.
+- rb5009 owns DHCP+TFTP. Its per-host pin `flash:/netboot/per-host/MAC-5847ca77098a.ipxe` (MS-01 NIC MAC `58:47:ca:77:09:8a`) presented an iPXE menu whose **default-on-timeout was `install-openshift` on a 30-second timer** (`choose --timeout 30000 --default install-openshift target`). That pin had been armed since the 2026-05-11 netboot migration and simply never disarmed.
+- On an unattended reboot (~17:00 UTC), MS-01 PXE-booted, hit its pin, the 30s timer expired to `install-openshift`, and the agent-based installer **auto-wiped the 990 PRO NVMe** and started a fresh install. etcd/cluster state was overwritten → old cluster unrecoverable. (PV zvols on TrueNAS were untouched.)
+- **The loop**: agent-based install itself reboots mid-flight. With the pin still defaulting to `install-openshift` and firmware still netboot-first, each mid-install reboot re-PXEs, re-hits the pin, times out to `install-openshift` again, and **restarts the install** — forever. The install can never reach "boot from disk."
+
+The two independent controls that must both be respected: (1) firmware is netboot-first and won't be changed, so (2) the **pin default is the safety interlock** — it must be `local` at all times except during a deliberate install, and must be flipped back to `local` the instant the install is underway.
+
+---
+
+### Step-by-step
+
+All Ansible invocations use the dual-inventory form (localhost is in inventory, so it must be passed explicitly):
+
+```
+-i 'localhost ansible_connection=local,' -i igou-inventory/inventory.yaml
+```
+
+#### Phase 1 — Regenerate agent-install PXE artifacts
+
+Work dir the role uses: `~/openshift-agent-install/ocp/`. Play 1 wipes it fresh, renders manifests, produces `cluster-manifests/auth/{kubeconfig,kubeadmin-password}` and `cluster-manifests/boot-artifacts/`. Play 2 publishes boot-artifacts to the public nginx.
+
+1. Put the recovered pull secret (and any other normally-1Password-sourced vars) into a literal override file, e.g. `~/scratchpad/override.yml`, so no live `op` lookups are attempted.
+
+2. Run the deploy, **skipping the `op-save` tag** (the 1Password item-create + kubeconfig-CA-strip block) because Connect was on the dead cluster:
+
+```
+cd /workspace/igou-ansible
+ansible-playbook playbooks/openshift/agent-install/deploy_pxe_assets.yml \
+  -i 'localhost ansible_connection=local,' \
+  -i igou-inventory/inventory.yaml \
+  -e target_cluster=ocp \
+  -e @~/scratchpad/override.yml \
+  --skip-tags op-save
+```
+
+3. Play 2 (`hosts: truenas`, `become: true`) syncs `cluster-manifests/boot-artifacts/` → `/mnt/ssd/public/boot-files/ocp/` and is served at `https://public.igou.systems/boot-files/ocp/`. It creates the dir `mode: "0755"` and syncs with `--chmod=D0755,F0644`, then HEAD-probes the three files. **The perms matter**: a plain `rsync -a` leaves the dir `0750`, which the public-nginx worker (different UID) cannot traverse → HTTP 403 → the pin's initrd fetch fails and the boot silently exits. Confirm reachability:
+
+```
+curl -sI https://public.igou.systems/boot-files/ocp/agent.x86_64-vmlinuz
+curl -sI https://public.igou.systems/boot-files/ocp/agent.x86_64-initrd.img
+curl -sI https://public.igou.systems/boot-files/ocp/agent.x86_64-rootfs.img
+```
+
+All three must return `200`. The MS-01 pin's `install-openshift` entry sets `base {{ netboot_public_url }}/ocp` and pulls exactly these three filenames.
+
+> The `.ipxe` script is intentionally NOT published (`--exclude=*.ipxe`); the boot flow is the rb5009 per-host pin, which carries its own kernel/initrd/rootfs URLs. Do not reference any retired netbootxyz container path (`10.10.45.242`, `/mnt/ssd/containers/netbootxyz/...`, `10.10.45.240/hub/`).
+
+#### Phase 2 — Stage the safe pin (default `local`) ready to fire
+
+Prepare the disarmed version of `MAC-5847ca77098a.ipxe` (identical menu, but `choose --timeout 30000 --default local target`) so you can push it the moment install starts. Two ways:
+
+- **Canonical (preferred)**: edit the `58:47:ca:77:09:8a` pin fragment in `igou-inventory/group_vars/all/netboot.yml` to `--default local`, then push it with `deploy_assets.yml` (Phase 3, step 3). This is what PR **inventory#120** made the durable git default.
+- **Fast manual (what broke the live loop)**: keep the disarmed pin file in the scratchpad and `scp -O` it straight onto rb5009 flash:
+
+```
+scp -O ~/scratchpad/MAC-5847ca77098a.ipxe \
+  igou+cet1024w@rb5009.igou.systems:netboot/per-host/MAC-5847ca77098a.ipxe
+```
+
+Have this ready to execute; timing in Phase 3 is the whole game.
+
+#### Phase 3 — Trigger the install and flip the pin mid-install to BREAK the loop
+
+1. With Phase-1 artifacts live at 200, boot MS-01 into the installer (the pin's `install-openshift` default handles it on the 30s timeout, or select it at console).
+2. Watch the install progress until status is **`installing`** (agent installer is writing to disk / has begun bootstrap). The critical window is *after* the installer has committed to disk but *before* the first mid-install reboot.
+3. **Flip the pin to `default local` NOW** (Phase-2 scp, or `deploy_assets.yml --tags render,push,verify`). In the incident the flip landed at status=installing ~18:24 UTC.
+4. The mid-install reboot then PXEs, hits the now-`local`-default pin, times out to `sanboot` local disk, and **boots FROM DISK** (~18:31) — loop broken. Node reached `Ready` ~18:38; CVO rolled to 4.21.9.
+
+`deploy_assets.yml` pin push, for reference:
+
+```
+ansible-playbook playbooks/netboot/deploy_assets.yml \
+  -i 'localhost ansible_connection=local,' \
+  -i igou-inventory/inventory.yaml \
+  --tags render,push,verify
+```
+
+#### Phase 4 — Fix the kubeconfig cert after MCO settles
+
+Use the install's kubeconfig immediately:
+
+```
+export KUBECONFIG=$HOME/openshift-agent-install/ocp/cluster-manifests/auth/kubeconfig
+```
+
+After the MCO settles, the API serving cert rotates to a new CA and `oc` starts failing with `x509`. **Fix**: back up the kubeconfig, then strip the embedded CA so `oc` falls back to the system trust store (public LE cert on the API route is trusted):
+
+```
+cp "$KUBECONFIG" "${KUBECONFIG}_self_signed"
+# remove the certificate-authority-data: line from $KUBECONFIG
+```
+
+(This is exactly what the playbook's `op-save` block does automatically — `kubeconfig_self_signed` backup + `lineinfile` removing `certificate-authority-data`. Because Phase 1 skips `op-save`, do it by hand.)
+
+#### Phase 5a — Re-join `hpg5` (bare-metal PXE)
+
+1. Refresh the add-node boot artifacts (token in the initrd rotates; artifacts land in `/mnt/ssd/public/boot-files/ocp-add-node/`):
+
+```
+export KUBECONFIG=$HOME/openshift-agent-install/ocp/cluster-manifests/auth/kubeconfig
+ansible-playbook playbooks/openshift/add_node_iso.yml \
+  -i 'localhost ansible_connection=local,' \
+  -i igou-inventory/inventory.yaml \
+  -e target_cluster=ocp
+```
+
+`add_node_iso.yml` runs `oc adm node-image create --pxe`, publishes `node.x86_64-{vmlinuz,initrd.img,rootfs.img}` to the `ocp-add-node/` subdir with `--chmod=F0644,D0755` (same 403-avoidance as above), and preflights out any host already a node.
+
+2. **Arm** the hpg5 pin (`MAC-f8b46aab55c7.ipxe`, MAC `f8:b4:6a:ab:55:c7`) to default `ocp-node` instead of `local`, then push it (`deploy_assets.yml --tags render,push,verify`). Its `ocp-node` entry chains the `ocp-add-node/` artifacts. **Verify the pin content actually landed on rb5009 flash** before rebooting — a prior deploy silently ran from the wrong cwd and pushed nothing.
+3. Reboot hpg5 (route is via `eno1`). It PXE-boots, picks `ocp-node`, boots the add-node image, and installs RHCOS to disk. Bare-metal RTC is correct, so there is no clock/x509 problem here.
+4. Once it has written the disk, **revert the pin to default `local`** and push again, so every subsequent netboot falls through to the installed disk.
+5. Approve CSRs (Phase 6).
+
+> hpg5's host SSH key changes at each boot phase (live installer vs installed RHCOS) — clear it with `ssh-keygen -R hpg5.igou.systems` (and the IP) between phases or SSH will refuse.
+
+#### Phase 5b — Re-join `truenas-w1` (KubeVirt VM, node-image ISO)
+
+The `--pxe` / RAW-`.dsk` netboot fallback is **broken for this VM** (a raw `.efi` written to a disk is not a valid ESP → OVMF drops to the EFI shell). Use the full ISO instead.
+
+1. Generate a per-host node-image **ISO** (not `--pxe`), with a nodes-config pinned to the VM's identity (MAC `52:54:00:0a:09:15`, hostname `truenas-w1`):
+
+```
+export KUBECONFIG=$HOME/openshift-agent-install/ocp/cluster-manifests/auth/kubeconfig
+oc adm node-image create --dir ~/openshift-add-node/ocp-iso
+# produces a ~1.4G node.<arch>.iso
+```
+
+2. Upload the ISO to TrueNAS: `/mnt/ssd/vms/images/`.
+3. **Fix the VM clock to UTC before booting** (critical — see gotchas). RHCOS expects `hwclock=UTC`; the VM was set to `LOCAL`, putting the guest RTC ~4h behind, which makes Ignition's `GET https://api-int:22623/config/worker` fail `x509: certificate not yet valid` (the MCS cert's valid-from is the reinstall time, e.g. 18:23):
+
+```
+SSH_AUTH_SOCK= ssh -i ~/.ssh/id_ed25519 truenas_admin@truenas.igou.systems \
+  "midclt call vm.update 5 '{\"time\":\"UTC\"}'"
+```
+
+4. Attach the ISO as a **CDROM** device ordered FIRST so it boots the installer:
+
+```
+midclt call vm.device.create '{"vm":5,"attributes":{"dtype":"CDROM","path":"/mnt/ssd/vms/images/node.x86_64.iso","order":1000}}'
+```
+
+5. Device changes require a **full QEMU restart** (a soft reboot won't pick up the new device). Hard-destroy via the TrueNAS libvirt socket, then start:
+
+```
+sudo virsh -c "qemu+unix:///system?socket=/run/truenas_libvirt/libvirt-sock" destroy 5_truenasw1
+midclt call vm.start 5
+```
+
+6. It boots the ISO and installs RHCOS to the zvol. Watch the console via screenshot (TrueNAS 25.10 is libvirt/incus, not plain virsh):
+
+```
+sudo virsh -c "qemu+unix:///system?socket=/run/truenas_libvirt/libvirt-sock" \
+  screenshot 5_truenasw1 /tmp/x.png
+```
+
+7. After the disk is written (verify RHCOS partitions exist, e.g. `sgdisk`/`lsblk` shows the RHCOS layout on the zvol), **reorder the CDROM AFTER the disk** (`order: 1010`) and restart QEMU again, so it boots the installed disk and not the ISO in a loop:
+
+```
+midclt call vm.device.update <cdrom_device_id> '{"order":1010}'
+sudo virsh -c "qemu+unix:///system?socket=/run/truenas_libvirt/libvirt-sock" destroy 5_truenasw1
+midclt call vm.start 5
+```
+
+8. Approve CSRs (Phase 6).
+
+#### Phase 6 — CSR approval (the ~40-minute gotcha)
+
+Each joining node emits **two rounds** of CSRs: a kubelet **client** CSR (node-bootstrapper), then a kubelet **serving** CSR after the client one is approved. Both must be approved within ~1h or the join stalls.
+
+**Do NOT filter `oc get csr` on `$5`.** In `oc get csr` the `CONDITION` column is **column 6**, not 5 (`NAME AGE SIGNERNAME REQUESTOR REQUESTEDDURATION CONDITION`). A monitor's `awk '$5=="Pending"'` silently matched nothing while **9 node-bootstrapper CSRs piled up unapproved for ~40 min**. Use the status-based go-template instead of column arithmetic:
+
+```
+oc get csr -o go-template='{{range .items}}{{if not .status}}{{.metadata.name}}{{"\n"}}{{end}}{{end}}' \
+  | xargs --no-run-if-empty oc adm certificate approve
+```
+
+Run it repeatedly (both nodes, both rounds) until `oc get nodes` shows both workers `Ready`.
+
+> If a node still won't produce a client CSR, its kubelet may need a clean bootstrap: `systemctl stop kubelet`, `rm /var/lib/kubelet/kubeconfig /var/lib/kubelet/pki/*`, `systemctl start kubelet`. In this incident the real blocker was always just unapproved CSRs, not the kubelet.
+
+---
+
+### Verification
+
+```
+export KUBECONFIG=$HOME/openshift-agent-install/ocp/cluster-manifests/auth/kubeconfig
+
+# 1. All three nodes Ready (control plane + both workers)
+oc get nodes -o wide
+#   ocp.igou.systems   Ready control-plane,master,worker
+#   hpg5.igou.systems  Ready worker
+#   truenas-w1         Ready worker
+
+# 2. Cluster version reconciled
+oc get clusterversion
+#   version 4.21.9 True(Available) False(Progressing) — "Cluster version is 4.21.9"
+
+# 3. No CSRs left pending (correct selector)
+oc get csr -o go-template='{{range .items}}{{if not .status}}{{.metadata.name}}{{"\n"}}{{end}}{{end}}'
+#   (empty)
+
+# 4. Pin safety — MS-01 pin default is `local`, so an unattended reboot can never reinstall
+SSH_AUTH_SOCK= ssh -i ~/.ssh/id_ed25519 -o IdentitiesOnly=yes igou@rb5009.igou.systems -p 3480 \
+  "/file print value-list where name=\"netboot/per-host/MAC-5847ca77098a.ipxe\""
+#   must contain:  choose --timeout 30000 --default local target
+# Repeat for MAC-f8b46aab55c7.ipxe (hpg5) and MAC-52540...915.ipxe (truenas-w1): all `--default local`.
+
+# 5. Boot artifacts still served (perms not silently regressed to 403)
+curl -sI https://public.igou.systems/boot-files/ocp/agent.x86_64-vmlinuz          # 200
+curl -sI https://public.igou.systems/boot-files/ocp-add-node/node.x86_64-vmlinuz  # 200
+```
+
+Live state at close of the incident confirmed all of the above: 3 nodes `Ready` (v1.34.6), `clusterversion 4.21.9 Available`, zero pending CSRs.
+
+---
+
+### Rollback
+
+There is no "rollback" of a reinstall — the old etcd is gone. What you can roll back is the **install trigger**, and that IS the core safety action:
+
+- **Abort an in-progress reinstall loop**: push the `default local` pin (`scp -O … MAC-<hex>.ipxe`, or `deploy_assets.yml --tags render,push,verify`). The very next reboot then boots local disk instead of re-installing. This is the same flip used in Phase 3 — flipping to `local` at any time stops the loop.
+- **Disarm a worker mid-attempt**: flip its pin default back to `local` and push; the node stops PXE-installing on reboot. No node ever needs firmware changes.
+- **Leave the boot artifacts in place** — they are harmless when no pin defaults to installing them. The interlock is entirely the pin default.
+- Old PV zvols on TrueNAS were never touched; nothing here deletes data. `p330` stays excluded (dark, no BMC).
+
+Durable fixes merged so this can't recur silently: **inventory#120** (MS-01 pin default → `local` in git), **ansible#311** (deploy_pxe_assets publish-path fix). Still-open follow-ups from the incident: PR the `default local` for all worker pins, remove the stale `bootArtifactsBaseURL 10.10.45.242` in `host_vars/ocp.yml`, and fold the manual kubeconfig-CA-strip into the non-op path.
+
+---
+
+### Gotchas & pitfalls (all observed this incident)
+
+- **Netboot-first firmware + install-defaulting pin = auto-wipe.** MS-01 BootOrder is PXE→PXE→disk(3s). The pin default is the ONLY interlock; it must be `local` except during a deliberate install. A pin left defaulting to `install-openshift` since a months-old migration is what destroyed the cluster on an unattended reboot.
+- **The reinstall loop is real and self-sustaining.** Agent install reboots mid-flight; if the pin still defaults to install, every reboot restarts the install forever. You MUST flip the pin to `local` while status is `installing` (before the first in-install reboot) — timing is the whole trick.
+- **nginx 403 from perms, not from missing files.** `rsync -a` / a bare mkdir leaves `0750`; the public-nginx worker runs as a different UID and can't traverse → 403 → iPXE's initrd fetch fails → the boot menu silently exits with no obvious error. Always force `D0755,F0644` (the playbooks do; verify with `curl -sI … 200`).
+- **`oc get csr` CONDITION is column 6, not 5.** A `awk '$5=="Pending"'` monitor silently approved nothing while 9 CSRs stacked up for ~40 min. Use `-o go-template='{{if not .status}}…'` — it keys on the actual empty-status field, immune to column drift.
+- **Two CSR rounds per node** (kubelet client, then serving). Keep approving until `Ready`; approving once is not enough.
+- **truenas-w1 VM clock defaulted to LOCAL → x509 "certificate not yet valid."** RHCOS needs `hwclock=UTC`; a ~4h-behind guest RTC makes Ignition's MCS fetch fail because the MCS cert's valid-from is the (later) reinstall time. `midclt call vm.update 5 '{"time":"UTC"}'` + restart. This bites only the VM worker, not bare metal.
+- **TrueNAS VM device changes need a full QEMU restart**, not a guest reboot. Use `virsh -c "qemu+unix:///system?socket=/run/truenas_libvirt/libvirt-sock" destroy 5_truenasw1` then `midclt call vm.start 5`. TrueNAS 25.10 is libvirt/incus — the socket path is `/run/truenas_libvirt/libvirt-sock`, not the default virsh socket; console screenshots go through the same `-c` URI.
+- **The VM's RAW `.dsk` / `--pxe` netboot fallback does NOT work for an OCP install** — a raw `.efi` on a disk isn't a valid ESP and OVMF drops to a shell. Use the full `oc adm node-image create --dir` ISO attached as a CDROM.
+- **CDROM must be reordered after install** (order 1000 to boot installer → 1010 after disk write) or the VM boots the ISO in a loop — the VM analogue of the MS-01 pin loop. Verify the disk actually has RHCOS partitions before reordering.
+- **Verify pin content actually landed on rb5009.** One `deploy_assets` run silently executed from the wrong cwd and pushed nothing; always read back the flash file (`/file print value-list where name="…"`).
+- **hpg5 host key rotates per boot phase** — `ssh-keygen -R` between phases or SSH refuses to connect.
+- **Everything 1Password is dead during recovery.** Connect/ESO/AAP all ran on the destroyed cluster, so `op` lookups fail. Regenerate PXE assets with `--skip-tags op-save -e @override.yml` carrying a literal pull secret, and do the kubeconfig-CA strip by hand.
+- **Local repo checkouts are STALE.** `git fetch origin main` first; read canonical files via `git show origin/main:<path>` rather than trusting the working tree.

--- a/docs/runbooks/rebuild-hermes-vm.md
+++ b/docs/runbooks/rebuild-hermes-vm.md
@@ -1,0 +1,362 @@
+# Rebuild the Hermes agent VM and restore its state
+
+## Purpose
+
+Recreate the `hermes` KubeVirt VM (the Nous Hermes autonomous agent) on the
+`ocp.igou.systems` cluster and restore its persistent `~/.hermes` state from a
+TrueNAS/tar backup, after a disaster that destroyed the VM (or after the whole
+cluster was reinstalled). This runbook covers the exact procedure used during the
+2026-07-03 cluster-reinstall recovery: provision a fresh VM from the
+`centos-stream10` golden image, work around the shared-`hostnqn` NVMe-oF attach
+flakiness, load the state disk with the backed-up agent state, and hand off to the
+operator for the still-deferred guest convergence and go-live.
+
+This gets the VM **provisioned, running, and holding restored state**. It does
+**not** converge Hermes (install/configure) or bring the agent online — those stay
+operator-gated (see "What stays operator-deferred").
+
+## When to use
+
+- The `hermes` VM was deleted/lost (disaster, node loss, or full cluster reinstall)
+  and needs to be rebuilt from scratch.
+- The Argo `hermes-agent` app (GitOps guardrails) is already Synced/Healthy so the
+  namespace, DataVolumes, NetworkPolicies, EgressFirewall, and the VAP exist, but
+  no VM is running.
+- You have the `hermes-state` tar backup available and want the agent's
+  identity/config/memory restored (not a blank agent).
+
+Do **not** use this to converge or start the agent — that is a separate,
+operator-driven step.
+
+## Prerequisites
+
+- **Cluster access** — the session kubeconfig only, per standing directive:
+  ```bash
+  export KUBECONFIG=$HOME/openshift-agent-install/ocp/cluster-manifests/auth/kubeconfig
+  ```
+  All three nodes must be `Ready` (`ocp.igou.systems`/10.10.9.10 control-plane,
+  `hpg5.igou.systems`, `truenas-w1`/10.10.9.21).
+
+- **GitOps guardrails present** — the Argo `hermes-agent` application
+  (`applications/hermes-agent/` in `github.com/igou-io/igou-openshift`) is
+  Synced/Healthy, so these objects already exist in ns `hermes`:
+  - blank `hermes-state` DataVolume (30Gi, `freenas-nvmeof-ssd-csi`, Block mode)
+  - NetworkPolicies `hermes-deny-ingress` + `hermes-egress`
+  - EgressFirewall `default`
+  - ValidatingAdmissionPolicy `hermes-vm-hardening` (masquerade-only, no
+    hostDevices/GPU/passthrough — the provision spec must conform or CREATE/UPDATE
+    is rejected).
+  Verify:
+  ```bash
+  oc get application hermes-agent -n openshift-gitops -o jsonpath='{.status.sync.status} {.status.health.status}{"\n"}'
+  oc get dv,networkpolicy,egressfirewall,validatingadmissionpolicy -n hermes
+  ```
+
+- **centos-stream10 golden DataSource is `Ready`** — the provision playbook clones
+  it. On this cluster it lives in `openshift-virtualization-os-images`:
+  ```bash
+  oc get datasource centos-stream10 -n openshift-virtualization-os-images \
+    -o jsonpath='{.status.conditions[?(@.type=="Ready")].status}{"\n"}'   # -> True
+  ```
+  (Golden image is **BIOS-only** — the provision spec pins `vm_firmware: bios`;
+  Secure Boot is intentionally dropped.)
+
+- **Ansible repo** — `/workspace/igou-ansible` (`github.com/igou-io/igou-ansible`),
+  playbook `playbooks/hermes/provision-vm.yml` (thin wrapper over the
+  `kubevirt_vm_provision` role). Collections/roles installed
+  (`ansible-galaxy install -r requirements.yml`); `kubevirt.core` +
+  `kubernetes.core` available. The playbook is `connection: local` and authenticates
+  to the cluster via `$KUBECONFIG`.
+
+- **Seeded SSH key** — the local keypair `~/.ssh/id_ed25519` /
+  `~/.ssh/id_ed25519.pub`; the `.pub` is seeded into cloud-init as the `igou` admin
+  user's authorized key (non-secret). The private key is used for the post-boot
+  restore SSH session.
+
+- **State backup present** on the devcontainer:
+  ```
+  /workspace/backups/hermes/hermes-state-20260703.tar.zst      # ~4.9G file, 11.9G raw = ~/.hermes (auth.json/config.yaml/SOUL.md/…)
+  /workspace/backups/hermes/hermes-home-root-20260703.tar.zst  # ~4.9G file, 6.8G raw = /home/hermes non-.hermes (see note)
+  ```
+  `zstd -t` the archive first. (Original source was TrueNAS zvol clones
+  `ssd/k8s/rescue-hermes-{root,state}` snapshotted at `@rescue-20260703`; the tars
+  are the extracted, verified copies.)
+
+- `virtctl` on PATH (mise) for the port-forward SSH path.
+
+## Step-by-step
+
+### 1. Confirm the blank state disk exists and is Bound
+
+The `hermes-state` PVC is an Argo-owned **blank** DataVolume (Block mode). This is
+the disk that survives VM delete/rebuild and holds `~/.hermes`.
+
+```bash
+oc get pvc hermes-state -n hermes \
+  -o custom-columns=NAME:.metadata.name,STATUS:.status.phase,VOL:.spec.volumeName,MODE:.spec.volumeMode
+# hermes-state  Bound  pvc-46858de9-...  Block
+oc get dv hermes-state -n hermes    # PHASE Succeeded
+```
+
+If it is not Bound / not present, let Argo reconcile it (it is defined in
+`applications/hermes-agent/hermes-state-datavolume.yaml`; do **not** hand-create
+it — it is GitOps-managed). Note whether you will be restoring into a **fresh**
+blank disk (see step 3 note on the NVMe workaround).
+
+### 2. Provision the VM
+
+Seed your public key and run the provision playbook. It clones `centos-stream10`
+at golden size (30Gi, **no resize** — CDI smart-clone deadlocks on resize),
+burstable 4c/8Gi, masquerade networking (VAP-conforming), BIOS firmware, and
+attaches the existing `hermes-state` PVC as a plain data disk (`/dev/vdb` in the
+guest). Cloud-init creates the `igou` admin user with your key and enables the
+qemu-guest-agent; **no secrets, no convergence.**
+
+```bash
+cd /workspace/igou-ansible
+export KUBECONFIG=$HOME/openshift-agent-install/ocp/cluster-manifests/auth/kubeconfig
+
+ansible-playbook playbooks/hermes/provision-vm.yml \
+  -e host=localhost \
+  -e "vm_ssh_authorized_key=$(cat ~/.ssh/id_ed25519.pub)" \
+  -e kubeconfig="$KUBECONFIG"
+```
+
+- The playbook is idempotent; a re-run with no change reports `changed=0`.
+- To force a destructive rebuild of an existing VM **while preserving the
+  `hermes-state` data PVC**, add `-e rebuild=true` (maps to the role's
+  `vm_rebuild`; deletes the VM + root DV, keeps attached `vm_extra_pvcs`).
+  Never pass `vm_destroy_data` for hermes-state — it is Argo/CDI-owned and wiping
+  it fights Argo.
+
+Watch it come up (it must land on a single node; both disks attach there):
+
+```bash
+oc get vm,vmi -n hermes
+# VM hermes Running True ; VMI hermes Running <podIP> <node>  (e.g. 10.129.0.36 hpg5.igou.systems)
+oc get vmi hermes -n hermes -o jsonpath='{.status.guestOSInfo.prettyName}{"\n"}'   # CentOS Stream 10
+```
+
+### 3. If disk attach flakes — the shared-hostnqn NVMe-oF bug
+
+**Symptom.** The VM's second `freenas-nvmeof-ssd` disk (the state disk) fails to
+attach while the root disk is fine; VMI stays `Scheduling`/not-Ready. Node journal
+shows `nvme ... Connect command failed error 6` / `failed to write to
+nvme-fabrics device` / "unable to attach any nvme devices".
+
+**Root cause (latent, cluster-wide, still unfixed).** All three RHCOS nodes were
+baked with the **identical** NVMe host identity by the agent-based install:
+
+```bash
+for n in 10.10.9.10 hpg5.igou.systems 10.10.9.21; do
+  echo -n "$n: "; SSH_AUTH_SOCK= ssh -i ~/.ssh/id_ed25519 -o StrictHostKeyChecking=accept-new \
+    core@$n 'sudo cat /etc/nvme/hostnqn'
+done
+# all three return: nqn.2014-08.org.nvmexpress:uuid:466937ab-67bf-4315-971b-bc110d55ce28
+```
+
+NVMe-oF requires a **unique** `hostnqn`/`hostid` per host. When a second node
+connects to the same TrueNAS target subsystem with the same `hostnqn` that another
+node already holds a controller for, the connect is rejected → intermittent
+attach failures (and a data-corruption risk).
+
+**Workaround used this session (gets hermes up now):**
+
+1. **Retry.** The attach is intermittent — deleting the failing `virt-launcher`
+   pod / letting KubeVirt retry (or a `rebuild=true` re-provision) eventually wins
+   as controllers free up.
+2. **Recreate the blank state PVC to get a clean nvmeof subsystem.** Deleting the
+   `hermes-state` DataVolume/PVC and letting Argo/CDI re-provision a fresh blank
+   one allocates a **new TrueNAS zvol/target namespace** (fresh subsystem NQN),
+   sidestepping the stale-controller conflict. This is exactly why the live state
+   PVC is `pvc-46858de9` (recreated), not the original. Because it comes back
+   **blank and unformatted**, you then restore into it (step 4).
+
+> Recreating the state PVC discards whatever was on it — fine here, because we
+> restore from the tar backup anyway. If the disk held un-backed-up data, snapshot
+> or copy it first.
+
+**Permanent fix (deferred — see below).** A MachineConfig that regenerates unique
+`/etc/nvme/hostnqn` (`nvme gen-hostnqn`) + `/etc/nvme/hostid` (`uuidgen`) per node
+followed by a rolling reboot. Do **not** stop/start the hermes VM casually until
+this is fixed — every re-attach re-rolls this dice.
+
+### 4. Restore `~/.hermes` state onto the (blank) state disk
+
+The state disk presents in the guest as **`/dev/vdb`** (Block-mode PVC). A freshly
+recreated PVC is unformatted; the old state was XFS.
+
+**4a. Open an SSH path into the VM.** `hermes-deny-ingress` drops all inbound
+except tcp/22 from the `ansible-automation-platform` namespace, so a direct SSH
+from the devcontainer is blocked. Use the control-plane `virtctl port-forward`,
+which tunnels through the API server and **bypasses the NetworkPolicy**:
+
+```bash
+virtctl port-forward vmi/hermes -n hermes 12222:22 &
+ssh -p 12222 -i ~/.ssh/id_ed25519 -o IdentityAgent=none igou@localhost
+```
+
+(`IdentityAgent=none` because the forwarded agent socket flakes on signing; use the
+key file directly.)
+
+For the **bulk data transfer**, `virtctl port-forward` is unreliable for a
+single >few-GB stream — the websocket drops (~1006) after ~5 min. This session
+worked around it two ways, both used: (a) trimmed the payload so it fits the window
+(step 4c excludes `./containers`), and (b) added a **temporary allow-ingress
+NetworkPolicy** on tcp/22 for the transfer, then **deleted it** afterward so
+`deny-ingress` is fully restored. If you add the temp policy, remove it the moment
+the transfer completes:
+
+```bash
+# (temporary) allow ingress :22 for the transfer, e.g. temp-allow-ssh-restore
+# ... run the transfer ...
+oc delete networkpolicy temp-allow-ssh-restore -n hermes    # restore deny-ingress
+```
+
+**4b. Format and mount the state disk** (only if the PVC was recreated blank):
+
+```bash
+# inside the VM, as igou (sudo)
+sudo mkfs.xfs /dev/vdb            # skip if already xfs
+sudo mkdir -p /mnt/state && sudo mount /dev/vdb /mnt/state
+```
+
+**4c. Extract the essential state, excluding regenerable container storage.**
+`./containers` inside the tar is the rootless Podman image store (~10.5G) — the
+agent re-pulls it on convergence, so exclude it (this is also what keeps the
+transfer inside the port-forward window). Preserve ownership (agent runs as
+uid 1001):
+
+```bash
+# stream the backup from the devcontainer into the VM over the SSH path, extracting
+# into the mounted state disk, dropping the container image store:
+zstd -dc /workspace/backups/hermes/hermes-state-20260703.tar.zst \
+  | ssh -p 12222 -i ~/.ssh/id_ed25519 -o IdentityAgent=none igou@localhost \
+      'sudo tar -x --numeric-owner --exclude=./containers -C /mnt/state'
+```
+
+Restored (~1.4G): `auth.json`, `config.yaml`, `SOUL.md`, agent-config, dashboard,
+cron, memory — owner uid 1001 preserved.
+
+**4d. Unmount cleanly** so the data is durably on the PVC. The convergence's
+`setup-os.yml` later remounts `/dev/vdb` at `/home/hermes/.hermes` and, because the
+filesystem is already XFS, its `community.general.filesystem` task runs with
+`force: false` and **skips mkfs** — the pre-formatted, pre-populated disk survives.
+
+```bash
+sudo umount /mnt/state
+```
+
+Then tear down the temporary access: kill the `virtctl port-forward`, and delete
+any temp allow-ingress NetworkPolicy you created (4a).
+
+> `/home/hermes` non-`.hermes` content (agent-repos/workspace) lived on the
+> **non-persistent root disk** pre-disaster and is not restored here — it is
+> agent-regenerable. `hermes-home-root-20260703.tar.zst` holds it if any of it is
+> wanted later.
+
+## Verification
+
+```bash
+export KUBECONFIG=$HOME/openshift-agent-install/ocp/cluster-manifests/auth/kubeconfig
+
+# VM running, guest agent connected, both disks attached, VAP-admitted:
+oc get vm,vmi -n hermes
+oc get vmi hermes -n hermes -o jsonpath='{.status.phase}  {.status.nodeName}  {.status.guestOSInfo.prettyName}{"\n"}'
+
+# State PVC bound (the recreated one), 30Gi, Block:
+oc get pvc hermes-state -n hermes -o custom-columns=STATUS:.status.phase,VOL:.spec.volumeName,MODE:.spec.volumeMode
+
+# Guardrails intact:
+oc get networkpolicy hermes-deny-ingress hermes-egress -n hermes
+oc get egressfirewall default -n hermes -o jsonpath='{.status.status}{"\n"}'
+
+# Inside the VM (via port-forward SSH): state disk XFS, populated, uid 1001:
+#   sudo blkid /dev/vdb                 -> TYPE="xfs"
+#   sudo mount /dev/vdb /mnt/state && ls -la /mnt/state    # auth.json config.yaml SOUL.md ...
+#   stat -c '%u' /mnt/state/auth.json   -> 1001
+```
+
+Success = VM `Running`/Ready on a single node, guest agent up, `hermes-state`
+Bound and holding the restored XFS state, and `deny-ingress` back in force with no
+lingering temp NetworkPolicy or port-forward.
+
+## Rollback
+
+This runbook creates only the VM (and, if needed, a fresh blank state PVC); it does
+not converge or start the agent, so "rollback" is limited and safe.
+
+- **Undo the VM** without touching state data:
+  ```bash
+  # via the playbook, preserving hermes-state:
+  ansible-playbook playbooks/hermes/provision-vm.yml -e host=localhost -e rebuild=true \
+    -e "vm_ssh_authorized_key=$(cat ~/.ssh/id_ed25519.pub)" -e kubeconfig="$KUBECONFIG"
+  # or just delete the VM (root DV goes, hermes-state stays — it is a plain PVC):
+  oc delete vm hermes -n hermes
+  ```
+- **Bad restore / want a clean disk again:** delete the `hermes-state`
+  DataVolume/PVC, let Argo re-provision a fresh blank one (also re-rolls the NVMe
+  subsystem), then redo step 4. The tar backup is untouched and re-usable.
+- **Always remove temporary access artifacts** on abort: kill any
+  `virtctl port-forward`, `oc delete networkpolicy temp-allow-ssh-restore -n hermes`.
+- **Never** delete or hand-edit the Argo-owned guardrail objects to "fix" a
+  problem — let GitOps own them.
+
+## Gotchas & pitfalls (from this incident)
+
+- **All 3 nodes share one NVMe `hostnqn`/`hostid`** (`...466937ab...`) — the #1
+  cause of state-disk attach flakiness and a latent data-corruption risk. Verified
+  still true post-recovery on all of 10.10.9.10 / hpg5 / 10.10.9.21. Workaround:
+  retry + recreate the blank state PVC (fresh nvmeof subsystem). Real fix
+  (deferred): per-node MachineConfig regenerating unique hostnqn/hostid + rolling
+  reboot. **Avoid gratuitous stop/start of the hermes VM until fixed.**
+- **Recreated state PVC comes back blank + unformatted** — you must `mkfs.xfs
+  /dev/vdb` and re-extract; convergence's `setup-os.yml` only formats when the
+  device is unformatted (`force: false`), so it will preserve an already-XFS,
+  populated disk — that is by design, don't re-mkfs it.
+- **`deny-ingress` blocks devcontainer SSH** — it only allows tcp/22 from the AAP
+  namespace. Use `virtctl port-forward vmi/hermes` (API-server path, bypasses
+  NetworkPolicy). For bulk transfer, port-forward's websocket drops on a large
+  single stream (~1006 after ~5 min) → exclude `./containers` (~10.5G, regenerable)
+  and/or add a *temporary* allow-ingress NetworkPolicy and delete it right after.
+- **VM guest clock must be UTC.** A skewed/local-time guest clock breaks TLS
+  validation (against the OpenShift router / api.telegram.org / the in-cluster LLM)
+  and desyncs journald; `setup-os.yml` installs+enables `chrony` for this
+  (pre-rebuild the hermes VM was observed ~24h behind). This is the same class of
+  bug that bit the sibling `truenas-w1` RHCOS worker VM during this reinstall: its
+  hypervisor `time` was set to **local**, the guest RTC ran ~4h behind, and
+  Ignition's `GET api-int:22623/config/worker` failed x509 "certificate not yet
+  valid" because the MCS serving cert's valid-from was the (later) reinstall time —
+  fixed by setting the VM `time: UTC` and restarting. **Guest VMs in this cluster
+  must run their clock as UTC.**
+- **`vm_ssh_authorized_key` must be supplied** — provision-vm.yml defaults it to
+  empty and cloud-init only writes `ssh_authorized_keys` when it is non-empty; a
+  blank value yields a VM you cannot SSH into. The key must land on the **`igou`**
+  user (the cloud-init `user:` is `igou`), matching the convergence machine
+  credential — not the image default `cloud-user`.
+- **Clone at golden size, no resize** — CDI smart-clone deadlocks on resize with
+  the democratic-csi nvmeof volume-populator; `vm_root_size: 30Gi` matches the
+  golden image. Grow online later if ever needed.
+- **BIOS, not UEFI/Secure Boot** — the stock `centos-stream10` golden image is
+  BIOS-only; the spec pins `vm_firmware: bios`. Requesting SB/UEFI (or
+  hostDevices/GPU/non-masquerade) trips the `hermes-vm-hardening` VAP on
+  CREATE **and** UPDATE.
+- **Local repo checkouts are STALE** — for `igou-openshift` read from
+  `git show origin/main:<path>` rather than the working tree.
+
+## What stays operator-deferred
+
+Everything past "VM running with restored state" is intentionally **not** done by
+this runbook:
+
+- **Guest convergence** — `playbooks/hermes/{setup-os,setup-hermes,configure}.yml`
+  (install Hermes, mount `/dev/vdb`→`~/.hermes`, render `config.yaml`/`.env`,
+  nftables egress backstop, hardened `hermes-gateway.service` +
+  `hermes-dashboard.service`). These run **in-cluster via the AAP
+  `hermes-converge-e2e` workflow** (the devcontainer can't reach the masquerade pod
+  IP), and are gated on the operator's manual EgressFirewall OPEN→LOCKED git commits
+  in igou-openshift. `configure.yml` needs the in-cluster LLM (llmkube) up and the
+  1Password-sourced env (`.env`, dashboard basic-auth) supplied as extra-vars.
+- **Go-live** — enabling/starting `hermes-gateway.service`, Telegram, re-locking
+  egress, tearing down any temp LB/Route, and 1Password-sourcing the dashboard auth
+  are all held for the operator. Do **not** auto-enable the agent service.

--- a/docs/runbooks/restore-pvc-from-truenas.md
+++ b/docs/runbooks/restore-pvc-from-truenas.md
@@ -1,0 +1,320 @@
+## Restore a PVC / persistent volume from TrueNAS
+
+> Runbook derived strictly from the 2026-07-03 `ocp.igou.systems` cluster-reinstall incident.
+> Every command, path, hostname, zvol name and PVC id below is what was actually used to
+> recover the `hermes-state` PV and to identify/preserve the file-app zvols (jellyfin et al.)
+> after the cluster's etcd was wiped by an unattended agent-based reinstall.
+
+### Purpose
+
+When an OpenShift cluster is lost/rebuilt (or a single PVC is corrupted/deleted), the underlying
+persistent data usually still lives on TrueNAS as democratic-csi zvols. This runbook covers how to:
+
+1. **Rescue** an old zvol (snapshot + clone) so nothing can destroy it while you work.
+2. **Identify** which orphaned `pvc-<uuid>` zvol belongs to which app by content fingerprint.
+3. **Restore** that data into a freshly-provisioned PVC, using the exact methods that worked this
+   session — including the awkward case of a **block-mode PVC attached to a KubeVirt VM**
+   (`hermes-state`), a **filesystem PVC for a normal pod** (jellyfin pattern), byte-exact `dd`,
+   and low-copy **static import** of the zvol as a new PV.
+
+### When to use
+
+- A cluster rebuild left blank/fresh PVCs but the old data is intact on TrueNAS (this incident).
+- A single app's PVC was deleted or corrupted and its old zvol is still present.
+- You need to migrate a specific app's on-disk state onto a new cluster/namespace.
+
+**Why the old data survives at all (important):** all democratic-csi StorageClasses here are
+`reclaimPolicy: Delete`. The old zvols only survived because **etcd was wiped** — with no PV
+objects left, the CSI controller never issued a `DeleteVolume`, so the zvols were simply orphaned
+on TrueNAS (nothing GC'd them). On a *healthy* cluster, deleting the PVC/PV **will** destroy the
+zvol. That is exactly why Step 1 (snapshot + clone) comes first.
+
+### Prerequisites
+
+- **Cluster access:** `export KUBECONFIG=$HOME/openshift-agent-install/ocp/cluster-manifests/auth/kubeconfig`
+  (this session's kubeconfig; never use `~/.kube/*` — all stale).
+- **TrueNAS shell (read + zfs):**
+  `SSH_AUTH_SOCK= ssh -i ~/.ssh/id_ed25519 truenas_admin@truenas.igou.systems`
+  (host is `truenas.igou.systems`, **not** `igounas.igou.systems` which is an nginx VIP and rejects
+  the key). Remote shell is **zsh**, sudo is NOPASSWD. Long-running ZFS jobs: `midclt call --job ...`
+  (double-dash `--job`; `-job` errors).
+- **Backups / catalog on the devcontainer:**
+  - `/workspace/backups/ocp-pv-catalog-20260703.txt` — full `pool/k8s/vols/pvc-<uuid> | size | mtime | fs-type` list.
+  - `/workspace/backups/hermes/hermes-state-20260703.tar.zst` (11.9G raw = `~/.hermes` contents, xfs-level tar).
+  - `/workspace/backups/hermes/hermes-home-root-20260703.tar.zst` (hermes `/home` non-`.hermes`).
+- **`virtctl`** on PATH (for the KubeVirt-VM case).
+- **democratic-csi layout:** managed volumes live at `<pool>/k8s/vols/pvc-<uuid>` where pool ∈
+  `ssd` / `fast` / `cold`. Default StorageClass is `freenas-nvmeof-ssd-csi`. democratic-csi tags each
+  managed zvol with `democratic-csi:*` ZFS user properties — inspect with
+  `zfs get all <dataset> | grep democratic-csi` (this is also how the old PVC→zvol map is recoverable).
+
+---
+
+### Step 1 — Rescue the old zvol (snapshot + clone) BEFORE touching anything
+
+Pin the data with a recursive snapshot, then clone it to a **stable, human-named** dataset you can
+mount read-only. Cloning (vs. mounting the live zvol) means the app can never write through it and a
+stray `DeleteVolume` on the original can't take your rescue copy with it.
+
+```bash
+# on truenas.igou.systems (sudo, NOPASSWD)
+# example: old hermes-state = pvc-2d19e419 (xfs, 7.53G), old hermes-root = pvc-bf4dc3cf (gpt)
+
+sudo zfs snapshot ssd/k8s/vols/pvc-2d19e419-f817-4194-87b0-c5d68c6fee0a@rescue-20260703
+sudo zfs snapshot ssd/k8s/vols/pvc-bf4dc3cf-4cb3-4e9b-9c85-942c35e4ee89@rescue-20260703
+
+# clone to a friendly, mountable name (these are what were used this session)
+sudo zfs clone ssd/k8s/vols/pvc-2d19e419-...@rescue-20260703 ssd/k8s/rescue-hermes-state
+sudo zfs clone ssd/k8s/vols/pvc-bf4dc3cf-...@rescue-20260703 ssd/k8s/rescue-hermes-root
+```
+
+Mount the clones **read-only**. A clone of a zvol shows up as a block device under
+`/dev/zvol/<clone-path>` (and a `/dev/zdNNN` node — e.g. `ssd/k8s/rescue-hermes-state` = `/dev/zd624`):
+
+```bash
+sudo mkdir -p /mnt/rescue-state /mnt/rescue-root
+
+# bare filesystem zvol (hermes-state is raw xfs, no partition table) → mount directly, ro:
+sudo mount -o ro /dev/zvol/ssd/k8s/rescue-hermes-state /mnt/rescue-state
+
+# PARTITIONED zvol (hermes-root is GPT — the data was on partition 2) → expose partitions first:
+sudo losetup -Pf /dev/zvol/ssd/k8s/rescue-hermes-root   # creates e.g. /dev/loop1 with loop1p2
+sudo mount -o ro /dev/loop1p2 /mnt/rescue-root          # this session: "loop1 = root p2"
+```
+
+> Clean these up only **after** the full restore is verified: `umount`, `zfs destroy` the clones, then
+> `zfs destroy` the `@rescue-20260703` snapshots. Leave the original `pvc-*` zvols in place.
+
+---
+
+### Step 2 — Identify which old zvol belongs to which app (content fingerprint)
+
+After a rebuild you have dozens of anonymous `pvc-<uuid>` zvols and no PVC→zvol map (etcd is gone).
+Fingerprint them by mounting each read-only and listing the top level. This session used a helper
+(`/tmp/idvol.sh` on truenas) that, for every `*/k8s/vols/pvc-*`:
+
+1. Reads the fs type: `sudo blkid /dev/zvol/<ds>` / `sudo file -s /dev/zvol/<ds>`
+   (the catalog's `TYPE=xfs|ext4` / `PTTYPE=gpt|dos` column comes from this).
+2. If it's a **bare fs** → `mount -o ro` and `ls`.
+3. If it's **partitioned** (`PTTYPE=gpt|dos`) → `losetup -Pf` (or `kpartx -a`), mount the data
+   partition ro, `ls`.
+4. Records size + mtime + top-level directory names as the fingerprint, then unmounts.
+
+Confirmed mappings from this incident (full list: `/workspace/backups/ocp-pv-catalog-20260703.txt`):
+
+| App / data | Old zvol | FS | Fingerprint (top-level) |
+|---|---|---|---|
+| **jellyfin** config | `pvc-3f5e1c03-b542-4103-b911-a700f680d3c2` | ext4 | `config/ data/ log/ metadata/ plugins/` |
+| **hermes-state** | `pvc-2d19e419-f817-4194-87b0-c5d68c6fee0a` | xfs | `SOUL.md auth.json config.yaml` (candidate `pvc-2a75b3ea` also xfs) |
+| **hermes-root** | `pvc-bf4dc3cf-4cb3-4e9b-9c85-942c35e4ee89` | gpt | clone of centos-stream10 golden `pvc-5831f710` |
+
+> Old `pgdata`/DB zvols were **not** needed — those databases (quay/rhdh/forgejo) were restored from
+> Barman/RustFS backups instead of from their zvols. Only clearly-valuable file-app zvols (jellyfin)
+> justify a per-app restore; most file-app data is regenerable (model caches, queues, git-mirror).
+
+---
+
+### Step 3 — Restore the data (pick the method that matches the PVC)
+
+#### 3A. Block-mode PVC attached to a KubeVirt VM — the `hermes-state` case (the method actually used)
+
+`hermes-state` is a **block-mode** 30Gi PVC (`freenas-nvmeof-ssd-csi`) attached to the `hermes`
+KubeVirt VM as disk **`vdb`**. It comes up **blank/unformatted** from a fresh provision. Restore is
+done **inside the guest**, not with a temp pod.
+
+1. Provision the VM (creates + attaches the blank `hermes-state` PVC as `vdb`):
+
+   ```bash
+   ansible-playbook playbooks/hermes/provision-vm.yml \
+     -e host=localhost \
+     -e vm_ssh_authorized_key="$(cat ~/.ssh/id_ed25519.pub)" \
+     -e kubeconfig="$KUBECONFIG"
+   ```
+
+2. Reach the VM. Ingress is blocked by the `hermes-deny-ingress` (deny-all) NetworkPolicy, so use
+   `virtctl port-forward` — it rides the **control-plane path and bypasses the NetworkPolicy**:
+
+   ```bash
+   virtctl port-forward vmi/hermes -n hermes 12222:22 &
+   ssh -p 12222 -i ~/.ssh/id_ed25519 igou@localhost
+   ```
+
+3. Inside the guest, format and mount the blank block device:
+
+   ```bash
+   sudo mkfs.xfs /dev/vdb                 # blank PVC; this session got UUID 431c7ecf
+   sudo mkdir -p /mnt/restore
+   sudo mount /dev/vdb /mnt/restore
+   ```
+
+4. **Stream + extract the backup, EXCLUDING the regenerable `./containers` podman storage.**
+   The tar is xfs *contents* (not a raw image), so extract into the mounted fs. `./containers` is
+   ~10.5G of podman image storage the agent re-pulls on convergence — excluding it is what let the
+   transfer fit past the port-forward's size limit (see next note). ~1.4G of essential state was
+   restored (`auth.json config.yaml SOUL.md agent-config dashboard cron memory`), owner **uid 1001**
+   preserved:
+
+   ```bash
+   # from the devcontainer, piping the backup into the guest over ssh
+   zstd -dc /workspace/backups/hermes/hermes-state-20260703.tar.zst \
+     | ssh -p 12222 -i ~/.ssh/id_ed25519 igou@localhost \
+         'sudo tar -x --exclude=./containers --numeric-owner -C /mnt/restore'
+   ```
+
+   **Port-forward is flaky for large single streams** (websocket drops with code 1006 after ~5 min).
+   Two levers were used: (a) shrink the payload via `--exclude=./containers`; (b) for bulk transfer,
+   temporarily allow direct SSH to the VM's pod IP with a short-lived **allow-ingress** NetworkPolicy,
+   then delete it. Representative temp policy (match the virt-launcher pod's labels; delete when done):
+
+   ```yaml
+   apiVersion: networking.k8s.io/v1
+   kind: NetworkPolicy
+   metadata:
+     name: temp-allow-ssh-restore
+     namespace: hermes
+   spec:
+     podSelector:
+       matchLabels:
+         kubevirt.io/vm: hermes      # verify against the live virt-launcher pod labels
+     policyTypes: [Ingress]
+     ingress:
+       - ports:
+           - port: 22
+             protocol: TCP
+   ```
+
+   ```bash
+   # transfer straight to the VM pod IP while the temp policy is up, then REMOVE it:
+   POD_IP=$(oc get vmi hermes -n hermes -o jsonpath='{.status.interfaces[0].ipAddress}')
+   zstd -dc /workspace/backups/hermes/hermes-state-20260703.tar.zst \
+     | ssh -i ~/.ssh/id_ed25519 igou@${POD_IP} \
+         'sudo tar -x --exclude=./containers --numeric-owner -C /mnt/restore'
+   oc delete networkpolicy temp-allow-ssh-restore -n hermes   # restores deny-all ingress
+   ```
+
+5. Unmount cleanly so the data lands on the zvol, then let convergence take over:
+
+   ```bash
+   sudo umount /mnt/restore
+   ```
+
+   Convergence's `setup-os.yml` remounts this device at `/home/hermes/.hermes` and **skips mkfs**
+   (`force=false`) because it is already xfs — so the pre-populated state survives.
+
+> **Do NOT stop/start the hermes VM until the NVMe hostnqn bug (Gotchas) is fixed** — a stop/start
+> re-triggers the duplicate-hostnqn attach failure.
+
+#### 3B. Filesystem PVC for a normal pod — the jellyfin pattern (scale-to-0 + helper pod, tar-over-`oc exec`)
+
+For `jellyfin-config` (`pvc-3f5e1c03`, ext4) restore into a fresh filesystem PVC without the VM machinery:
+
+1. **Freeze Argo automated sync on BOTH `root-applications` (owns the child app spec) and the app
+   itself** — otherwise selfHeal rescales the deployment mid-copy.
+2. Scale the workload to 0: `oc scale deploy/jellyfin -n jellyfin --replicas=0`.
+3. Launch a helper pod mounting the target PVC. **Pin `runAsUser`/`fsGroup` to the namespace's
+   uid-range** (e.g. `1000950000`) — cluster-admin helper pods land in the `anyuid` SCC with no UID
+   injection, so a `runAsNonRoot` image otherwise fails.
+4. Copy the old data in via a tar stream (mirrors the biscuit→OCP migration: `ssh tar | oc exec`):
+
+   ```bash
+   # from truenas rescue clone → helper pod, over oc exec stdin (avoids flaky port-forward)
+   ssh -i ~/.ssh/id_ed25519 truenas_admin@truenas.igou.systems \
+       'sudo tar -C /mnt/rescue-<app> -cf - .' \
+     | oc exec -i -n jellyfin <helper-pod> -- tar -xf - -C /config
+   ```
+
+5. Restore Argo automated on both apps; selfHeal rescales the deployment back to 1.
+
+> Prefer `oc exec` stdin streaming or the temp-netpol SSH path over `virtctl port-forward` for
+> anything more than a few GB.
+
+#### 3C. Byte-exact raw copy (`dd` the clone into the block device)
+
+When you want a byte-for-byte restore (same fs/UUID, block PVC), attach the fresh block PVC to a
+pod/VM and `dd` the rescue clone straight in. Sizes must match.
+
+```bash
+# stream the rescue clone device from truenas into the VM's blank block disk
+ssh -i ~/.ssh/id_ed25519 truenas_admin@truenas.igou.systems \
+    'sudo dd if=/dev/zvol/ssd/k8s/rescue-hermes-state bs=4M' \
+  | ssh -p 12222 -i ~/.ssh/id_ed25519 igou@localhost 'sudo dd of=/dev/vdb bs=4M'
+```
+
+This was the documented byte-exact alternative to 3A's tar method; 3A was preferred because it lets
+you exclude the regenerable `./containers` and doesn't require size parity.
+
+#### 3D. Static-import the old zvol as a PV (lowest-copy, most fiddly)
+
+Instead of copying, present the existing zvol to the new cluster as a statically-provisioned PV and
+bind a PVC to it. Steps: `zfs get all <dataset> | grep democratic-csi` to read the driver metadata,
+then hand-author a `PersistentVolume` with the democratic-csi `csi:` block (`driver`,
+`volumeHandle` = the existing dataset, matching `volumeAttributes`, `volumeMode`) and
+**`persistentVolumeReclaimPolicy: Retain`** so a later delete can't destroy it, plus a matching PVC.
+The session preferred copy-based restores (3A/3B) over this because the nvmeof/iscsi `volumeHandle`
+and attributes must be reconstructed exactly.
+
+---
+
+### Verification
+
+- **Zvol / clone health (truenas):** `zfs list -t all | grep -E 'rescue|pvc-<uuid>'`;
+  `blkid /dev/zvol/<clone>` shows the expected fs (`xfs`/`ext4`).
+- **hermes-state (3A):** after mount, `ls -la /mnt/restore` shows `auth.json config.yaml SOUL.md
+  agent-config dashboard cron memory` (NOT `containers`), owned by uid **1001**;
+  `xfs_admin -u /dev/vdb` (or `blkid`) reports the expected UUID; clean `umount` returns 0.
+- **PVC bound & attached:**
+  `oc get pvc -n hermes hermes-state` → `Bound` to a `pvc-<uuid>` on `freenas-nvmeof-ssd-csi`;
+  `oc get vmi hermes -n hermes` running with `vdb` attached.
+- **App-level (jellyfin 3B):** after rescale, the app reports its restored identity/library and file
+  counts match the fingerprint (this session verified 3318 files / 323M for the biscuit migration).
+- **Ingress locked back down:** `oc get networkpolicy -n hermes` shows `hermes-deny-ingress` present
+  and `temp-allow-ssh-restore` **absent**.
+
+### Rollback
+
+- The original `pvc-<uuid>` zvols are **never modified** (all writes go to the *clone* or to the *new*
+  PVC), so rollback is: destroy the new/failed target and re-clone from the `@rescue-20260703`
+  snapshot. `zfs rollback` is available on the original because the snapshot exists.
+- If a restore into a PVC goes wrong: unmount, `oc delete pvc` (fresh data only — the source zvol is
+  untouched), re-provision, retry.
+- Always keep the rescue clones and snapshots until the app is verified healthy; tear them down only
+  at the end (`umount /mnt/rescue-*`; `losetup -d /dev/loop1`; `zfs destroy ssd/k8s/rescue-hermes-*`;
+  `zfs destroy <orig>@rescue-20260703`).
+
+### Gotchas & pitfalls (from this incident)
+
+- **`reclaimPolicy: Delete` is a data-loss trap.** All democratic-csi SCs here are `Delete`. Old
+  zvols survived *only* because etcd was wiped (no PV → no `DeleteVolume`). Deleting a live PVC/PV
+  **destroys** the zvol. Always snapshot + clone first; set static-imported PVs to `Retain`.
+- **`virtctl port-forward` drops on big transfers.** Websocket dies with code 1006 after ~5 min on a
+  multi-GB single stream. Mitigations: exclude regenerable data (`--exclude=./containers`), or add a
+  temporary allow-ingress NetworkPolicy and SSH straight to the VM pod IP, then delete the policy.
+- **Restore the deny-all NetworkPolicy afterward.** `temp-allow-ssh-restore` must be deleted so
+  `hermes-deny-ingress` is back in force.
+- **Block PVC comes up blank.** A fresh block-mode PVC is unformatted — `mkfs.xfs /dev/vdb` yourself;
+  convergence's `setup-os.yml` will then *skip* mkfs (`force=false`) and keep your data.
+- **Exclude podman/container storage.** `./containers` in the hermes tar is ~10.5G of regenerable
+  image cache; excluding it is both faster and what made the transfer fit. The agent re-pulls on
+  convergence.
+- **Preserve ownership.** Extract with `--numeric-owner`; hermes state is uid **1001**. For pod
+  helper restores, pin `runAsUser`/`fsGroup` to the namespace uid-range (`anyuid` SCC does no UID
+  injection).
+- **Partitioned vs. bare zvols mount differently.** Raw-fs zvols (hermes-state = xfs) mount directly;
+  GPT/DOS zvols (hermes-root) need `losetup -Pf` (or `kpartx`) and you mount the data partition
+  (`loop1p2` this session).
+- **🚨 Duplicate NVMe hostnqn/hostid across all 3 nodes.** All nodes share
+  `nqn.2014-08.org.nvmexpress:uuid:466937ab-67bf-4315-971b-bc110d55ce28` (baked by the agent
+  install). This causes intermittent nvme-of attach failures ("unable to attach any nvme devices" /
+  "Connect command failed error 6") when a second node connects to the same subsystem, and risks
+  corruption. It directly hit the hermes VM's second nvmeof disk during restore. Workaround that
+  worked: retry, and recreate the PVC if it stays stuck (`hermes-state` was recreated fresh →
+  `pvc-46858de9`). Real fix pending: per-node MachineConfig regenerating `/etc/nvme/hostnqn`
+  (`nvme gen-hostnqn`) + `/etc/nvme/hostid` (`uuidgen`) + rolling reboot. **Until fixed, do not
+  stop/start the hermes VM.**
+- **DBs restore from Barman, not zvols.** Don't waste time on old `pgdata` zvols — quay/rhdh/forgejo
+  were recovered from RustFS/Barman object-store backups; their zvols are stale.
+- **TrueNAS host name & shell quirks.** SSH to `truenas.igou.systems` (not `igounas.igou.systems`);
+  remote shell is zsh; ZFS job methods need `--job` (double dash).
+- **Stale local repo checkout.** `/workspace/igou-openshift` is far behind origin — use
+  `git fetch origin` + `git show origin/main:<path>` when authoring/applying manifests; `oc kustomize`
+  from the stale tree renders old specs.

--- a/docs/runbooks/zfs-snapshot-rescue.md
+++ b/docs/runbooks/zfs-snapshot-rescue.md
@@ -1,0 +1,261 @@
+## ZFS snapshot/clone rescue of cluster PVs before a destructive op
+
+> Source of truth: the 2026-07-03 `ocp` cluster-reinstall incident. Every command,
+> path, and gotcha below was taken from the ACTUAL procedure used to rescue the
+> hermes agent's persistent volumes off TrueNAS before/while the cluster was rebuilt.
+> Verified against live TrueNAS state on 2026-07-04 (clones + snapshots still present).
+
+### Purpose
+
+Take a crash-consistent, near-instant, zero-cost **ZFS snapshot** of the democratic-csi
+zvols that back cluster PVCs, **clone** those snapshots into stable writable zvol devices,
+loop/direct-mount them **read-only**, and **stream the contents off-box** (tar → zstd over
+ssh) to durable storage — so PV data survives a destructive operation (cluster reinstall,
+disk wipe, risky migration) even when the cluster's etcd/PV bindings are gone.
+
+The live cluster is NOT required for any of this. The zvols live on TrueNAS
+(`truenas.igou.systems`) and outlive the OpenShift install completely. In the incident the
+cluster was already destroyed (etcd overwritten) yet all PV zvols were intact and fully
+recoverable by this procedure.
+
+### When to use
+
+- **Before** any operation that can wipe a node/disk or orphan PVs: agent-based reinstall,
+  netboot reprovision, TrueNAS pool surgery, democratic-csi driver migration, one-way app
+  data migrations (SQLite/MariaDB schema upgrades — same reflex as the pre-Renovate
+  `zfs snapshot -r ssd/containers@<tag>` habit).
+- **After** a disaster, to extract still-valuable data from old zvols whose PVCs no longer
+  exist in the new cluster (block-mode data recovery, fingerprinting orphaned zvols).
+- Any time you want a portable, filesystem-agnostic backup of a PVC's contents that can be
+  restored into a freshly-created (different-UUID, possibly different-size) PVC.
+
+### Prerequisites
+
+- **Read-only SSH to TrueNAS** with NOPASSWD sudo:
+  `SSH_AUTH_SOCK= ssh -i ~/.ssh/id_ed25519 -o IdentitiesOnly=yes truenas_admin@truenas.igou.systems`
+  - Use `truenas_admin@truenas.igou.systems` — **NOT** `igounas.igou.systems` (that is an
+    nginx vhost VIP and rejects the key). Remote shell is **zsh** (avoid bare `===` in
+    unquoted echos).
+  - In the devcontainer the forwarded ssh-agent often wedges — always prefix `SSH_AUTH_SOCK=`
+    and pass `-o IdentitiesOnly=yes -i ~/.ssh/id_ed25519`.
+- **PVC → zvol mapping.** democratic-csi zvols live at `<pool>/k8s/vols/pvc-<uuid>` on the
+  `ssd`, `fast`, and `cold` pools. While the cluster is alive, get the handle from
+  `oc get pv <name> -o jsonpath='{.spec.csi.volumeHandle}'`. After a disaster, fingerprint
+  orphaned zvols by mounting them ro and inspecting content (the incident's `/tmp/idvol.sh`
+  helper looped `blkid`/`file -s`/`ls` over `/dev/zvol/<pool>/k8s/vols/*`). A catalog of the
+  survivors is at `/workspace/backups/ocp-pv-catalog-20260703.txt`
+  (`<pool>/k8s/vols/pvc-… | size mtime | TYPE=/PTTYPE=`).
+- **Durable landing space for the stream:** the devcontainer's `/workspace/backups/` — it is
+  bind-mounted from the host and **survives container rebuilds**. Do NOT stage multi-GB
+  backups in `/tmp` or anywhere on the container filesystem (ephemeral, lost on rebuild).
+- `zstd` available on the devcontainer (it is), and enough free space on `/workspace`.
+
+Known mapping from the incident (for reference):
+
+| Role         | Live PVC zvol                              | Layout                    | Clone                          |
+|--------------|--------------------------------------------|---------------------------|--------------------------------|
+| hermes root  | `ssd/k8s/vols/pvc-bf4dc3cf-…` (10.8G)       | **GPT**, p2 = xfs @ 2097152 | `ssd/k8s/rescue-hermes-root`   |
+| hermes state | `ssd/k8s/vols/pvc-2d19e419-…` (7.53G)       | **whole-zvol xfs** (no PT) | `ssd/k8s/rescue-hermes-state`  |
+
+(hermes root pvc-bf4dc3cf was itself a clone of the `centos-stream10` golden DataSource
+zvol `pvc-5831f710`, which is why it carries a GPT image layout instead of a raw xfs.)
+
+### Step-by-step (real commands, real hosts/paths)
+
+All `zfs`/`mount`/`losetup`/`tar` commands run **on TrueNAS** (over the ssh above); the final
+stream is initiated **from the devcontainer** so the bytes land on `/workspace`.
+
+**1. Snapshot the target zvols — do this FIRST, before the destructive op.**
+Snapshots are atomic, instantaneous, and cost 0B until the source diverges.
+
+```
+# per-zvol (what the incident used):
+sudo zfs snapshot ssd/k8s/vols/pvc-bf4dc3cf-4cb3-4e9b-9c85-942c35e4ee89@rescue-20260703
+sudo zfs snapshot ssd/k8s/vols/pvc-2d19e419-f817-4194-87b0-c5d68c6fee0a@rescue-20260703
+
+# OR grab EVERY pvc on a pool at once (recursive), mirroring the pre-Renovate habit:
+sudo zfs snapshot -r ssd/k8s/vols@rescue-20260703
+```
+
+**2. Clone each snapshot into a stable, writable zvol device.**
+Cloning gives a friendly `/dev/zvol` path decoupled from the live PVC zvol, and a device you
+can safely loop-mount without any risk to the source.
+
+```
+sudo zfs clone ssd/k8s/vols/pvc-bf4dc3cf-…@rescue-20260703 ssd/k8s/rescue-hermes-root
+sudo zfs clone ssd/k8s/vols/pvc-2d19e419-…@rescue-20260703 ssd/k8s/rescue-hermes-state
+```
+
+The clones appear as:
+```
+/dev/zvol/ssd/k8s/rescue-hermes-root  -> ../../../zd576
+/dev/zvol/ssd/k8s/rescue-hermes-state -> ../../../zd624
+```
+
+**3. Determine each clone's on-disk layout (decides how you mount it).**
+
+```
+sudo blkid  /dev/zvol/ssd/k8s/rescue-hermes-state   # -> TYPE="xfs"  (whole-zvol fs)
+sudo sgdisk -p /dev/zvol/ssd/k8s/rescue-hermes-root  # -> GPT: part 2 (8300) starts sector 4096
+```
+
+Two cases observed:
+- **Whole-zvol xfs** (block-mode PVC): `blkid` reports `TYPE=xfs` directly on the zvol.
+  Mount the zvol device itself.
+- **GPT image** (cloned from an OS golden image): `sgdisk -p` shows part 1 = `EF02`
+  (BIOS boot, 1024 KiB) and part 2 = `8300` Linux at **start sector 4096** →
+  byte offset `4096 * 512 = 2097152`. The xfs root lives inside part 2; mount via a loop
+  device at that offset.
+
+**4a. Mount the whole-zvol xfs clone directly, read-only.**
+
+```
+sudo mkdir -p /mnt/rescue-state
+sudo mount -o ro,norecovery /dev/zvol/ssd/k8s/rescue-hermes-state /mnt/rescue-state
+```
+
+**4b. Loop-mount the GPT clone's partition 2 at offset 2097152, read-only.**
+
+```
+sudo mkdir -p /mnt/rescue-root
+sudo losetup -f --offset 2097152 --read-only /dev/zvol/ssd/k8s/rescue-hermes-root
+sudo losetup -a                                   # find it, e.g. /dev/loop1: (/dev/zd576), offset 2097152
+sudo mount -o ro,norecovery /dev/loop1 /mnt/rescue-root
+# (equivalent: `losetup -fP --read-only <clone>` to auto-scan, then mount /dev/loopNp2)
+```
+
+`-o norecovery` is mandatory here — see gotchas. Both mounts end up as:
+```
+/dev/zd624  on /mnt/rescue-state type xfs (ro,relatime,norecovery,…)
+/dev/loop1  on /mnt/rescue-root  type xfs (ro,relatime,norecovery,…)
+```
+
+**5. Verify you mounted the right thing.**
+
+```
+sudo ls /mnt/rescue-state      # SOUL.md  auth.json  config.yaml  bin  cache …
+sudo ls /mnt/rescue-root/home  # hermes …
+df -h /mnt/rescue-root /mnt/rescue-state
+```
+
+**6. Stream the contents off-box (tar → zstd over ssh) into `/workspace/backups`.**
+Run from the devcontainer so bytes land on the durable bind-mount. tar the directory
+**contents** (portable — restores into any freshly-created PVC), zstd on all cores locally.
+
+```
+mkdir -p /workspace/backups/hermes
+
+# state clone -> archive
+SSH_AUTH_SOCK= ssh -i ~/.ssh/id_ed25519 -o IdentitiesOnly=yes truenas_admin@truenas.igou.systems \
+  "sudo tar -C /mnt/rescue-state --numeric-owner -cf - ." \
+  | zstd -T0 -o /workspace/backups/hermes/hermes-state-20260703.tar.zst
+
+# root clone -> archive
+SSH_AUTH_SOCK= ssh -i ~/.ssh/id_ed25519 -o IdentitiesOnly=yes truenas_admin@truenas.igou.systems \
+  "sudo tar -C /mnt/rescue-root --numeric-owner -cf - ." \
+  | zstd -T0 -o /workspace/backups/hermes/hermes-home-root-20260703.tar.zst
+```
+
+`--numeric-owner` preserves guest uids (hermes = uid 1001) that don't exist in TrueNAS'
+passwd. Result sizes from the incident: state 11.9G raw → 4.09G .zst; root 6.8G raw → 4.92G .zst.
+
+**7. Verify archive integrity.**
+
+```
+zstd -t /workspace/backups/hermes/hermes-state-20260703.tar.zst
+zstd -t /workspace/backups/hermes/hermes-home-root-20260703.tar.zst
+```
+
+### Where the rescue artifacts live
+
+- **Clones (on TrueNAS, still present):** `ssd/k8s/rescue-hermes-root` (→ `/dev/zd576`),
+  `ssd/k8s/rescue-hermes-state` (→ `/dev/zd624`).
+- **Snapshots (on TrueNAS):** `…/pvc-bf4dc3cf-…@rescue-20260703`,
+  `…/pvc-2d19e419-…@rescue-20260703` (created 2026-07-03 13:57).
+- **Read-only mounts (on TrueNAS):** `/mnt/rescue-root` (loop1), `/mnt/rescue-state` (zd624).
+- **Off-box archives (devcontainer, durable):**
+  `/workspace/backups/hermes/hermes-home-root-20260703.tar.zst`,
+  `/workspace/backups/hermes/hermes-state-20260703.tar.zst`.
+- **Orphan-zvol catalog:** `/workspace/backups/ocp-pv-catalog-20260703.txt`.
+
+### Verification
+
+```
+# snapshots exist
+sudo zfs list -t snapshot -o name,creation | grep rescue
+# clones exist and point at the right snapshot origin
+sudo zfs list -o name,origin,volsize -t volume | grep rescue
+# mounts are read-only
+mount | grep -E 'rescue-(root|state)'
+# archives pass integrity check
+zstd -t /workspace/backups/hermes/*.tar.zst
+# (optional) compare a known file's content between mount and the extracted tar
+sudo sha256sum /mnt/rescue-state/SOUL.md
+```
+
+### Rollback / cleanup
+
+Only after per-app restore is fully confirmed. Order matters: **unmount → detach loop →
+destroy clone → destroy snapshot**. A snapshot with a live dependent clone will not
+`zfs destroy` (unless `-R`, which would also nuke the clone). Never touch the live
+`…/vols/pvc-*` zvol.
+
+```
+sudo umount /mnt/rescue-root /mnt/rescue-state
+sudo losetup -d /dev/loop1
+sudo rmdir  /mnt/rescue-root /mnt/rescue-state          # optional
+
+sudo zfs destroy ssd/k8s/rescue-hermes-root            # clone first
+sudo zfs destroy ssd/k8s/rescue-hermes-state
+sudo zfs destroy ssd/k8s/vols/pvc-bf4dc3cf-…@rescue-20260703   # then snapshot
+sudo zfs destroy ssd/k8s/vols/pvc-2d19e419-…@rescue-20260703
+```
+
+> NOTE: as of 2026-07-04 these clones/snapshots/mounts are STILL PRESENT — the incident note
+> reads "Clean these up after full restore." Do not destroy them until every intended per-app
+> PV restore is verified against the new cluster.
+
+**Restoring the data back into a PVC.** The tar-of-contents restores filesystem-agnostically:
+- **Block-mode (xfs) PVC:** create the PVC, run a temp pod with it as a raw
+  `volumeDevices`/`volumeDevice` (block), `mkfs.xfs` the device, `mount`, extract the tar,
+  unmount. (This is exactly how hermes-state was rehydrated — vdb formatted xfs, essential
+  `.hermes` extracted, `./containers` excluded as regenerable.)
+- **Byte-exact alternative:** `dd if=/dev/zd624 of=…` (or into the new zvol) for an exact
+  image — larger, and only works if the target zvol matches size/layout.
+
+### Gotchas & pitfalls (from this incident)
+
+1. **Snapshot FIRST, decide later.** It is atomic, instant, and 0B. Reach for
+   `zfs snapshot -r <pool>/k8s/vols@<tag>` to capture every PVC on a pool before any
+   destructive op — same reflex as the pre-Renovate `zfs snapshot -r ssd/containers@<tag>`.
+2. **Whole-zvol xfs vs GPT image — always check before mounting.** Block-mode PVCs are raw
+   xfs on the whole zvol (mount directly). A zvol cloned from an OS golden image
+   (e.g. hermes root ← `centos-stream10` golden `pvc-5831f710`) is **GPT-partitioned**; you
+   must loop-mount part 2 at **offset 2097152**. Run `blkid` / `sgdisk -p` first — guessing
+   wrong wastes time.
+3. **xfs read-only mount of an unclean filesystem REQUIRES `-o norecovery`.** The clone's log
+   is dirty (the cluster died uncleanly). Without `norecovery`, a `ro` mount errors out
+   because xfs wants to replay the log (which it can't do read-only). `norecovery` skips
+   replay so the ro mount succeeds — and ro (plus operating on a clone, never the live zvol)
+   guarantees the source of truth is untouched.
+4. **Shared xfs UUID across clones of the same golden image** can cause a mount collision
+   (duplicate-UUID). Mount them one at a time, or add `-o nouuid`.
+5. **Wrong TrueNAS hostname fails silently-ish.** Use `truenas_admin@truenas.igou.systems`,
+   not `igounas.igou.systems` (nginx VIP rejects the key). Remote shell is zsh.
+6. **Devcontainer ssh-agent wedges** — always `SSH_AUTH_SOCK= … -o IdentitiesOnly=yes
+   -i ~/.ssh/id_ed25519`.
+7. **Stage backups on `/workspace/backups` only** — it is a durable host bind-mount. `/tmp`
+   and the container FS are ephemeral (lost on rebuild); a multi-GB archive there would
+   vanish exactly when you need it.
+8. **`--numeric-owner` on tar** — guest uids (hermes 1001) aren't in TrueNAS' passwd; without
+   it you lose ownership on restore.
+9. **Prefer tar-of-contents over `dd` of the block device** for the general case — it is
+   smaller and restores into a re-created PVC that may have a new fs UUID or different size.
+   Reserve `dd` for when you need a byte-exact image into an identically-sized target.
+10. **`virtctl port-forward` is unreliable for multi-GB single streams** (websocket 1006
+    drops around the ~5-minute mark). The ssh + tar + zstd path straight off the TrueNAS host
+    is the dependable large-transfer route; when forced through a port-forward, exclude bulky
+    regenerable data (e.g. `./containers` podman image storage) to keep the stream short.
+11. **Operate ONLY on the clone device** (`/dev/zvol/ssd/k8s/rescue-*` → `zdNNN`), never on
+    the live PVC zvol (`/dev/zvol/ssd/k8s/vols/pvc-*`). The clone is the safety layer; the
+    whole point is to keep the live zvol pristine.


### PR DESCRIPTION
Multi-agent review (63 Opus 4.8 subagents) of the 2026-07-03 `ocp` cluster disaster & recovery — assembled into docs, not an issue flood.

## What's here
- **`docs/post-mortems/2026-07-03-ocp-disaster-recovery.md`** — one post-mortem, sections authored by 4 expert reviewers (incident/timeline, GitOps repo, Ansible repo, architecture) + 6 professional personas (Kubernetes admin, SRE, software engineer, virtualization admin, DBA, code/process-readability), with an executive summary and a consolidated **prioritized action-item table**.
- **`docs/post-mortems/2026-07-03-component-reviews.md`** — read-only health check + functionality review of all **46** app-of-apps components, including the Hermes agent VM.
- **`docs/runbooks/`** — six runbooks distilled from the actual recovery: PVC/PV restore from TrueNAS, CNPG Barman recovery, ZFS snapshot rescue, Hermes VM rebuild, agent reinstall + netboot pin safety, and GitOps bootstrap from scratch.

## Highest-signal findings
- 🔴 **NVMe-oF identity collision is worse than first thought** — all 3 nodes *and* the democratic-csi node plugin carry duplicate hostnqns; the host-only MachineConfig fix is necessary but not sufficient.
- 🔴 **Recovery-critical settings live only on the cluster, not git** — the ArgoCD repo-server tuning + PushSecret/ExternalSecret health-checks that un-stalled DR are absent from the bootstrap playbook and revert on next run.
- 🔴 **CNPG clusters left in one-shot `bootstrap.recovery`** — a Cluster recreate would silently roll back to the 2026-07-02 snapshot; **forgejo** additionally serves an empty DB with its repo volume orphaned.
- 🟠 **1Password Connect PushSecret write-back broken (403)** — the re-seeded token lost its `ocp-push`/`claude` write grants.
- Plus per-component notes (orphaned GPU time-slicing config, master-only nvme-tcp MachineConfig, etc.).

Docs only — no manifest changes. Follow-up PRs will action the items.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01D96MwumLzMACaBTHNTRoov