### PR TITLE
feat(hermes): MetalLB LoadBalancer for SSH access from VLAN9

### DIFF
--- a/applications/hermes-agent/hermes-deny-ingress-networkpolicy.yaml
+++ b/applications/hermes-agent/hermes-deny-ingress-networkpolicy.yaml
@@ -8,12 +8,22 @@ spec:
   policyTypes:
     - Ingress
   ingress:
-    # SSH from the AAP namespace only, so Ansible can converge the guest over
-    # the masquerade pod IP. All other inbound is still denied.
+    # SSH from the AAP namespace, so Ansible can converge the guest over the
+    # masquerade pod IP. All other inbound is still denied.
     - from:
         - namespaceSelector:
             matchLabels:
               kubernetes.io/metadata.name: ansible-automation-platform
+      ports:
+        - protocol: TCP
+          port: 22
+    # SSH from VLAN9 (the trusted server LAN) so operators can reach the guest
+    # over the hermes-ssh MetalLB LoadBalancer (10.10.150.1). The LB service
+    # uses externalTrafficPolicy: Local, so OVN sees the real VLAN9 client
+    # source IP and this ipBlock matches. Key-only auth; password login is off.
+    - from:
+        - ipBlock:
+            cidr: 10.10.9.0/24
       ports:
         - protocol: TCP
           port: 22

--- a/applications/hermes-agent/hermes-ssh-service.yaml
+++ b/applications/hermes-agent/hermes-ssh-service.yaml
@@ -1,0 +1,29 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: hermes-ssh
+  namespace: hermes
+  annotations:
+    argocd.argoproj.io/sync-wave: '5'
+    # Pin to the historical hermes management IP (inventory ansible_host for
+    # hermes-hermes). MetalLB advertises the trusted-lan pool (10.10.150.0/24)
+    # into the fabric over BGP, so this address is reachable from VLAN9 clients
+    # via the rb5009. autoAssign is off on that pool, so the pool must be named
+    # explicitly.
+    metallb.universe.tf/address-pool: trusted-lan
+    metallb.universe.tf/loadBalancerIPs: 10.10.150.1
+spec:
+  type: LoadBalancer
+  # Local preserves the client source IP (needed for the deny-ingress
+  # NetworkPolicy's VLAN9 ipBlock match) and keeps traffic on the node running
+  # the hermes virt-launcher pod — no extra hop, no asymmetric-return stall.
+  externalTrafficPolicy: Local
+  # Select the hermes VM's virt-launcher pod. KubeVirt masquerade forwards the
+  # pod's :22 to the guest's sshd.
+  selector:
+    vm.kubevirt.io/name: hermes
+  ports:
+    - name: ssh
+      protocol: TCP
+      port: 22
+      targetPort: 22

--- a/applications/hermes-agent/kustomization.yaml
+++ b/applications/hermes-agent/kustomization.yaml
@@ -7,4 +7,5 @@ resources:
   - default-egressfirewall.yaml
   - hermes-deny-ingress-networkpolicy.yaml
   - hermes-egress-networkpolicy.yaml
+  - hermes-ssh-service.yaml
   - hermes-vm-hardening-validatingadmissionpolicy.yaml


### PR DESCRIPTION
Exposes the hermes VM's sshd on a stable MetalLB address (10.10.150.1, the inventory ansible_host) from the trusted-lan pool (BGP-advertised, reachable from VLAN9). Replaces the ad-hoc `virtctl port-forward` with a durable endpoint for operators and a persistent on-VM Claude session (running as the unprivileged hermes user).

- `hermes-ssh` Service: LoadBalancer, externalTrafficPolicy Local, selector `vm.kubevirt.io/name=hermes`, :22.
- `deny-ingress` NetworkPolicy: add `ipBlock 10.10.9.0/24` for :22 (Local ETP preserves the VLAN9 source IP). Key-only auth; all other inbound still denied.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01D96MwumLzMACaBTHNTRoov