### PR TITLE
feat(secrets): per-vault ClusterSecretStores + repoint ESO to lab_* vaults (Phase 1)

### DIFF
--- a/.helm/charts/ocp-base-config/templates/auth/external-secret.yaml
+++ b/.helm/charts/ocp-base-config/templates/auth/external-secret.yaml
@@ -12,7 +12,7 @@ spec:
   refreshInterval: 24h
   secretStoreRef:
     kind: ClusterSecretStore
-    name: onepassword-sdk-ocp-pull
+    name: onepassword-lab-openshift
   target:
     name: {{ .Values.auth.externalSecret.name }}
     creationPolicy: Owner

--- a/.helm/charts/pac-tenant/test-values.yaml
+++ b/.helm/charts/pac-tenant/test-values.yaml
@@ -5,7 +5,7 @@
 # GCP SM, Azure KV).
 secretStore:
   kind: ClusterSecretStore
-  name: onepassword-sdk-ocp-pull
+  name: onepassword-ocp-pull
 
 tenants:
   - name: simple-tenant

--- a/applications/forgejo/cnpg-s3-credentials-externalsecret.yaml
+++ b/applications/forgejo/cnpg-s3-credentials-externalsecret.yaml
@@ -20,7 +20,7 @@ spec:
   refreshInterval: 24h
   secretStoreRef:
     kind: ClusterSecretStore
-    name: onepassword-sdk-ocp-pull
+    name: onepassword-lab-s3
   target:
     name: cnpg-s3-credentials
     creationPolicy: Owner

--- a/applications/forgejo/forgejo-secrets-externalsecret.yaml
+++ b/applications/forgejo/forgejo-secrets-externalsecret.yaml
@@ -8,7 +8,7 @@ spec:
   refreshInterval: 24h
   secretStoreRef:
     kind: ClusterSecretStore
-    name: onepassword-sdk-ocp-pull
+    name: onepassword-lab-forgejo
   target:
     name: forgejo-secrets
     creationPolicy: Owner

--- a/applications/gitea-mirror/gitea-mirror-secrets-externalsecret.yaml
+++ b/applications/gitea-mirror/gitea-mirror-secrets-externalsecret.yaml
@@ -8,7 +8,7 @@ spec:
   refreshInterval: 24h
   secretStoreRef:
     kind: ClusterSecretStore
-    name: onepassword-sdk-ocp-pull
+    name: onepassword-lab-github
   target:
     name: gitea-mirror-secrets
     creationPolicy: Owner

--- a/applications/gitea/gitea-admin-secret-externalsecret.yaml
+++ b/applications/gitea/gitea-admin-secret-externalsecret.yaml
@@ -11,7 +11,7 @@ spec:
   refreshInterval: 24h
   secretStoreRef:
     kind: ClusterSecretStore
-    name: onepassword-sdk-ocp-pull
+    name: onepassword-ocp-pull
   target:
     name: gitea-admin-secret
     creationPolicy: Owner

--- a/applications/gotify/gotify-bridge-token-externalsecret.yaml
+++ b/applications/gotify/gotify-bridge-token-externalsecret.yaml
@@ -15,7 +15,7 @@ spec:
         nullBytePolicy: Ignore
   secretStoreRef:
     kind: ClusterSecretStore
-    name: onepassword-sdk-ocp-pull
+    name: onepassword-lab-openshift
   target:
     creationPolicy: Owner
     deletionPolicy: Retain

--- a/applications/minecraft-server/minecraft-secrets-externalsecret.yml
+++ b/applications/minecraft-server/minecraft-secrets-externalsecret.yml
@@ -1,4 +1,4 @@
-apiVersion: external-secrets.io/v
+apiVersion: external-secrets.io/v1
 kind: ExternalSecret
 metadata:
   name: minecraft-secrets
@@ -12,7 +12,7 @@ spec:
   refreshInterval: 24h
   secretStoreRef:
     kind: ClusterSecretStore
-    name: onepassword-sdk-ocp
+    name: onepassword-lab-openshift
   target:
     creationPolicy: Owner
     deletionPolicy: Retain

--- a/applications/n8n/n8n-secrets-externalsecret.yaml
+++ b/applications/n8n/n8n-secrets-externalsecret.yaml
@@ -14,7 +14,7 @@ spec:
       nullBytePolicy: Ignore
   secretStoreRef:
     kind: ClusterSecretStore
-    name: onepassword-sdk-ocp-pull
+    name: onepassword-ocp-pull
   target:
     creationPolicy: Owner
     deletionPolicy: Retain

--- a/applications/searxng/searxng-secrets-externalsecret.yaml
+++ b/applications/searxng/searxng-secrets-externalsecret.yaml
@@ -8,7 +8,7 @@ spec:
   refreshInterval: 24h
   secretStoreRef:
     kind: ClusterSecretStore
-    name: onepassword-sdk-ocp-pull
+    name: onepassword-lab-openshift
   target:
     name: searxng-secrets
     creationPolicy: Owner

--- a/applications/temporalio/cnpg-s3-credentials-externalsecret.yaml
+++ b/applications/temporalio/cnpg-s3-credentials-externalsecret.yaml
@@ -14,7 +14,7 @@ spec:
   refreshInterval: 24h
   secretStoreRef:
     kind: ClusterSecretStore
-    name: onepassword-sdk-ocp-pull
+    name: onepassword-lab-s3
   target:
     name: cnpg-s3-credentials
     creationPolicy: Owner

--- a/clusters/ocp/ansible-automation-platform/aap-admin-password-externalsecret.yml
+++ b/clusters/ocp/ansible-automation-platform/aap-admin-password-externalsecret.yml
@@ -10,7 +10,7 @@ spec:
     creationPolicy: Owner
     deletionPolicy: Retain
   secretStoreRef:
-    name: onepassword-sdk-ocp-pull
+    name: onepassword-lab-aap
     kind: ClusterSecretStore
   refreshInterval: 24h
   dataFrom:

--- a/clusters/ocp/cluster-api/casval-bmc-secret-externalsecret.yaml
+++ b/clusters/ocp/cluster-api/casval-bmc-secret-externalsecret.yaml
@@ -10,7 +10,7 @@ spec:
     creationPolicy: Owner
     deletionPolicy: Retain
   secretStoreRef:
-    name: onepassword-sdk-ocp-pull
+    name: onepassword-lab-openshift
     kind: ClusterSecretStore
   refreshInterval: 24h
   dataFrom:

--- a/clusters/ocp/democratic-csi/democratic-csi-iscsi-cold-externalsecret.yml
+++ b/clusters/ocp/democratic-csi/democratic-csi-iscsi-cold-externalsecret.yml
@@ -7,7 +7,7 @@ spec:
   refreshInterval: 24h
   secretStoreRef:
     kind: ClusterSecretStore
-    name: onepassword-sdk-ocp-pull
+    name: onepassword-lab-openshift
   target:
     name: democratic-csi-iscsi-cold-config
     creationPolicy: Owner

--- a/clusters/ocp/democratic-csi/democratic-csi-iscsi-fast-externalsecret.yml
+++ b/clusters/ocp/democratic-csi/democratic-csi-iscsi-fast-externalsecret.yml
@@ -7,7 +7,7 @@ spec:
   refreshInterval: 24h
   secretStoreRef:
     kind: ClusterSecretStore
-    name: onepassword-sdk-ocp-pull
+    name: onepassword-lab-openshift
   target:
     name: democratic-csi-iscsi-fast-config
     creationPolicy: Owner

--- a/clusters/ocp/democratic-csi/democratic-csi-iscsi-ssd-externalsecret.yml
+++ b/clusters/ocp/democratic-csi/democratic-csi-iscsi-ssd-externalsecret.yml
@@ -7,7 +7,7 @@ spec:
   refreshInterval: 24h
   secretStoreRef:
     kind: ClusterSecretStore
-    name: onepassword-sdk-ocp-pull
+    name: onepassword-lab-openshift
   target:
     name: democratic-csi-iscsi-ssd-config
     creationPolicy: Owner

--- a/clusters/ocp/democratic-csi/democratic-csi-nfs-cold-externalsecret.yml
+++ b/clusters/ocp/democratic-csi/democratic-csi-nfs-cold-externalsecret.yml
@@ -7,7 +7,7 @@ spec:
   refreshInterval: 24h
   secretStoreRef:
     kind: ClusterSecretStore
-    name: onepassword-sdk-ocp-pull
+    name: onepassword-lab-openshift
   target:
     name: democratic-csi-nfs-cold-config
     creationPolicy: Owner

--- a/clusters/ocp/democratic-csi/democratic-csi-nfs-fast-externalsecret.yml
+++ b/clusters/ocp/democratic-csi/democratic-csi-nfs-fast-externalsecret.yml
@@ -7,7 +7,7 @@ spec:
   refreshInterval: 24h
   secretStoreRef:
     kind: ClusterSecretStore
-    name: onepassword-sdk-ocp-pull
+    name: onepassword-lab-openshift
   target:
     name: democratic-csi-nfs-fast-config
     creationPolicy: Owner

--- a/clusters/ocp/democratic-csi/democratic-csi-nfs-ssd-externalsecret.yml
+++ b/clusters/ocp/democratic-csi/democratic-csi-nfs-ssd-externalsecret.yml
@@ -7,7 +7,7 @@ spec:
   refreshInterval: 24h
   secretStoreRef:
     kind: ClusterSecretStore
-    name: onepassword-sdk-ocp-pull
+    name: onepassword-lab-openshift
   target:
     name: democratic-csi-nfs-ssd-config
     creationPolicy: Owner

--- a/clusters/ocp/democratic-csi/democratic-csi-nvmeof-cold-externalsecret.yml
+++ b/clusters/ocp/democratic-csi/democratic-csi-nvmeof-cold-externalsecret.yml
@@ -7,7 +7,7 @@ spec:
   refreshInterval: 24h
   secretStoreRef:
     kind: ClusterSecretStore
-    name: onepassword-sdk-ocp-pull
+    name: onepassword-lab-openshift
   target:
     name: democratic-csi-nvmeof-cold-config
     creationPolicy: Owner

--- a/clusters/ocp/democratic-csi/democratic-csi-nvmeof-fast-externalsecret.yml
+++ b/clusters/ocp/democratic-csi/democratic-csi-nvmeof-fast-externalsecret.yml
@@ -7,7 +7,7 @@ spec:
   refreshInterval: 24h
   secretStoreRef:
     kind: ClusterSecretStore
-    name: onepassword-sdk-ocp-pull
+    name: onepassword-lab-openshift
   target:
     name: democratic-csi-nvmeof-fast-config
     creationPolicy: Owner

--- a/clusters/ocp/democratic-csi/democratic-csi-nvmeof-ssd-externalsecret.yml
+++ b/clusters/ocp/democratic-csi/democratic-csi-nvmeof-ssd-externalsecret.yml
@@ -7,7 +7,7 @@ spec:
   refreshInterval: 24h
   secretStoreRef:
     kind: ClusterSecretStore
-    name: onepassword-sdk-ocp-pull
+    name: onepassword-lab-openshift
   target:
     name: democratic-csi-nvmeof-ssd-config
     creationPolicy: Owner

--- a/clusters/ocp/external-secrets-operator/kustomization.yaml
+++ b/clusters/ocp/external-secrets-operator/kustomization.yaml
@@ -3,6 +3,16 @@ kind: Kustomization
 
 resources:
   - ../../../components/external-secrets-operator
-  - onepassword-sdk-ocp-pull-clustersecretstore.yaml
-  - onepassword-sdk-ocp-push-clustersecretstore.yaml
-  - onepassword-sdk-claude-container-clustersecretstore.yaml
+  - onepassword-ocp-pull-clustersecretstore.yaml
+  - onepassword-ocp-push-clustersecretstore.yaml
+  - onepassword-claude-clustersecretstore.yaml
+  - onepassword-lab-openshift-clustersecretstore.yaml
+  - onepassword-lab-redhat-clustersecretstore.yaml
+  - onepassword-lab-container-registries-clustersecretstore.yaml
+  - onepassword-lab-forgejo-clustersecretstore.yaml
+  - onepassword-lab-github-clustersecretstore.yaml
+  - onepassword-lab-s3-clustersecretstore.yaml
+  - onepassword-lab-routeros-clustersecretstore.yaml
+  - onepassword-lab-external-api-keys-clustersecretstore.yaml
+  - onepassword-lab-aap-clustersecretstore.yaml
+  - onepassword-lab-serviceaccounts-clustersecretstore.yaml

--- a/clusters/ocp/external-secrets-operator/onepassword-claude-clustersecretstore.yaml
+++ b/clusters/ocp/external-secrets-operator/onepassword-claude-clustersecretstore.yaml
@@ -1,0 +1,19 @@
+apiVersion: external-secrets.io/v1
+kind: ClusterSecretStore
+metadata:
+  name: onepassword-claude
+spec:
+  refreshInterval: 3600
+  retrySettings:
+    retryInterval: 1h0m0s
+  provider:
+    onepassword:
+      connectHost: http://onepassword-connect.onepassword-connect.svc:8080
+      vaults:
+        claude: 1
+      auth:
+        secretRef:
+          connectTokenSecretRef:
+            name: onepassword-connect-token
+            key: token
+            namespace: external-secrets-operator

--- a/clusters/ocp/external-secrets-operator/onepassword-lab-aap-clustersecretstore.yaml
+++ b/clusters/ocp/external-secrets-operator/onepassword-lab-aap-clustersecretstore.yaml
@@ -1,0 +1,19 @@
+apiVersion: external-secrets.io/v1
+kind: ClusterSecretStore
+metadata:
+  name: onepassword-lab-aap
+spec:
+  refreshInterval: 3600
+  retrySettings:
+    retryInterval: 1h0m0s
+  provider:
+    onepassword:
+      connectHost: http://onepassword-connect.onepassword-connect.svc:8080
+      vaults:
+        lab_aap: 1
+      auth:
+        secretRef:
+          connectTokenSecretRef:
+            name: onepassword-connect-token
+            key: token
+            namespace: external-secrets-operator

--- a/clusters/ocp/external-secrets-operator/onepassword-lab-container-registries-clustersecretstore.yaml
+++ b/clusters/ocp/external-secrets-operator/onepassword-lab-container-registries-clustersecretstore.yaml
@@ -1,0 +1,19 @@
+apiVersion: external-secrets.io/v1
+kind: ClusterSecretStore
+metadata:
+  name: onepassword-lab-container-registries
+spec:
+  refreshInterval: 3600
+  retrySettings:
+    retryInterval: 1h0m0s
+  provider:
+    onepassword:
+      connectHost: http://onepassword-connect.onepassword-connect.svc:8080
+      vaults:
+        lab_container_registries: 1
+      auth:
+        secretRef:
+          connectTokenSecretRef:
+            name: onepassword-connect-token
+            key: token
+            namespace: external-secrets-operator

--- a/clusters/ocp/external-secrets-operator/onepassword-lab-external-api-keys-clustersecretstore.yaml
+++ b/clusters/ocp/external-secrets-operator/onepassword-lab-external-api-keys-clustersecretstore.yaml
@@ -1,0 +1,19 @@
+apiVersion: external-secrets.io/v1
+kind: ClusterSecretStore
+metadata:
+  name: onepassword-lab-external-api-keys
+spec:
+  refreshInterval: 3600
+  retrySettings:
+    retryInterval: 1h0m0s
+  provider:
+    onepassword:
+      connectHost: http://onepassword-connect.onepassword-connect.svc:8080
+      vaults:
+        lab_external_api_keys: 1
+      auth:
+        secretRef:
+          connectTokenSecretRef:
+            name: onepassword-connect-token
+            key: token
+            namespace: external-secrets-operator

--- a/clusters/ocp/external-secrets-operator/onepassword-lab-forgejo-clustersecretstore.yaml
+++ b/clusters/ocp/external-secrets-operator/onepassword-lab-forgejo-clustersecretstore.yaml
@@ -1,0 +1,19 @@
+apiVersion: external-secrets.io/v1
+kind: ClusterSecretStore
+metadata:
+  name: onepassword-lab-forgejo
+spec:
+  refreshInterval: 3600
+  retrySettings:
+    retryInterval: 1h0m0s
+  provider:
+    onepassword:
+      connectHost: http://onepassword-connect.onepassword-connect.svc:8080
+      vaults:
+        lab_forgejo: 1
+      auth:
+        secretRef:
+          connectTokenSecretRef:
+            name: onepassword-connect-token
+            key: token
+            namespace: external-secrets-operator

--- a/clusters/ocp/external-secrets-operator/onepassword-lab-github-clustersecretstore.yaml
+++ b/clusters/ocp/external-secrets-operator/onepassword-lab-github-clustersecretstore.yaml
@@ -1,0 +1,19 @@
+apiVersion: external-secrets.io/v1
+kind: ClusterSecretStore
+metadata:
+  name: onepassword-lab-github
+spec:
+  refreshInterval: 3600
+  retrySettings:
+    retryInterval: 1h0m0s
+  provider:
+    onepassword:
+      connectHost: http://onepassword-connect.onepassword-connect.svc:8080
+      vaults:
+        lab_github: 1
+      auth:
+        secretRef:
+          connectTokenSecretRef:
+            name: onepassword-connect-token
+            key: token
+            namespace: external-secrets-operator

--- a/clusters/ocp/external-secrets-operator/onepassword-lab-openshift-clustersecretstore.yaml
+++ b/clusters/ocp/external-secrets-operator/onepassword-lab-openshift-clustersecretstore.yaml
@@ -1,0 +1,19 @@
+apiVersion: external-secrets.io/v1
+kind: ClusterSecretStore
+metadata:
+  name: onepassword-lab-openshift
+spec:
+  refreshInterval: 3600
+  retrySettings:
+    retryInterval: 1h0m0s
+  provider:
+    onepassword:
+      connectHost: http://onepassword-connect.onepassword-connect.svc:8080
+      vaults:
+        lab_openshift: 1
+      auth:
+        secretRef:
+          connectTokenSecretRef:
+            name: onepassword-connect-token
+            key: token
+            namespace: external-secrets-operator

--- a/clusters/ocp/external-secrets-operator/onepassword-lab-redhat-clustersecretstore.yaml
+++ b/clusters/ocp/external-secrets-operator/onepassword-lab-redhat-clustersecretstore.yaml
@@ -1,7 +1,7 @@
 apiVersion: external-secrets.io/v1
 kind: ClusterSecretStore
 metadata:
-  name: onepassword-sdk-ocp-push
+  name: onepassword-lab-redhat
 spec:
   refreshInterval: 3600
   retrySettings:
@@ -10,7 +10,7 @@ spec:
     onepassword:
       connectHost: http://onepassword-connect.onepassword-connect.svc:8080
       vaults:
-        ocp-push: 1
+        lab_redhat: 1
       auth:
         secretRef:
           connectTokenSecretRef:

--- a/clusters/ocp/external-secrets-operator/onepassword-lab-routeros-clustersecretstore.yaml
+++ b/clusters/ocp/external-secrets-operator/onepassword-lab-routeros-clustersecretstore.yaml
@@ -1,0 +1,19 @@
+apiVersion: external-secrets.io/v1
+kind: ClusterSecretStore
+metadata:
+  name: onepassword-lab-routeros
+spec:
+  refreshInterval: 3600
+  retrySettings:
+    retryInterval: 1h0m0s
+  provider:
+    onepassword:
+      connectHost: http://onepassword-connect.onepassword-connect.svc:8080
+      vaults:
+        lab_routeros: 1
+      auth:
+        secretRef:
+          connectTokenSecretRef:
+            name: onepassword-connect-token
+            key: token
+            namespace: external-secrets-operator

--- a/clusters/ocp/external-secrets-operator/onepassword-lab-s3-clustersecretstore.yaml
+++ b/clusters/ocp/external-secrets-operator/onepassword-lab-s3-clustersecretstore.yaml
@@ -1,0 +1,19 @@
+apiVersion: external-secrets.io/v1
+kind: ClusterSecretStore
+metadata:
+  name: onepassword-lab-s3
+spec:
+  refreshInterval: 3600
+  retrySettings:
+    retryInterval: 1h0m0s
+  provider:
+    onepassword:
+      connectHost: http://onepassword-connect.onepassword-connect.svc:8080
+      vaults:
+        lab_s3: 1
+      auth:
+        secretRef:
+          connectTokenSecretRef:
+            name: onepassword-connect-token
+            key: token
+            namespace: external-secrets-operator

--- a/clusters/ocp/external-secrets-operator/onepassword-lab-serviceaccounts-clustersecretstore.yaml
+++ b/clusters/ocp/external-secrets-operator/onepassword-lab-serviceaccounts-clustersecretstore.yaml
@@ -1,7 +1,7 @@
 apiVersion: external-secrets.io/v1
 kind: ClusterSecretStore
 metadata:
-  name: onepassword-sdk-ocp-pull
+  name: onepassword-lab-serviceaccounts
 spec:
   refreshInterval: 3600
   retrySettings:
@@ -10,7 +10,7 @@ spec:
     onepassword:
       connectHost: http://onepassword-connect.onepassword-connect.svc:8080
       vaults:
-        ocp-pull: 1
+        lab_serviceaccounts: 1
       auth:
         secretRef:
           connectTokenSecretRef:

--- a/clusters/ocp/external-secrets-operator/onepassword-ocp-pull-clustersecretstore.yaml
+++ b/clusters/ocp/external-secrets-operator/onepassword-ocp-pull-clustersecretstore.yaml
@@ -1,7 +1,7 @@
 apiVersion: external-secrets.io/v1
 kind: ClusterSecretStore
 metadata:
-  name: onepassword-sdk-claude
+  name: onepassword-ocp-pull
 spec:
   refreshInterval: 3600
   retrySettings:
@@ -10,7 +10,7 @@ spec:
     onepassword:
       connectHost: http://onepassword-connect.onepassword-connect.svc:8080
       vaults:
-        claude: 1
+        ocp-pull: 1
       auth:
         secretRef:
           connectTokenSecretRef:

--- a/clusters/ocp/external-secrets-operator/onepassword-ocp-push-clustersecretstore.yaml
+++ b/clusters/ocp/external-secrets-operator/onepassword-ocp-push-clustersecretstore.yaml
@@ -1,0 +1,19 @@
+apiVersion: external-secrets.io/v1
+kind: ClusterSecretStore
+metadata:
+  name: onepassword-ocp-push
+spec:
+  refreshInterval: 3600
+  retrySettings:
+    retryInterval: 1h0m0s
+  provider:
+    onepassword:
+      connectHost: http://onepassword-connect.onepassword-connect.svc:8080
+      vaults:
+        ocp-push: 1
+      auth:
+        secretRef:
+          connectTokenSecretRef:
+            name: onepassword-connect-token
+            key: token
+            namespace: external-secrets-operator

--- a/clusters/ocp/pac-tenants/values.yaml
+++ b/clusters/ocp/pac-tenants/values.yaml
@@ -9,7 +9,7 @@
 # whichever ClusterSecretStore exists and the chart is provider-agnostic.
 secretStore:
   kind: ClusterSecretStore
-  name: onepassword-sdk-ocp-pull
+  name: onepassword-ocp-pull
 
 tenants:
   - name: igou-ansible

--- a/components/alertmanager-config/alertmanager-eda-event-stream-externalsecret.yaml
+++ b/components/alertmanager-config/alertmanager-eda-event-stream-externalsecret.yaml
@@ -8,7 +8,7 @@ spec:
   refreshInterval: 24h
   secretStoreRef:
     kind: ClusterSecretStore
-    name: onepassword-sdk-ocp-pull
+    name: onepassword-lab-aap
   target:
     name: alertmanager-eda-event-stream
     creationPolicy: Owner

--- a/components/alertmanager-config/alertmanager-slack-bot-token-externalsecret.yaml
+++ b/components/alertmanager-config/alertmanager-slack-bot-token-externalsecret.yaml
@@ -8,7 +8,7 @@ spec:
   refreshInterval: 24h
   secretStoreRef:
     kind: ClusterSecretStore
-    name: onepassword-sdk-ocp-pull
+    name: onepassword-lab-external-api-keys
   target:
     name: alertmanager-slack-bot-token
     creationPolicy: Owner

--- a/components/cert-manager-operator/external-secret.yaml
+++ b/components/cert-manager-operator/external-secret.yaml
@@ -10,14 +10,14 @@ spec:
   refreshInterval: 24h
   secretStoreRef:
     kind: ClusterSecretStore
-    name: onepassword-sdk-ocp-pull
+    name: onepassword-lab-external-api-keys
   target:
     name: dns-token
     creationPolicy: Owner
     deletionPolicy: Retain
   dataFrom:
   - extract:
-      key: dns-token
+      key: dns-token-ocp
       conversionStrategy: Default
       decodingStrategy: None
       metadataPolicy: None

--- a/components/openshift-pipelines/chains-signing-externalsecret.yaml
+++ b/components/openshift-pipelines/chains-signing-externalsecret.yaml
@@ -11,7 +11,7 @@ spec:
   refreshInterval: 24h
   secretStoreRef:
     kind: ClusterSecretStore
-    name: onepassword-sdk-ocp-pull
+    name: onepassword-lab-openshift
   target:
     name: signing-secrets
     creationPolicy: Merge

--- a/components/quay-operator/cnpg-s3-credentials-externalsecret.yaml
+++ b/components/quay-operator/cnpg-s3-credentials-externalsecret.yaml
@@ -14,7 +14,7 @@ spec:
   refreshInterval: 24h
   secretStoreRef:
     kind: ClusterSecretStore
-    name: onepassword-sdk-ocp-pull
+    name: onepassword-lab-s3
   target:
     name: cnpg-s3-credentials
     creationPolicy: Owner

--- a/components/quay-operator/config-bundle-secret-externalsecret.yaml
+++ b/components/quay-operator/config-bundle-secret-externalsecret.yaml
@@ -10,7 +10,7 @@ spec:
   refreshInterval: 24h
   secretStoreRef:
     kind: ClusterSecretStore
-    name: onepassword-sdk-ocp-pull
+    name: onepassword-lab-openshift
   target:
     name: config-bundle-secret
     creationPolicy: Owner

--- a/components/quay-operator/quay-clair-pg-credentials-externalsecret.yaml
+++ b/components/quay-operator/quay-clair-pg-credentials-externalsecret.yaml
@@ -11,7 +11,7 @@ spec:
   refreshInterval: 24h
   secretStoreRef:
     kind: ClusterSecretStore
-    name: onepassword-sdk-ocp-pull
+    name: onepassword-lab-openshift
   target:
     name: quay-clair-pg-credentials
     creationPolicy: Owner

--- a/components/quay-operator/quay-pg-credentials-externalsecret.yaml
+++ b/components/quay-operator/quay-pg-credentials-externalsecret.yaml
@@ -11,7 +11,7 @@ spec:
   refreshInterval: 24h
   secretStoreRef:
     kind: ClusterSecretStore
-    name: onepassword-sdk-ocp-pull
+    name: onepassword-lab-openshift
   target:
     name: quay-pg-credentials
     creationPolicy: Owner

--- a/components/rhdh/cnpg-s3-credentials-externalsecret.yaml
+++ b/components/rhdh/cnpg-s3-credentials-externalsecret.yaml
@@ -14,7 +14,7 @@ spec:
   refreshInterval: 24h
   secretStoreRef:
     kind: ClusterSecretStore
-    name: onepassword-sdk-ocp-pull
+    name: onepassword-lab-s3
   target:
     name: cnpg-s3-credentials
     creationPolicy: Owner

--- a/components/rhdh/rhdh-backend-secret-externalsecret.yaml
+++ b/components/rhdh/rhdh-backend-secret-externalsecret.yaml
@@ -11,7 +11,7 @@ spec:
   refreshInterval: 24h
   secretStoreRef:
     kind: ClusterSecretStore
-    name: onepassword-sdk-ocp-pull
+    name: onepassword-lab-openshift
   target:
     name: rhdh-backend-secret
     creationPolicy: Owner

--- a/components/rhdh/rhdh-postgres-credentials-externalsecret.yaml
+++ b/components/rhdh/rhdh-postgres-credentials-externalsecret.yaml
@@ -11,7 +11,7 @@ spec:
   refreshInterval: 24h
   secretStoreRef:
     kind: ClusterSecretStore
-    name: onepassword-sdk-ocp-pull
+    name: onepassword-lab-openshift
   target:
     name: rhdh-postgres-credentials
     creationPolicy: Owner

--- a/components/service-accounts/values.yaml
+++ b/components/service-accounts/values.yaml
@@ -149,7 +149,9 @@ serviceAccounts:
       - name: cluster-read-only-token-push
         refreshInterval: "0"
         secretStoreRefs:
-          - name: onepassword-sdk-claude
+          - name: onepassword-claude
+            kind: ClusterSecretStore
+          - name: onepassword-lab-serviceaccounts
             kind: ClusterSecretStore
         data:
           - conversionStrategy: None
@@ -168,7 +170,9 @@ serviceAccounts:
       - name: cluster-edit-token-push
         refreshInterval: "0"
         secretStoreRefs:
-          - name: onepassword-sdk-claude
+          - name: onepassword-claude
+            kind: ClusterSecretStore
+          - name: onepassword-lab-serviceaccounts
             kind: ClusterSecretStore
         data:
           - conversionStrategy: None
@@ -184,7 +188,9 @@ serviceAccounts:
       - name: claude-edit-token-push
         refreshInterval: "0"
         secretStoreRefs:
-          - name: onepassword-sdk-claude
+          - name: onepassword-claude
+            kind: ClusterSecretStore
+          - name: onepassword-lab-serviceaccounts
             kind: ClusterSecretStore
         data:
           - conversionStrategy: None
@@ -206,7 +212,9 @@ serviceAccounts:
       - name: ansible-molecule-token-push
         refreshInterval: "0"
         secretStoreRefs:
-          - name: onepassword-sdk-claude
+          - name: onepassword-claude
+            kind: ClusterSecretStore
+          - name: onepassword-lab-serviceaccounts
             kind: ClusterSecretStore
         data:
           - conversionStrategy: None
@@ -234,7 +242,9 @@ serviceAccounts:
       - name: virtualmachine-ops-token
         refreshInterval: "0"
         secretStoreRefs:
-          - name: onepassword-sdk-ocp-push
+          - name: onepassword-ocp-push
+            kind: ClusterSecretStore
+          - name: onepassword-lab-serviceaccounts
             kind: ClusterSecretStore
         data:
           - conversionStrategy: None
@@ -249,7 +259,9 @@ serviceAccounts:
       - name: ns-agent-token
         refreshInterval: "0"
         secretStoreRefs:
-          - name: onepassword-sdk-ocp-push
+          - name: onepassword-ocp-push
+            kind: ClusterSecretStore
+          - name: onepassword-lab-serviceaccounts
             kind: ClusterSecretStore
         data:
           - conversionStrategy: None

--- a/components/tailscale-operator/operator-oauth-externalsecret.yml
+++ b/components/tailscale-operator/operator-oauth-externalsecret.yml
@@ -7,7 +7,7 @@ spec:
     creationPolicy: Owner
     deletionPolicy: Retain
   secretStoreRef:
-    name: onepassword-sdk-ocp-pull
+    name: onepassword-ocp-pull
     kind: ClusterSecretStore
   refreshInterval: 24h
   dataFrom:

--- a/components/user-workload-monitoring/exporters/mktxp/kustomization.yaml
+++ b/components/user-workload-monitoring/exporters/mktxp/kustomization.yaml
@@ -109,7 +109,7 @@ helmCharts:
               refreshInterval: 24h
               secretStoreRef:
                 kind: ClusterSecretStore
-                name: onepassword-sdk-ocp-pull
+                name: onepassword-lab-routeros
               target:
                 name: mktxp-secret
                 creationPolicy: Owner


### PR DESCRIPTION
Phase 1 of the secrets vault migration (tracked locally). Moves OpenShift ESO off the awx-era monolithic stores onto **per-vault** 1Password Connect stores backed by the **openshift entity token**.

## Changes
- **Stores**: 3 → 13. Renamed the misleading `onepassword-sdk-*` → `onepassword-<vault>`; added one store per vault the openshift entity reads/writes (lab_openshift, lab_redhat, lab_container_registries, lab_forgejo, lab_github, lab_s3, lab_routeros, lab_external_api_keys, lab_aap, lab_serviceaccounts, + transitional ocp-pull/ocp-push/claude).
- **33 ExternalSecrets** repointed to their context vault (items pre-staged in Phase 0).
- **SA-token PushSecrets** dual-target `lab_serviceaccounts` — old `claude`/`ocp-push` refs kept so current readers (devcontainer/molecule/AAP) don't break mid-migration; removed in a later phase.
- **Specials**: cert-manager `dns-token`→`dns-token-ocp` (disambiguated from the Ansible DNS token); quay `config-bundle-secret` reads all 3 items from `lab_openshift` (single store, resolves the vault-span blocker); minecraft broken store ref + malformed `apiVersion` fixed.

## Deferred (left on the renamed transitional `onepassword-ocp-pull`)
- **tailscale** ES — pending entity-token re-mint with finer granularity
- **gitea-admin / n8n** — 1P items don't exist anywhere (apps deferred)
- **pac-tenant** — its 3 tenant secrets span lab_forgejo/lab_container_registries/lab_redhat but the chart uses one store; needs a per-secret store override (follow-up)

## Prereq / validation
- Requires the **openshift-entity Connect token** seeded in secret `onepassword-connect-token` (ns `external-secrets-operator`) — done.
- `kustomize build --enable-helm` on the store overlay + `helm template` on the service-account-access / ocp-base-config charts render clean.

After merge: verify stores `Ready`, ExternalSecrets `SecretSynced`, PushSecrets `Synced`, apps Healthy. Then remote-tenant mirror + the later phases (AAP lookups, devcontainer, decommission).

🤖 Generated with [Claude Code](https://claude.com/claude-code)