### PR TITLE
fix(secrets): pac-tenant ExternalSecrets read per-vault stores (forgejo/registries/redhat)

### DIFF
--- a/.helm/charts/pac-tenant/templates/_helpers.tpl
+++ b/.helm/charts/pac-tenant/templates/_helpers.tpl
@@ -29,15 +29,21 @@ true
 
 {{/*
 pac-tenant.secretStoreRef — renders the spec.secretStoreRef block for an
-ExternalSecret using the chart-level secretStore.{kind,name} config.
+ExternalSecret. Each secret may point at its own store via an optional
+per-secret `secretStore.{kind,name}` override; unset fields fall back to the
+chart-level secretStore.{kind,name} default. This lets ExternalSecrets whose
+items live in different context vaults each reference the matching per-vault
+ClusterSecretStore.
 Usage:
   spec:
     secretStoreRef:
-      {{- include "pac-tenant.secretStoreRef" $ | nindent 6 }}
+      {{- include "pac-tenant.secretStoreRef" (dict "root" $ "store" $secret.secretStore) | nindent 6 }}
 */}}
 {{- define "pac-tenant.secretStoreRef" -}}
-kind: {{ .Values.secretStore.kind | quote }}
-name: {{ .Values.secretStore.name | quote }}
+{{- $root := .root -}}
+{{- $store := .store | default dict -}}
+kind: {{ $store.kind | default $root.Values.secretStore.kind | quote }}
+name: {{ $store.name | default $root.Values.secretStore.name | quote }}
 {{- end -}}
 
 {{/*

--- a/.helm/charts/pac-tenant/templates/externalsecrets.yaml
+++ b/.helm/charts/pac-tenant/templates/externalsecrets.yaml
@@ -20,7 +20,7 @@ metadata:
 spec:
   refreshInterval: 24h
   secretStoreRef:
-    {{- include "pac-tenant.secretStoreRef" $ | nindent 4 }}
+    {{- include "pac-tenant.secretStoreRef" (dict "root" $ "store" $secret.secretStore) | nindent 4 }}
   target:
     name: {{ $secret.name | quote }}
     creationPolicy: Owner
@@ -53,7 +53,7 @@ metadata:
 spec:
   refreshInterval: 24h
   secretStoreRef:
-    {{- include "pac-tenant.secretStoreRef" $ | nindent 4 }}
+    {{- include "pac-tenant.secretStoreRef" (dict "root" $ "store" $secret.secretStore) | nindent 4 }}
   target:
     name: {{ $secret.name | quote }}
     creationPolicy: Owner
@@ -85,7 +85,7 @@ metadata:
 spec:
   refreshInterval: 24h
   secretStoreRef:
-    {{- include "pac-tenant.secretStoreRef" $ | nindent 4 }}
+    {{- include "pac-tenant.secretStoreRef" (dict "root" $ "store" $secret.secretStore) | nindent 4 }}
   target:
     name: {{ $secret.name | quote }}
     creationPolicy: Owner

--- a/.helm/charts/pac-tenant/templates/forgejo-secret.yaml
+++ b/.helm/charts/pac-tenant/templates/forgejo-secret.yaml
@@ -16,7 +16,7 @@ metadata:
 spec:
   refreshInterval: 24h
   secretStoreRef:
-    {{- include "pac-tenant.secretStoreRef" $ | nindent 4 }}
+    {{- include "pac-tenant.secretStoreRef" (dict "root" $ "store" $tenant.gitProvider.secretStore) | nindent 4 }}
   target:
     name: forgejo-webhook-config
     creationPolicy: Owner

--- a/.helm/charts/pac-tenant/values.yaml
+++ b/.helm/charts/pac-tenant/values.yaml
@@ -59,6 +59,9 @@ defaults:
 #         key: <remote-secret-key>                       `provider.token` (Forgejo PAT) and `webhook.secret`
 #         # property: <field>                          # optional, provider-specific (e.g. Vault KV property)
 #         # version: <version>                         # optional, provider-specific
+#       # secretStore:                                 # optional per-secret store override. Defaults to the
+#       #   name: <store-name>                           chart-level secretStore.name; set it when this item
+#       #   # kind: ClusterSecretStore                   lives in a different context vault/store than the default.
 #     concurrencyLimit: <int>                          # optional; unset by default. Mutually
 #                                                        exclusive with the cluster's global
 #                                                        enable-cancel-in-progress-on-* setting —
@@ -104,6 +107,12 @@ defaults:
 #           key: <key-in-secret>                         (typically created via workspaceSecrets)
 #         # filter: "..."                              # optional CEL expression to scope the param to specific events
 #     secrets:
+#       # Every secret entry below (imagePullSecrets / serviceAccountSecrets /
+#       # workspaceSecrets) accepts an optional per-secret store override:
+#       #   secretStore:
+#       #     name: <store-name>                       # defaults to chart-level secretStore.name
+#       #     # kind: ClusterSecretStore               # defaults to chart-level secretStore.kind
+#       # Use it when the item lives in a different context vault/store than the default.
 #       imagePullSecrets:                              # SSA-patched onto the operator-managed `pipeline` SA's
 #                                                        imagePullSecrets (consumed by the kubelet).
 #         - name: <k8s-secret-name>

--- a/clusters/ocp/pac-tenants/values.yaml
+++ b/clusters/ocp/pac-tenants/values.yaml
@@ -17,6 +17,9 @@ tenants:
     gitProvider:
       remoteRef:
         key: ci-forgejo-igou-ansible
+      # Item lives in the lab_forgejo context vault.
+      secretStore:
+        name: onepassword-lab-forgejo
     imageStreams:
       - name: ee-minimal-rhel9
         from: registry.redhat.io/ansible-automation-platform-27/ee-minimal-rhel9:latest
@@ -25,6 +28,9 @@ tenants:
         - name: quay-push-config
           remoteRef:
             key: ci-quay-shared
+          # Item lives in the lab_container_registries context vault.
+          secretStore:
+            name: onepassword-lab-container-registries
           asImagePullSecret: true
       # Red Hat Automation Hub offline token (from console.redhat.com/openshift/token).
       # The remote secret must contain a field `token` with the SSO offline token.
@@ -32,6 +38,9 @@ tenants:
         - name: rh-automationhub-credentials
           remoteRef:
             key: rh-automationhub-credentials
+          # Item lives in the lab_redhat context vault.
+          secretStore:
+            name: onepassword-lab-redhat
     # Galaxy servers exposed to ansible-builder PipelineRuns. Repository params
     # are interpolated into PipelineRun YAML at trigger time (PaC {{ name }}
     # syntax); the pipeline turns them into ANSIBLE_GALAXY_SERVER_<NAME>_*


### PR DESCRIPTION
## What

Part of the secrets migration to per-vault 1Password Connect stores. The three per-tenant ExternalSecrets in the `pac-tenant` chart read items that now live in **different context vaults**, but the chart forced all of them through one shared `secretStore.name`. An ExternalSecret has exactly one store -> one vault, so a single shared store can't serve three vaults.

## Change

- `pac-tenant.secretStoreRef` helper now takes `(dict "root" $ "store" <per-secret secretStore>)`. Each `secretStore.{name,kind}` field is optional and **falls back to the chart-level `secretStore` default**, so behavior is unchanged for any secret that doesn't set one.
- `forgejo-secret.yaml` and all three secret loops in `externalsecrets.yaml` pass their entry's `secretStore` through.
- `clusters/ocp/pac-tenants/values.yaml` sets each ES to its own per-vault ClusterSecretStore.

Item keys, `dataFrom` rewrite blocks, dockerconfig projection, and `asImagePullSecret` behavior are untouched — only the store each ES points at changed.

## Rendered result

`kustomize build --enable-helm clusters/ocp/pac-tenants`:

| ExternalSecret | store |
|---|---|
| `forgejo-webhook-config` | `onepassword-lab-forgejo` |
| `quay-push-config` | `onepassword-lab-container-registries` |
| `rh-automationhub-credentials` | `onepassword-lab-redhat` |

The per-vault ClusterSecretStores and the vault items already exist (created in an earlier PR).

## Validation

- `kustomize build --enable-helm clusters/ocp/pac-tenants` renders; each ES shows its correct per-vault store (table above).
- `helm lint .helm/charts/pac-tenant` -> 0 failed.
- `yamllint` clean on both edited plain-YAML files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AX6Zg1Qfdm2Z6XZSmdoBrU