### PR TITLE
fix(llmkube): drop pinned fsGroup so restricted-v2 SCC injects it

### DIFF
--- a/applications/llmkube/gemma-4-e2b-inferenceservice.yaml
+++ b/applications/llmkube/gemma-4-e2b-inferenceservice.yaml
@@ -25,8 +25,7 @@ spec:
   flashAttention: false
   jinja: true                 # apply the Gemma chat template
   parallelSlots: 1
-  podSecurityContext:
-    fsGroup: 1001030000       # OpenShift restricted-v2 SCC range (llmkube default 102 is rejected)
+  podSecurityContext:         # no fsGroup: the SCC injects it (pinned values break on ns recreation)
     seccompProfile:
       type: RuntimeDefault
   extraArgs:

--- a/applications/llmkube/qwen3-35b-a3b-inferenceservice.yaml
+++ b/applications/llmkube/qwen3-35b-a3b-inferenceservice.yaml
@@ -26,12 +26,12 @@ spec:
   # 378 GiB RAM; the small hybrid KV makes the PCIe penalty modest).
   flashAttention: true
   jinja: true                # Qwen3.6 chat template is jinja-only (thinking tags)
-  # llmkube 0.8.1 defaults the inference pod's fsGroup to 102, which OpenShift's
-  # restricted-v2 SCC rejects (must be within the namespace's allocated range,
-  # openshift.io/sa.scc.supplemental-groups=1001030000/10000). Pin fsGroup into
-  # that range so the model-cache PVC is group-writable and the pod can schedule.
+  # No fsGroup here: the restricted-v2 SCC injects one from the namespace's
+  # allocated range, and that range changes whenever the namespace is recreated
+  # (a pinned value broke pod admission after the 2026-07 cluster reinstall).
+  # llmkube's fsGroup default of 102 only applies when podSecurityContext is
+  # entirely unset, so keeping seccompProfile here is enough to suppress it.
   podSecurityContext:
-    fsGroup: 1001030000
     seccompProfile:
       type: RuntimeDefault
   cacheTypeK: f16

--- a/applications/llmkube/qwen35-2b-inferenceservice.yaml
+++ b/applications/llmkube/qwen35-2b-inferenceservice.yaml
@@ -31,8 +31,7 @@ spec:
   flashAttention: false
   jinja: true                 # apply the Qwen3.5 chat template (tool-calling + reasoning)
   parallelSlots: 1
-  podSecurityContext:
-    fsGroup: 1001030000       # OpenShift restricted-v2 SCC range (llmkube default 102 is rejected)
+  podSecurityContext:         # no fsGroup: the SCC injects it (pinned values break on ns recreation)
     seccompProfile:
       type: RuntimeDefault
   extraArgs:


### PR DESCRIPTION
## Problem
All three llmkube InferenceServices (`qwen3-35b-a3b`, `qwen35-2b`, `gemma-4-e2b`) have been stuck in `Creating` (0/1 replicas) since the cluster reinstall. The ReplicaSets fail pod admission:

```
pods ... is forbidden: unable to validate against any security context constraint:
provider restricted-v2: .spec.securityContext.fsGroup: Invalid value: [1001030000]:
1001030000 is not an allowed group
```

The isvc manifests pinned `fsGroup: 1001030000` — the UID range the old `llmkube-system` namespace happened to get. The rebuilt cluster allocated a new range (`openshift.io/sa.scc.uid-range: 1001140000/10000`), so the pinned value is now outside the allowed range.

## Fix
Remove the fsGroup pin entirely instead of re-pinning to the new range. restricted-v2 injects a valid fsGroup from the namespace's current allocation, so this survives any future namespace recreation. llmkube's own fsGroup-102 default (the original reason for the pin) only applies when `podSecurityContext` is fully unset — the remaining `seccompProfile` block suppresses it.

`kustomize build --enable-helm` verified: no literal fsGroup left in the rendered isvc specs.

## Validation plan
Merge → Argo sync → all three isvc schedule; `qwen3-35b-a3b` (burst-pinned) triggers casval scale-from-zero, which is being tested end-to-end in this session.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01ABCDdxkj3rbL6jF1QA5EwM