### PR TITLE
fix(openshift-virt): default VM evictionStrategy to None (no live migration)

### DIFF
--- a/components/openshift-virt/kubevirt-hyperconverged.yml
+++ b/components/openshift-virt/kubevirt-hyperconverged.yml
@@ -7,6 +7,15 @@ metadata:
     argocd.argoproj.io/sync-wave: "3"
     argocd.argoproj.io/sync-options: SkipDryRunOnMissingResource=true
 spec:
+  # This cluster does NOT support live migration by design: we run RWO block
+  # storage only (no RWX block), so VM disks can't be shared across nodes and
+  # VMs are never migratable. A short outage to power-cycle a VM during node
+  # maintenance is acceptable here. Default every VM's eviction strategy to
+  # None so a node drain cleanly shuts the VM down instead of attempting a
+  # migration that can't succeed — which is what raises the (noise)
+  # VMCannotBeEvicted alert under the KubeVirt default of LiveMigrate.
+  # See igou-io/igou-openshift#405.
+  evictionStrategy: None
   featureGates:
     deployTektonTaskResources: true
     enableCommonBootImageImport: true


### PR DESCRIPTION
Closes #405.

## Problem
`VMCannotBeEvicted` is firing continuously for the `hermes` VM: its eviction strategy resolves to `LiveMigrate` but the VM is `LiveMigratable=False`, so a node drain can neither migrate nor evict it.

Per the design of this cluster, that's the wrong default: **we never live-migrate** — RWO block storage only (no RWX block), so VM disks can't be shared across nodes and VMs are never migratable. A short outage to power-cycle a VM during node maintenance is acceptable.

## Fix
Set `HyperConverged.spec.evictionStrategy: None` (was unset → inheriting KubeVirt's `LiveMigrate` default). With `None`, a node drain **cleanly powers the VM off** instead of attempting an impossible migration.

Confirmed the hermes VM sets **no per-VM eviction strategy** — it inherits the HCO default (`VMI.spec.evictionStrategy=LiveMigrate` today comes purely from inheritance). So this one cluster-wide change fixes hermes and every future VM, and `VMCannotBeEvicted` stops matching at the root — no Alertmanager silence/inhibit needed. An explanatory comment documents the no-live-migration stance inline so reviewers don't reintroduce `LiveMigrate`.

## Validation
- `oc explain hyperconverged.spec.evictionStrategy` → enum includes `None` (CNV 4.21).
- `kustomize build` renders `evictionStrategy: None`; yamllint clean.

## Rollout note
Applying updates the HCO CR; existing running VMs keep running. The changed default takes effect on the next drain/eviction (VM powers off instead of alerting). Optional: to clear the currently-firing alert immediately without waiting for a drain, no action is required once the resolved strategy is `None`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01ABCDdxkj3rbL6jF1QA5EwM