### PR TITLE
metallb: narrow iot/guest-dmz pools to ocp's half (disjoint from rk8s)

### DIFF
--- a/clusters/ocp/metallb/guest-dmz-ipaddresspool.yaml
+++ b/clusters/ocp/metallb/guest-dmz-ipaddresspool.yaml
@@ -8,6 +8,9 @@ metadata:
     argocd.argoproj.io/sync-wave: '0'
 spec:
   addresses:
-    - 10.10.152.0/24
+    # Low /25 — ocp's half of the guest-dmz tier; carries the live jellyfin
+    # (.1) and dmz gateway (.3) VIPs. rk8s (igou-kubernetes) owns
+    # 10.10.152.128/25. rb5009's metallb-in filter enforces the split.
+    - 10.10.152.1-10.10.152.127
   autoAssign: false
   avoidBuggyIPs: true

--- a/clusters/ocp/metallb/iot-ipaddresspool.yaml
+++ b/clusters/ocp/metallb/iot-ipaddresspool.yaml
@@ -8,6 +8,8 @@ metadata:
     argocd.argoproj.io/sync-wave: '0'
 spec:
   addresses:
-    - 10.10.151.0/24
+    # Low /25 — ocp's half of the iot tier. rk8s (igou-kubernetes) owns
+    # 10.10.151.128/25. rb5009's metallb-in filter enforces the split.
+    - 10.10.151.1-10.10.151.127
   autoAssign: false
   avoidBuggyIPs: true

--- a/clusters/ocp/metallb/trusted-lan-ipaddresspool.yaml
+++ b/clusters/ocp/metallb/trusted-lan-ipaddresspool.yaml
@@ -8,6 +8,9 @@ metadata:
     argocd.argoproj.io/sync-wave: '0'
 spec:
   addresses:
-    - 10.10.150.0/24
+    # Low /25 — ocp's half of the trusted-lan tier; carries the live hermes
+    # VIP (.1). rk8s (igou-kubernetes) owns 10.10.150.128/25 and its gateway
+    # VIP is 10.10.150.129. rb5009's metallb-in filter enforces the split.
+    - 10.10.150.1-10.10.150.127
   autoAssign: false
   avoidBuggyIPs: true


### PR DESCRIPTION
Narrows all three ocp MetalLB pools to their low /25 half (keeps live hermes .150.1, jellyfin .152.1, dmz-gw .152.3).
## Why
rb5009 runs one MetalLB BGP fabric shared by **both** clusters: rk8s boards and ocp nodes all peer as AS 64513, and both repos' pools claim the same three /24s (`10.10.150/151/152.0/24`). The router cannot tell the clusters apart, so nothing stops them from handing out or announcing the **same** address. Live audit (rb5009 route table) showed the overlap already booked on **10.10.150.1** — ocp advertises it (a hermes LB) while rk8s had reserved it as its gateway VIP.

## The split — uniform ocp-low
Every tier splits at the /25 boundary with one rule: **ocp owns the low /25, rk8s owns the high /25.** All live ocp services sit in the low half, so rk8s took the high half and **moved its gateway VIP off the contested `.150.1` to `.150.129`** — which dissolves the collision outright, with no dependency on the hermes migration.

| Tier | ocp (low) | rk8s (high) | live ocp svc |
|---|---|---|---|
| trusted-lan .150 | `.1-.127` | `.129-.254` (`.129` gateway) | .1 hermes |
| iot .151 | `.1-.127` | `.129-.254` | none |
| guest-dmz .152 | `.1-.127` | `.129-.254` | .1 jellyfin, .3 dmz-gw |

## Coordination — merge together, in order
1. **igou-inventory** `chore/rb5009-metallb-tier-filter` → apply via `routeros_configure_check` first; verify board sessions bind to the `metallb-rk8s` /29 listener; it also re-points `*.rk8s` DNS to `.150.129`.
2. **igou-kubernetes** + **igou-openshift** pool splits (Argo auto-sync; all live IPs stay in-pool → non-disruptive).

No remaining operator-gated blocker: hermes stays on `.150.1` (now cleanly inside ocp's low /25), and the rk8s Gateway can be created on `.150.129` whenever.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JsKPv4Gq1Ftbc3rsBAvbvv