### PR TITLE
feat(hermes): expose dashboard via edge Route

### DIFF
--- a/applications/hermes-agent/hermes-allow-dashboard-ingress-networkpolicy.yaml
+++ b/applications/hermes-agent/hermes-allow-dashboard-ingress-networkpolicy.yaml
@@ -1,0 +1,22 @@
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: hermes-allow-dashboard-ingress
+  namespace: hermes
+spec:
+  # hermes-deny-ingress denies all inbound except SSH:22 from AAP. The dashboard
+  # Route/Service are useless without a matching allow: the OpenShift router
+  # pods live in openshift-ingress, so permit that namespace to reach :9119.
+  # Everything else stays denied; the dashboard's own scrypt BasicAuth is the
+  # actual access gate.
+  podSelector: {}
+  policyTypes:
+    - Ingress
+  ingress:
+    - from:
+        - namespaceSelector:
+            matchLabels:
+              policy-group.network.openshift.io/ingress: ""
+      ports:
+        - protocol: TCP
+          port: 9119

--- a/applications/hermes-agent/hermes-dashboard-route.yaml
+++ b/applications/hermes-agent/hermes-dashboard-route.yaml
@@ -1,0 +1,23 @@
+apiVersion: route.openshift.io/v1
+kind: Route
+metadata:
+  name: hermes-dashboard
+  namespace: hermes
+  labels:
+    app: hermes
+spec:
+  host: hermes-dashboard.apps.ocp.igou.systems
+  to:
+    kind: Service
+    name: hermes-dashboard
+    weight: 100
+  port:
+    targetPort: dashboard
+  # Edge termination: the router terminates TLS (default wildcard cert for
+  # *.apps.ocp.igou.systems) and forwards plaintext HTTP to the dashboard on
+  # :9119. The dashboard enforces its own scrypt BasicAuth gate on top; the
+  # Route adds no auth of its own. Redirect any plaintext hit to HTTPS.
+  tls:
+    termination: edge
+    insecureEdgeTerminationPolicy: Redirect
+  wildcardPolicy: None

--- a/applications/hermes-agent/hermes-dashboard-service.yaml
+++ b/applications/hermes-agent/hermes-dashboard-service.yaml
@@ -1,0 +1,19 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: hermes-dashboard
+  namespace: hermes
+  labels:
+    app: hermes
+spec:
+  type: ClusterIP
+  # Select the VM's virt-launcher pod (masquerade forwards all ports to the
+  # guest, so :9119 reaches hermes-dashboard.service inside the VM), the same
+  # selector the hermes-ssh LoadBalancer uses for :22.
+  selector:
+    vm.kubevirt.io/name: hermes
+  ports:
+    - name: dashboard
+      protocol: TCP
+      port: 9119
+      targetPort: 9119

--- a/applications/hermes-agent/kustomization.yaml
+++ b/applications/hermes-agent/kustomization.yaml
@@ -6,6 +6,9 @@ resources:
   - hermes-state-datavolume.yaml
   - default-egressfirewall.yaml
   - hermes-deny-ingress-networkpolicy.yaml
+  - hermes-allow-dashboard-ingress-networkpolicy.yaml
   - hermes-egress-networkpolicy.yaml
   - hermes-ssh-service.yaml
+  - hermes-dashboard-service.yaml
+  - hermes-dashboard-route.yaml
   - hermes-vm-hardening-validatingadmissionpolicy.yaml


### PR DESCRIPTION
## What

The Hermes agent **dashboard** runs on the VM (`hermes-dashboard.service`, listening `0.0.0.0:9119`, confirmed up — returns a `302` to its login) but was **never exposed through OpenShift**. The `hermes` namespace only carries the `hermes-ssh` LoadBalancer (`:22`) and a deny-all-ingress policy, so after the cluster reinstall there is no working Route to the dashboard.

This adds the three resources required to reach it declaratively via GitOps:

| Resource | Purpose |
|---|---|
| `Service/hermes-dashboard` | ClusterIP `:9119` selecting the VM's virt-launcher pod (`vm.kubevirt.io/name=hermes`). Masquerade forwards **all** ports to the guest, so `:9119` reaches the dashboard — the same path `hermes-ssh` uses for `:22`. |
| `Route/hermes-dashboard` | `hermes-dashboard.apps.ocp.igou.systems`, **edge TLS** (default `*.apps` wildcard cert) with HTTP→HTTPS redirect. |
| `NetworkPolicy/hermes-allow-dashboard-ingress` | Permits **only** the `openshift-ingress` namespace (the router) to reach `:9119`. `hermes-deny-ingress` still denies all other inbound except SSH:22 from AAP. |

## Why a bare Route wasn't enough

A Route alone would `503`: there was no Service targeting the dashboard port, and `hermes-deny-ingress` blocks the router pods. All three pieces are needed for it to actually serve.

## Security

- The dashboard's own **scrypt BasicAuth** gate (`HERMES_DASHBOARD_BASIC_AUTH_*`) remains the access control; the Route adds no auth of its own and simply terminates TLS.
- Ingress stays default-deny; this only opens `:9119` from the router namespace.
- No VM / Ansible change required — masquerade already forwards the port.

## Validation

- `kustomize build` renders all resources.
- `oc apply --dry-run=server` succeeds for Service, Route, and NetworkPolicy.

## Note for reviewer

Exposing the dashboard was previously deferred pending operator go-live. Merging this makes the dashboard reachable at `https://hermes-dashboard.apps.ocp.igou.systems` (behind BasicAuth) once ArgoCD syncs. Hold the merge if go-live should wait.

🤖 Generated with [Claude Code](https://claude.com/claude-code)