### PR TITLE
fix(democratic-csi): unique NVMe host NQN per node

### DIFF
--- a/components/democratic-csi/kustomization.yaml
+++ b/components/democratic-csi/kustomization.yaml
@@ -12,6 +12,13 @@ resources:
   - allow-privileged-to-democratic-csi-nvmeof-fast-config-node-sa-clusterrolebinding.yaml
   - allow-privileged-to-democratic-csi-nvmeof-ssd-config-node-sa-clusterrolebinding.yaml
   - allow-privileged-to-democratic-csi-nvmeof-cold-config-node-sa-clusterrolebinding.yaml
+# Give each node a unique, stable NVMe host NQN (igou-io/igou-openshift#404).
+# Targets only the three NVMe-oF node DaemonSets by name regex.
+patches:
+  - path: patches/nvmeof-unique-hostnqn.yaml
+    target:
+      kind: DaemonSet
+      name: democratic-csi-nvmeof-.*-config-node
 helmCharts:
 # ---- iSCSI - fast pool ----
 - name: democratic-csi

--- a/components/democratic-csi/patches/nvmeof-unique-hostnqn.yaml
+++ b/components/democratic-csi/patches/nvmeof-unique-hostnqn.yaml
@@ -9,13 +9,28 @@
 # isolation at the fabric layer (reservation/ANA ambiguity; data-integrity risk
 # if two nodes ever attach the same namespace).
 #
+# UPSTREAM: this is tracked as democratic-csi/democratic-csi#451 (open). The
+# baked value is literally in the image Dockerfile (echo 'nqn...941e4f03...' >
+# /etc/nvme/hostnqn), on both `next` and `master`. The maintainer added a
+# generate-if-missing step (`if (!fs.existsSync) nvme gen-hostnqn`) but it is
+# dead code while the Dockerfile keeps baking the file, so even the latest
+# `next` image ships duplicate NQNs by default. There is no chart release past
+# 0.15.1 and no config/driver option to set the hostnqn per node (democratic-csi
+# calls `nvme connect` without --hostnqn, so /etc/nvme/hostnqn is authoritative).
+# Native alternatives are strictly worse here: nvmeDirMountEnabled: true only
+# surfaces the HOST /etc/nvme, which on RHCOS is ALSO a shared duplicate (Red Hat
+# KB 7073579), so it would still need a per-node MachineConfig + reboots.
+# REMOVE THIS PATCH only once #451's Dockerfile stops baking hostnqn/hostid AND a
+# persistent per-node mount lands upstream.
+#
 # Fix: an initContainer derives a deterministic host NQN from the node's
 # /etc/machine-id (unique per node, stable across reboots — NOT random, so the
 # NQN is stable so reconnects and any future TrueNAS host ACL keep matching) and
 # writes hostnqn + hostid into an emptyDir mounted over /etc/nvme in the
-# csi-driver container. discovery.conf is intentionally not recreated: the
-# freenas-api-nvmeof driver connects to explicit transports from its config and
-# does not use nvme discovery.
+# csi-driver container. This is deliberately deterministic, unlike upstream's
+# random-on-first-start which would remint the NQN on every pod reschedule.
+# discovery.conf is intentionally not recreated: the freenas-api-nvmeof driver
+# connects to explicit transports from its config and does not use nvme discovery.
 #
 # Applied to the three NVMe-oF node DaemonSets (ssd/fast/cold) via a targeted
 # kustomize patch because the chart's node template has no initContainers hook.

--- a/components/democratic-csi/patches/nvmeof-unique-hostnqn.yaml
+++ b/components/democratic-csi/patches/nvmeof-unique-hostnqn.yaml
@@ -1,0 +1,76 @@
+# Give each node a UNIQUE, STABLE NVMe host NQN/host ID for the democratic-csi
+# NVMe-oF node plugins. See igou-io/igou-openshift#404.
+#
+# Problem: the democratic-csi container image ships a static /etc/nvme/hostnqn
+# (uuid:941e4f03-...). Because the DaemonSet runs the same image on every node
+# and we do not mount the host's /etc/nvme (node.driver.nvmeDirMountEnabled is
+# false by default), every node connects to TrueNAS presenting the SAME host
+# NQN — so all nodes look like one NVMe initiator and there is no per-host
+# isolation at the fabric layer (reservation/ANA ambiguity; data-integrity risk
+# if two nodes ever attach the same namespace).
+#
+# Fix: an initContainer derives a deterministic host NQN from the node's
+# /etc/machine-id (unique per node, stable across reboots — NOT random, so the
+# NQN is stable so reconnects and any future TrueNAS host ACL keep matching) and
+# writes hostnqn + hostid into an emptyDir mounted over /etc/nvme in the
+# csi-driver container. discovery.conf is intentionally not recreated: the
+# freenas-api-nvmeof driver connects to explicit transports from its config and
+# does not use nvme discovery.
+#
+# Applied to the three NVMe-oF node DaemonSets (ssd/fast/cold) via a targeted
+# kustomize patch because the chart's node template has no initContainers hook.
+apiVersion: apps/v1
+kind: DaemonSet
+metadata:
+  name: nvmeof-node  # overridden by the patch target selector in kustomization.yaml
+spec:
+  template:
+    spec:
+      initContainers:
+        - name: unique-hostnqn
+          # Same image the node plugin already runs (guaranteed present on every
+          # node, ships /bin/sh + coreutils) so this adds no extra image pull.
+          # renovate: datasource=docker depName=ghcr.io/democratic-csi/democratic-csi
+          image: ghcr.io/democratic-csi/democratic-csi:next@sha256:0f308ae601474cb9633f90dc96f59dbd23440b0ed0e77d70e224465246a12dfa
+          command:
+            - /bin/sh
+            - -c
+            - |
+              set -eu
+              # /etc/machine-id is 32 hex chars = a 128-bit id, unique per node
+              # and stable across reboots. Format it into UUID shape and use it
+              # as the NVMe host identity (deterministic => stable NQN).
+              mid=$(tr -d '\n' < /host-machine-id)
+              if [ "${#mid}" -ne 32 ]; then
+                echo "machine-id is not 32 hex chars ('${mid}'); refusing to generate hostnqn" >&2
+                exit 1
+              fi
+              uuid=$(printf '%s-%s-%s-%s-%s' \
+                "$(printf '%s' "$mid" | cut -c1-8)" \
+                "$(printf '%s' "$mid" | cut -c9-12)" \
+                "$(printf '%s' "$mid" | cut -c13-16)" \
+                "$(printf '%s' "$mid" | cut -c17-20)" \
+                "$(printf '%s' "$mid" | cut -c21-32)")
+              printf 'nqn.2014-08.org.nvmexpress:uuid:%s\n' "$uuid" > /etc/nvme/hostnqn
+              printf '%s\n' "$uuid" > /etc/nvme/hostid
+              echo "wrote unique NVMe host identity: nqn.2014-08.org.nvmexpress:uuid:${uuid}"
+          securityContext:
+            privileged: true
+          volumeMounts:
+            - name: host-machine-id
+              mountPath: /host-machine-id
+              readOnly: true
+            - name: nvme-dir
+              mountPath: /etc/nvme
+      containers:
+        - name: csi-driver
+          volumeMounts:
+            - name: nvme-dir
+              mountPath: /etc/nvme
+      volumes:
+        - name: nvme-dir
+          emptyDir: {}
+        - name: host-machine-id
+          hostPath:
+            path: /etc/machine-id
+            type: File


### PR DESCRIPTION
Closes #404.

## Problem
All democratic-csi NVMe-oF node plugins connect to TrueNAS with the **same** host NQN `uuid:941e4f03-...`, baked into the democratic-csi container image. The DaemonSet runs one image on every node and we don't mount the host's `/etc/nvme` (`node.driver.nvmeDirMountEnabled` defaults false), so every node presents to TrueNAS as the *same* NVMe initiator — no per-host isolation at the fabric layer, and a data-integrity risk if two nodes ever attach the same namespace. Confirmed identical on ocp/hpg5/p330.

## Fix
The chart's node template has no `initContainers` hook, so this is a targeted kustomize `patches` entry (`patches/nvmeof-unique-hostnqn.yaml`) applied by name regex to the three NVMe-oF node DaemonSets (ssd/fast/cold):

- An **initContainer** derives a deterministic host NQN + host ID from the node's `/etc/machine-id` (32 hex = a 128-bit id, **unique per node and stable across reboots**), formats it into UUID shape, and writes `hostnqn`/`hostid` into an `emptyDir` mounted over `/etc/nvme` in the `csi-driver` container.
- Deterministic (not `nvme gen-hostnqn` random) so the NQN is **stable** — reconnects and any future TrueNAS host ACL keep matching.
- Reuses the node-plugin image (already present on every node; no extra pull) just for `sh`+coreutils.

## Validation
- `kustomize build --enable-helm` renders the initContainer + emptyDir + csi-driver mount on **exactly** the 3 nvmeof node DaemonSets; the other 6 (iscsi/nfs) are untouched.
- yamllint clean.
- UUID derivation verified against real machine-ids: valid UUID shape, unique per node (ocp `ce8235e7-...`, hpg5 `de69ca75-...`).

## Rollout notes
- Applying restarts the 3 nvmeof node DaemonSets. Already-attached volumes keep their existing (old-NQN) kernel connections (`ctrl-loss-tmo=-1`); new attaches and post-reboot reconnects use the unique NQN, so it converges as volumes cycle / nodes drain. `nvme disconnect` on teardown is unaffected (keyed on device/subsystem, not host NQN).
- `discovery.conf` is intentionally not recreated in the emptyDir — the `freenas-api-nvmeof` driver connects to explicit transports from its config and doesn't use nvme discovery.

## Follow-ups (not in this PR)
- iSCSI initiator-name (`/etc/iscsi/initiatorname.iscsi`) duplication was not conclusively verified (host file absent); tracked as the #404 iSCSI check.
- Host `/etc/nvme/hostnqn` duplication (serves only each node's local boot disk) remains as low-priority cosmetic cleanup.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01ABCDdxkj3rbL6jF1QA5EwM