### PR TITLE
chore(llmkube): default qwen3-35b-a3b to replicas 0 (casval at rest)

### DIFF
--- a/applications/llmkube/qwen3-35b-a3b-inferenceservice.yaml
+++ b/applications/llmkube/qwen3-35b-a3b-inferenceservice.yaml
@@ -15,7 +15,14 @@ spec:
   # ignores --n-gpu-layers. Override with the CUDA build so the 2x RTX 4060 Ti
   # on casval are actually used for inference.
   image: ghcr.io/ggml-org/llama.cpp:server-cuda13@sha256:4cdb8aa17091f9942fcf89896d63ed244e48828e1b15f28f59e7ab49d84b8527
-  replicas: 1
+  # At rest this model is OFF (replicas: 0) so the casval burst baremetal node
+  # stays scaled to zero — the pod pins to casval (nodeSelector burst below), and
+  # a running replica is what holds the cluster-autoscaler's casval MachineSet at 1.
+  # To bring the big model up, scale to 1 (live patch or here); a Pending burst pod
+  # triggers the autoscaler to provision casval 0->1 (~12 min cold). ArgoCD ignores
+  # /spec/replicas (clusters/ocp/values.yaml ignoreDifferences) so a live scale-up
+  # is not reverted, but the checked-in value is the bootstrap/resting default.
+  replicas: 0
   # Tuning targets: Qwen3.6-35B-A3B UD-Q5_K_XL (~25 GiB) on 2x RTX 4060 Ti 16 GiB.
   # Hybrid linear-attn MoE: only 10/40 layers hold a KV cache (2 KV heads), so KV is
   # tiny — ~1.25 GiB at 64k, ~3.8 GiB at 200k (f16). Native ctx is 256k (n_ctx_train


### PR DESCRIPTION
## What

Set the checked-in default for the `qwen3-35b-a3b` InferenceService to `replicas: 0`.

## Why

The 35b model is the only workload pinned to the `casval` burst baremetal node. A running replica is what keeps a burst pod scheduled, which is what holds the cluster-autoscaler's `casval` MachineSet at 1. Previously git declared `replicas: 1`, so a fresh bootstrap (Argo *creates* the CR with the full manifest) would auto-provision casval on every reinstall.

Setting the declared/resting value to `0` makes **"casval scaled to zero" the documented at-rest state** (matching `CLAUDE.md`: *"the casval burst worker is 0 replicas at rest"*).

ArgoCD ignores `/spec/replicas` on InferenceService CRs (`clusters/ocp/values.yaml` `ignoreDifferences`), so:
- live scale-ups (`oc patch isvc ... replicas: N`) still work and are **not** reverted by sync;
- this change only affects the bootstrap/resting default, not any currently-running model.

## Context

Companion to a live scale-down of casval performed this session: scaled `qwen3-35b-a3b` → 0, the cluster-autoscaler drained casval and scaled the `casval-worker` MachineSet 1→0, and CAPM3/metal3 deprovisioned + powered off the BareMetalHost (now `available`, `poweredOn: false`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01ABCDdxkj3rbL6jF1QA5EwM