### PR TITLE
docs(cluster-api): rerun bootstrap after reinstall; derive CLUSTER_NAME from ConfigMap

### DIFF
--- a/clusters/ocp/cluster-api/README.md
+++ b/clusters/ocp/cluster-api/README.md
@@ -8,7 +8,7 @@ the CronJob workarounds).
 
 ## Cluster-name config
 
-`cluster-config-configmap.yaml` carries `clusterName`, which must equal
+`cluster-config-configmap.yaml` carries `clusterName`, which should equal
 `infrastructure.status.infrastructureName`. On reprovision, update that
 ConfigMap and commit — kustomize `replacements` propagate the value into
 the Cluster, Metal3Cluster, and MachineSet fields that must match it.
@@ -17,11 +17,32 @@ the Cluster, Metal3Cluster, and MachineSet fields that must match it.
 oc get infrastructure cluster -o jsonpath='{.status.infrastructureName}'
 ```
 
-## Manual bootstrap (one-time per cluster)
+Note: `MachineSet.spec.clusterName` is immutable, so changing the
+ConfigMap value requires deleting the `casval-worker` MachineSet (do it
+while casval is scaled to zero) and letting ArgoCD recreate it. The CAPI
+stack is internally consistent as long as everything uses the ConfigMap
+value — a drift from the live `infrastructureName` (e.g. after a cluster
+reinstall) is cosmetic and does not block provisioning, but rename at the
+next opportunity to keep names meaningful.
+
+## Manual bootstrap (one-time per cluster — RERUN AFTER EVERY REINSTALL)
 
 These steps are not yet automated in GitOps; they will eventually move to
 the GitOps bootstrap Ansible. Perform them once after the
 `cluster-api-operator` and `cluster-api` ArgoCD applications go healthy.
+
+**A cluster reinstall silently loses all of them** (they live only in the
+recreated namespaces). Symptoms of a missed re-run, seen 2026-07-05:
+
+- BMH stuck in `provisioning` with `poweredOn: false`; baremetal-operator
+  logs `could not retrieve user data: ... secrets "worker-user-data-managed"
+  not found` → step 1 missing.
+- capm3/capi logs loop on `error getting kubeconfig secret: Secret
+  "<clusterName>-kubeconfig" not found`; Machine never gets a nodeRef →
+  step 2 missing.
+- After fixing, the baremetal-operator can sit in reconcile backoff for
+  minutes; touch an annotation on the BMH to trigger an immediate retry
+  (`oc annotate bmh casval -n openshift-cluster-api nudge=1 --overwrite`).
 
 ### 1. Copy `worker-user-data-managed` secret
 
@@ -42,8 +63,14 @@ here) via the `<cluster-name>-kubeconfig` Secret. The Secret must carry the
 Additionally, `ControlPlaneInitialized=True` must be patched onto the
 Cluster status since there are no CAPI-managed control-plane Machines.
 
+`CLUSTER_NAME` here MUST be the CAPI Cluster object's name — i.e. the
+`clusterName` in `cluster-config-configmap.yaml` — NOT the live
+`infrastructure.status.infrastructureName`. The two match only while the
+ConfigMap is kept in sync; after a reinstall they drift, and deriving the
+secret name from the infra name mints a secret CAPI never reads.
+
 ```bash
-CLUSTER_NAME=$(oc get infrastructure cluster -o jsonpath='{.status.infrastructureName}')
+CLUSTER_NAME=$(oc get cm cluster-api-cluster-config -n openshift-cluster-api -o jsonpath='{.data.clusterName}')
 API_SERVER=$(oc whoami --show-server)
 CA_DATA=$(oc get configmap kube-root-ca.crt -n openshift-cluster-api -o jsonpath='{.data.ca\.crt}' | base64 -w0)
 TOKEN=$(oc create token default -n openshift-cluster-api --duration=8760h)


### PR DESCRIPTION
Documents what the 2026-07-05 casval scale-from-zero test uncovered on the rebuilt cluster:

- The three manual bootstrap steps (user-data secret copy, workload kubeconfig secret, `ControlPlaneInitialized` patch) are lost on cluster reinstall and must be rerun — added the failure signatures observed for each so the next person can diagnose from logs.
- **Bug in the step-2 script**: `CLUSTER_NAME` was derived from live `infrastructure.status.infrastructureName`, but the kubeconfig Secret must match the CAPI **Cluster object name** (the ConfigMap value). Post-reinstall these drift (`ocp-hb42r` in git vs live `ocp-m97rd`), so the verbatim script mints a secret CAPI never reads. Now derived from `cluster-api-cluster-config`.
- Documented that the name drift is cosmetic (CAPI is self-consistent on the ConfigMap value) and that a rename requires deleting the MachineSet (`spec.clusterName` immutable) while casval is at zero.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01ABCDdxkj3rbL6jF1QA5EwM