### PR TITLE
fix(cnpg): revert recovered DBs to initdb steady-state + ignoreDifferences

### DIFF
--- a/applications/forgejo/forgejo-pg-cluster.yaml
+++ b/applications/forgejo/forgejo-pg-cluster.yaml
@@ -17,23 +17,17 @@ spec:
     nodeSelector:
       node-role.kubernetes.io/control-plane: ""
     podAntiAffinityType: preferred # CNPG default; declared to avoid ArgoCD drift
-  # 2026-07-03 disaster recovery: restore the forgejo database from the Barman
-  # Cloud backup on RustFS (latest base 2026-07-02) instead of initdb. Revert to
-  # the initdb block below once recovered and verified.
-  #   bootstrap:
-  #     initdb:
-  #       database: forgejo
-  #       owner: forgejo
+  # 2026-07-03: the forgejo database was disaster-recovered from Barman
+  # (bootstrap.recovery + a temporary externalClusters). Now restored and
+  # verified, this is reverted to steady-state initdb so a future Cluster
+  # recreate re-inits fresh rather than silently rolling back to the pre-disaster
+  # snapshot. The live cluster keeps its recovery-baked bootstrap (immutable) —
+  # the app ignoreDifferences on /spec/bootstrap + /spec/externalClusters
+  # suppresses that drift.
   bootstrap:
-    recovery:
-      source: forgejo-pg
-  externalClusters:
-    - name: forgejo-pg
-      plugin:
-        name: barman-cloud.cloudnative-pg.io
-        parameters:
-          barmanObjectName: forgejo-pg-backup
-          serverName: forgejo-pg
+    initdb:
+      database: forgejo
+      owner: forgejo
   storage:
     size: 10Gi
     storageClass: freenas-nvmeof-ssd-csi

--- a/clusters/ocp/values.yaml
+++ b/clusters/ocp/values.yaml
@@ -359,6 +359,16 @@ applications:
     source:
       path: applications/forgejo
 
+    # The DB was disaster-recovered 2026-07-03; the live CNPG Cluster keeps its
+    # recovery-baked, CNPG-defaulted bootstrap (immutable, set once at creation)
+    # while git holds the steady-state initdb for a clean recreate. Ignore that
+    # drift so the app stays Synced.
+    ignoreDifferences:
+      - group: postgresql.cnpg.io
+        kind: Cluster
+        jsonPointers:
+          - /spec/bootstrap
+          - /spec/externalClusters
   gitea-mirror:
     project: cluster-apps
     annotations:
@@ -374,6 +384,16 @@ applications:
     source:
       path: components/quay-operator
 
+    # The DB was disaster-recovered 2026-07-03; the live CNPG Cluster keeps its
+    # recovery-baked, CNPG-defaulted bootstrap (immutable, set once at creation)
+    # while git holds the steady-state initdb for a clean recreate. Ignore that
+    # drift so the app stays Synced.
+    ignoreDifferences:
+      - group: postgresql.cnpg.io
+        kind: Cluster
+        jsonPointers:
+          - /spec/bootstrap
+          - /spec/externalClusters
   rhdh:
     annotations:
       argocd.argoproj.io/compare-options: IgnoreExtraneous
@@ -381,6 +401,16 @@ applications:
     source:
       path: components/rhdh
 
+    # The DB was disaster-recovered 2026-07-03; the live CNPG Cluster keeps its
+    # recovery-baked, CNPG-defaulted bootstrap (immutable, set once at creation)
+    # while git holds the steady-state initdb for a clean recreate. Ignore that
+    # drift so the app stays Synced.
+    ignoreDifferences:
+      - group: postgresql.cnpg.io
+        kind: Cluster
+        jsonPointers:
+          - /spec/bootstrap
+          - /spec/externalClusters
   alertmanager-config:
     annotations:
       argocd.argoproj.io/compare-options: IgnoreExtraneous

--- a/components/quay-operator/quay-pg-cluster.yaml
+++ b/components/quay-operator/quay-pg-cluster.yaml
@@ -20,29 +20,21 @@ spec:
     nodeSelector:
       node-role.kubernetes.io/control-plane: ""
     podAntiAffinityType: preferred # CNPG default; declared to avoid ArgoCD drift
-  # 2026-07-03 disaster recovery: bootstrap by restoring the quay database from
-  # the Barman Cloud backup on RustFS (the cluster's own history), rather than
-  # initdb. CNPG opens a new timeline so continued WAL archiving to the same
-  # serverName does not collide with the restored backup. Revert to the initdb
-  # block (kept below, commented) once the DB is recovered and verified.
-  #   bootstrap:
-  #     initdb:
-  #       database: quay
-  #       owner: quay
-  #       secret:
-  #         name: quay-pg-credentials
-  #       postInitApplicationSQL:
-  #         - CREATE EXTENSION IF NOT EXISTS pg_trgm
+  # 2026-07-03: the database was disaster-recovered from Barman (bootstrap.recovery
+  # + a temporary externalClusters). Now that it is restored and verified, this is
+  # reverted to the steady-state initdb so a future Cluster *recreate* re-inits a
+  # fresh DB instead of silently rolling back to the pre-disaster snapshot. The
+  # live cluster keeps its recovery-baked, CNPG-defaulted bootstrap (bootstrap is
+  # set once at creation and is immutable) — the app ignoreDifferences on
+  # /spec/bootstrap + /spec/externalClusters suppresses that drift.
   bootstrap:
-    recovery:
-      source: quay-pg
-  externalClusters:
-    - name: quay-pg
-      plugin:
-        name: barman-cloud.cloudnative-pg.io
-        parameters:
-          barmanObjectName: quay-pg-backup
-          serverName: quay-pg
+    initdb:
+      database: quay
+      owner: quay
+      secret:
+        name: quay-pg-credentials
+      postInitApplicationSQL:
+        - CREATE EXTENSION IF NOT EXISTS pg_trgm
   # The clair role lives on the same cluster but owns its own database (managed
   # via the Database CR in clair-database.yaml). CNPG keeps the role's password
   # in sync with the password key of quay-clair-pg-credentials.

--- a/components/rhdh/rhdh-pg-cluster.yaml
+++ b/components/rhdh/rhdh-pg-cluster.yaml
@@ -20,25 +20,19 @@ spec:
     nodeSelector:
       node-role.kubernetes.io/control-plane: ""
     podAntiAffinityType: preferred # CNPG default; declared to avoid ArgoCD drift
-  # 2026-07-03 disaster recovery: restore the backstage database from the Barman
-  # Cloud backup on RustFS (latest base 2026-07-02) instead of initdb. Revert to
-  # the initdb block below once recovered and verified.
-  #   bootstrap:
-  #     initdb:
-  #       database: backstage
-  #       owner: backstage
-  #       secret:
-  #         name: rhdh-postgres-credentials
+  # 2026-07-03: the backstage database was disaster-recovered from Barman
+  # (bootstrap.recovery + a temporary externalClusters). Now restored and
+  # verified, this is reverted to steady-state initdb so a future Cluster
+  # recreate re-inits fresh rather than silently rolling back to the pre-disaster
+  # snapshot. The live cluster keeps its recovery-baked bootstrap (immutable) —
+  # the app ignoreDifferences on /spec/bootstrap + /spec/externalClusters
+  # suppresses that drift.
   bootstrap:
-    recovery:
-      source: rhdh-pg
-  externalClusters:
-    - name: rhdh-pg
-      plugin:
-        name: barman-cloud.cloudnative-pg.io
-        parameters:
-          barmanObjectName: rhdh-pg-backup
-          serverName: rhdh-pg
+    initdb:
+      database: backstage
+      owner: backstage
+      secret:
+        name: rhdh-postgres-credentials
   storage:
     size: 10Gi
     storageClass: freenas-nvmeof-ssd-csi


### PR DESCRIPTION
The quay/rhdh/forgejo databases were disaster-recovered from Barman on 2026-07-03. Now that they're restored + verified, this reverts git to steady-state `initdb` (so a future Cluster recreate re-inits fresh rather than silently rolling back to the pre-disaster snapshot — the trap the DR post-mortem flagged) and adds `ignoreDifferences` on the immutable `/spec/bootstrap` + `/spec/externalClusters` so the apps return to Synced. Resolves the 3 OutOfSync apps.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01D96MwumLzMACaBTHNTRoov