### PR TITLE
feat(test-workloads): Windows VM unattended-install pattern — all 7 eval editions (#380)

### DIFF
--- a/.yamllint
+++ b/.yamllint
@@ -3,6 +3,8 @@ extends: default
 ignore:
   - .helm/charts/*/templates/
   - tools/kube-burner/*/templates/
+  # sed-templated installer manifests with @@SENTINEL@@ placeholders (not valid YAML)
+  - test-workloads/windows-vms/examples/
 
 rules:
   line-length:

--- a/test-workloads/windows-vms/README.md
+++ b/test-workloads/windows-vms/README.md
@@ -16,6 +16,11 @@ All seven editions were deployed and verified booting on OpenShift (each reached
 | `win11-ltsc2024`     | Windows 11 Enterprise LTSC 2024 (1)                | windows.11   |
 | `win11-iot-ltsc2024` | Windows 11 IoT Enterprise LTSC 2024 (1)            | windows.11   |
 
+Of these, only **`winsrv2025` (latest Server)** and **`win11-25h2` (latest
+desktop)** are kept live on the cluster as GitOps-managed DataVolumes
+(`datavolumes.yaml`). The rest were verified once and are re-imported on demand
+for testing (see below).
+
 > **Reviewer note — this is not (yet) a hands-free `oc apply -k`.** The install is
 > partly imperative and hit several issues during the first run. The
 > [Gaps & known issues](#gaps--known-issues) section below documents every one and
@@ -26,15 +31,25 @@ All seven editions were deployed and verified booting on OpenShift (each reached
 ## What's git-managed here
 
 - `namespace.yaml` — the `windows-images` namespace.
-- `datavolumes.yaml` — one CDI DataVolume per ISO, imported over HTTP from
-  `public.igou.systems` (see #380 Phase 2). Applied via `kustomization.yaml`:
-  `oc apply -k test-workloads/windows-vms/`. **Caveat:** these imports only work
-  once the ISOs are actually published on `public.igou.systems` by igou-ansible
-  **#333** (+ the ssd/public quota bump). That pipeline has not been run yet, so
-  today you must upload the ISOs with `virtctl image-upload` instead (see repro).
+- `datavolumes.yaml` — **only two** CDI DataVolumes, the standing library kept
+  live on the cluster: the **latest Server** (`iso-winserver2025-eval`) and the
+  **latest desktop** (`iso-win11-25h2-enterprise-eval`). Each imports over HTTP
+  from `public.igou.systems` onto the **cold pool over NFS**
+  (`freenas-nfs-cold-csi`) — bulk read-mostly ISOs belong on cold RAIDZ2, and NFS
+  gives RWX so several test VMs can share one ISO cdrom. Applied via
+  `kustomization.yaml`: `oc apply -k test-workloads/windows-vms/`. The ISOs are
+  published on `public.igou.systems` (hydrated from the igounas archive), so these
+  imports resolve as-is.
 
-Installer VMs are inherently imperative (they need the CD-boot prompt caught on
-first boot), so they live in `examples/` rather than the kustomization.
+Deliberately **not** GitOps-managed:
+- The other five editions (older Server, Win11 LTSC/IoT). They were all verified
+  (table above) but are not kept live. To work with one, publish it to
+  `public.igou.systems` and `virtctl image-upload` / add a throwaway DataVolume on
+  demand — see the repro and `examples/`.
+- Installer/build VMs — inherently imperative (they need the CD-boot prompt caught
+  on first boot), so they live in `examples/`, not the kustomization. Those
+  scripts (`vm-template.yaml`, `autounattend.*.xml`, `autoboot.py`, `boot-vm.sh`)
+  are kept on purpose: they are the hands-on debugging/testing kit for any edition.
 
 ## The install pattern (`examples/`)
 

--- a/test-workloads/windows-vms/README.md
+++ b/test-workloads/windows-vms/README.md
@@ -1,0 +1,201 @@
+# Windows VMs on OpenShift Virtualization (testing)
+
+Unattended install + verification of the full Microsoft Evaluation Center ISO
+library on the `ocp` cluster (CNV 4.21.10). Design: igou-io/igou-openshift#380.
+
+All seven editions were deployed and verified booting on OpenShift (each reached
+`AgentConnected=True` with the guest OS reported by qemu-guest-agent):
+
+| VM name              | Edition (install.wim index)                        | Preference   |
+|----------------------|----------------------------------------------------|--------------|
+| `winsrv2025`         | Server 2025 Standard Eval, Desktop Experience (2)  | windows.2k25 |
+| `winsrv2022`         | Server 2022 Standard Eval, Desktop Experience (2)  | windows.2k22 |
+| `winsrv2019`         | Server 2019 Standard Eval, Desktop Experience (2)  | windows.2k19 |
+| `winsrv2016`         | Server 2016 Datacenter Eval, Desktop Experience (2)| windows.2k16 |
+| `win11-25h2`         | Windows 11 Enterprise Eval 25H2 (1)                | windows.11   |
+| `win11-ltsc2024`     | Windows 11 Enterprise LTSC 2024 (1)                | windows.11   |
+| `win11-iot-ltsc2024` | Windows 11 IoT Enterprise LTSC 2024 (1)            | windows.11   |
+
+> **Reviewer note — this is not (yet) a hands-free `oc apply -k`.** The install is
+> partly imperative and hit several issues during the first run. The
+> [Gaps & known issues](#gaps--known-issues) section below documents every one and
+> **distinguishes issues that were transient to the storage backend at the time
+> (now resolved) from issues native to Windows-on-KubeVirt that will recur** on
+> any run. Read that before reproducing.
+
+## What's git-managed here
+
+- `namespace.yaml` — the `windows-images` namespace.
+- `datavolumes.yaml` — one CDI DataVolume per ISO, imported over HTTP from
+  `public.igou.systems` (see #380 Phase 2). Applied via `kustomization.yaml`:
+  `oc apply -k test-workloads/windows-vms/`. **Caveat:** these imports only work
+  once the ISOs are actually published on `public.igou.systems` by igou-ansible
+  **#333** (+ the ssd/public quota bump). That pipeline has not been run yet, so
+  today you must upload the ISOs with `virtctl image-upload` instead (see repro).
+
+Installer VMs are inherently imperative (they need the CD-boot prompt caught on
+first boot), so they live in `examples/` rather than the kustomization.
+
+## The install pattern (`examples/`)
+
+- **`vm-template.yaml`** — parameterized VM (`@@NAME@@`, `@@PREFERENCE@@`,
+  `@@ISOPVC@@`). Key choices:
+  - Applies the `windows.*` ClusterPreference for hyper-v enlightenment, q35,
+    clock, disk/NIC model — but sets `tpm: {}` and `firmware.bootloader.efi`
+    explicitly so vTPM/EFI state is **non-persistent**. Non-persistent NVRAM
+    lives in the virt-launcher for the life of the VMI and survives guest
+    reboots, so the install completes; only a full VM stop/start resets it (which
+    then leaves the disk un-bootable — see Gaps). For durable state, merge #417
+    (`HyperConverged.spec.vmStateStorageClass`) and switch the preference's
+    persistent defaults back on.
+  - `cpu: {sockets: 2, cores: 1}` — the `windows.11` client preference *requires*
+    the 2 vCPUs presented as sockets; `sockets:1/cores:2` fails admission.
+  - `nodeAffinity NotIn truenas-w1` — keeps VMs off the TrueNAS-hosted worker.
+    Note this uses the **short hostname** `truenas-w1` (its `kubernetes.io/hostname`
+    label), not the FQDN — see #420.
+  - rootdisk uses the cluster default StorageClass (`freenas-nvmeof-ssd-csi`).
+- **`autounattend.server.xml` / `autounattend.client.xml`** — fully unattended:
+  wipes disk 0, GPT EFI+MSR+Windows partitions, selects the edition by
+  `/IMAGE/INDEX`, skips OOBE, auto-logon, and a FirstLogonCommand that installs
+  the virtio-win guest tools (drivers + qemu-ga) so KubeVirt reports
+  `AgentConnected` + `guestOSInfo` — the verification signal. The client variant
+  creates a local admin account and adds the Win11 NRO / hardware-check bypasses.
+  No `<ProductKey>` element (see Gaps). Sentinels `@@INDEX@@`, `@@HOSTNAME@@`, and
+  `@@ADMINPW@@` are substituted at apply time — the admin/auto-logon password is
+  **not** committed (injected via `sed` in step 2, see repro). Delivered as a
+  KubeVirt `sysprep` volume from a ConfigMap keyed `autounattend.xml`.
+- **`autoboot.py`** — presses Enter while the guest framebuffer is dark to catch
+  the "Press any key to boot from CD" prompt, stops when the blue Setup screen
+  appears (exit 0), or gives up on the gray UEFI Front Page (exit 1).
+- **`boot-vm.sh`** — **the reliable driver.** `autoboot.py` alone is a timing
+  gamble; this wrapper force power-cycles the VM and retries `autoboot.py` until
+  Setup appears. Use this, not bare `autoboot.py`.
+
+### Reproduce one edition (hands-free path, works today)
+
+```sh
+cd test-workloads/windows-vms
+
+# 1. ISO PVC. datavolumes.yaml (HTTP import) needs #333 first; until then upload:
+virtctl image-upload dv iso-winserver2025-eval -n windows-images --size 9Gi \
+  --image-path winserver2025-eval-en-us.iso \
+  --uploadproxy-url https://cdi-uploadproxy-openshift-cnv.apps.ocp.igou.systems --insecure
+
+# 2. autounattend ConfigMap (INDEX per the table above; 2 = Server Std Desktop,
+#    1 = the Win11 client editions). Use autounattend.client.xml for win11-*.
+#    @@ADMINPW@@ is the local admin/auto-logon password — injected here so it is
+#    never committed to git (keeps GitGuardian green). Supply your own:
+read -rsp 'VM admin password: ' ADMINPW; echo
+sed -e 's/@@INDEX@@/2/' -e 's/@@HOSTNAME@@/winsrv2025/' -e "s/@@ADMINPW@@/$ADMINPW/g" \
+    examples/autounattend.server.xml > /tmp/au.xml
+oc create configmap winsrv2025-unattend -n windows-images --from-file=autounattend.xml=/tmp/au.xml
+rm -f /tmp/au.xml   # scrub the rendered file; the password lived in it
+
+# 3. VM
+sed -e 's/@@NAME@@/winsrv2025/g' -e 's/@@PREFERENCE@@/windows.2k25/g' \
+    -e 's/@@ISOPVC@@/iso-winserver2025-eval/g' examples/vm-template.yaml | oc apply -f -
+
+# 4. catch the CD-boot prompt (retries until Setup — do NOT use bare autoboot.py)
+examples/boot-vm.sh winsrv2025 5901
+
+# 5. verify (after install + first logon + guest-tools install, ~15-20 min)
+oc get vmi winsrv2025 -n windows-images \
+  -o jsonpath='{.status.conditions[?(@.type=="AgentConnected")].status} {.status.guestOSInfo.prettyName}'
+```
+
+For `win11-iot-ltsc2024` there is one extra **manual** step during OOBE — see the
+IoT entry in Gaps.
+
+## Gaps & known issues
+
+Everything below was hit during the first end-to-end run. Grouped by whether it
+is **native to Windows-on-KubeVirt** (expect it every time) or was **transient to
+the degraded TrueNAS storage backend at the time** (fixed; won't recur on a
+healthy pool — confirmed by a later full Server 2025 install that provisioned +
+installed + verified cleanly on `freenas-nvmeof-ssd-csi`).
+
+### A. Native to Windows / KubeVirt — will recur, handled by this PR
+
+1. **CD-boot prompt must be caught per install.** Windows install media prints
+   "Press any key to boot from CD or DVD"; headless, it times out and the VM
+   drops to no-boot. Needs `boot-vm.sh` (power-cycle + retry `autoboot.py`).
+   Inherent to the media on any UEFI VM; unrelated to storage. *Handled:*
+   `boot-vm.sh` committed.
+2. **Empty `<ProductKey>` breaks older Server eval Setup.** With
+   `<ProductKey><Key></Key></ProductKey>`, Server 2016/2019/2022 eval Setup fails
+   with *"Windows cannot find the Microsoft Software License Terms."* Eval media
+   uses `ei.cfg`, so no key is needed — the element must be **absent**.
+   *Handled:* removed from both autounattend files.
+3. **`windows.11` preference requires 2 vCPUs as sockets.** `sockets:1/cores:2`
+   fails admission (`insufficient CPU resources of 1 vCPU provided as sockets`).
+   *Handled:* `sockets:2/cores:1` in the template.
+4. **Non-persistent EFI/vTPM survives guest reboots but not VM stop/start.** The
+   install (many guest reboots) completes fine, but a full stop/start resets
+   NVRAM and the installed disk becomes un-bootable. This is the deliberate
+   trade-off to avoid depending on #417; documented so nobody stops a verified
+   VM expecting it to come back. Real fix: #417 + persistent EFI/TPM.
+5. **Client OOBE bypass is required for Win11.** Local admin account +
+   `HideOnlineAccountScreens` + `BypassNRO` + LabConfig hardware-check bypasses,
+   or 24H2/25H2 OOBE demands a network/Microsoft account. *Handled:*
+   `autounattend.client.xml`.
+6. **Guest agent needs the virtio-win guest tools installed in-guest.** Without
+   the FirstLogonCommand that runs `virtio-win-guest-tools.exe`, qemu-ga never
+   starts and `AgentConnected` stays false — i.e. no verification signal.
+   *Handled:* FirstLogonCommand in both autounattend files.
+7. **`win11-iot-ltsc2024` needs a manual OOBE fix (edition-specific).** IoT
+   Enterprise LTSC — and only that edition; 25h2 and ltsc2024 with the identical
+   autounattend did not — fails OOBE with *"The computer restarted unexpectedly
+   or encountered an unexpected error."* This reproduced on healthy local
+   storage, so it is **not** a storage issue; it is an IoT-edition/OOBE quirk.
+   **Manual recovery** (done over VNC): at the error dialog press **Shift+F10**,
+   then in the cmd window run
+   `reg add HKLM\SYSTEM\Setup\Status\ChildCompletion /v setup.exe /t REG_DWORD /d 3 /f`,
+   `exit`, then click **OK** to reboot — OOBE then resumes and the VM verifies.
+   *Not yet automated* (would need an autounattend/SetupComplete change to avoid
+   the error, or a scripted VNC keystroke recovery). Reviewer TODO if IoT LTSC is
+   a recurring target.
+
+### B. Transient to the storage backend at the time — resolved, won't recur
+
+These stemmed from the TrueNAS/democratic-csi backend being driven into a
+degraded state by ~a day of heavy concurrent volume create/delete churn during
+the first run. After a change to the ssd pool they no longer occur; a subsequent
+full Server 2025 install on `freenas-nvmeof-ssd-csi` provisioned in ~56s and
+installed cleanly with zero CSI errors.
+
+1. **nvme-oF `CreateVolume` wedged** — `AxiosError` / `operation locked` /
+   `DeadlineExceeded`; PVCs never bound. Root contributor is almost certainly the
+   **duplicate NVMe host NQN across nodes** that igou-io/igou-openshift **#409**
+   fixes. *Resolved by the ssd-pool change; #409 still recommended.*
+2. **democratic-csi controllers OOM-killed (27×)** under concurrent provisioning.
+   Restarting the controller pods cleared stuck locks/backoff (temporary relief).
+3. **Stale RWO `VolumeAttachment`s / multi-attach** after force power-cycling or
+   force-deleting VMs — the degraded CSI failed to detach, blocking the next
+   launcher. On a healthy backend, force ops detach cleanly.
+4. **NFS-backed install crawl / qemu monitor lock** — installing to an NFS
+   rootdisk on the degraded pool caused I/O timeouts and libvirt monitor-lock
+   warnings; installs crawled (>1 hr). *Note:* NFS is inherently slower than
+   block for install write I/O, but the **timeouts** were storage degradation.
+   Prefer a block SC (`freenas-nvmeof-ssd-csi`, the default here) for rootdisks.
+5. **`casval-worker` autoscaled 0→1** — the cluster-autoscaler read the
+   storage-blocked `cdi-upload-prime` pods as needing compute. It scaled back to
+   0 once the stuck pods were cleared. Downstream of the storage wedge.
+6. **LVMS local-storage fallback.** While TrueNAS was degraded, the last VMs were
+   installed with rootdisk + ISO on **`lvms-lvm-local-storage`** (topolvm, local
+   NVMe on `ocp`) to bypass TrueNAS entirely — fast and reliable. Not needed now
+   that the pool is fixed, but it is a good fallback when the shared backend is
+   unhealthy. (Local storage is `ocp`-only and node-pins the VM.)
+
+### C. Prerequisites (cluster config, not this workload)
+
+1. **#420 — MERGED, required.** The `truenas-w1` node exclusion in the HCO used
+   the FQDN `truenas-w1.igou.systems`, but the node's `kubernetes.io/hostname`
+   label is the short name `truenas-w1`, so the exclusion never matched. This let
+   virt-handler *and CDI importer/uploader pods* schedule onto that flaky node,
+   where the CDI pods failed their readiness probe and **stalled ISO uploads**.
+   HCO propagates placement to CDI, so this one-line fix corrects it. Must be
+   present to reproduce.
+2. **#409 — open, recommended.** Unique NVMe host NQN per node; likely the root
+   of the nvme-oF `CreateVolume` wedging under load (B.1).
+3. **#417 — open, optional.** `HyperConverged.spec.vmStateStorageClass`; only
+   needed if you want persistent EFI/vTPM (durable across VM stop/start).

--- a/test-workloads/windows-vms/datavolumes.yaml
+++ b/test-workloads/windows-vms/datavolumes.yaml
@@ -1,16 +1,19 @@
-# CDI DataVolumes that import the Microsoft Evaluation Center ISOs over HTTP from
-# public.igou.systems (TrueNAS static autoindex). One PVC per release; installer
-# VMs attach these as a cdrom. See igou-io/igou-openshift#380 Phase 2.
+# The only Windows ISOs kept live on the cluster (GitOps-managed): the latest
+# Server and the latest desktop eval. CDI imports each over HTTP from
+# public.igou.systems (TrueNAS static autoindex) into the windows-images
+# namespace; installer/build VMs attach these as a cdrom. See #380.
 #
-# The `storage` API (not spec.pvc) defers volumeMode/accessModes to the
-# StorageProfile and auto-adds filesystem overhead. deleteAfterCompletion=false
-# keeps the PVC after import so multiple VMs can reuse it.
+# Storage: pinned to the cold pool over NFS (freenas-nfs-cold-csi). ISOs are
+# bulk, read-mostly, imported once — cold RAIDZ2 is the right tier, and NFS
+# gives RWX/Filesystem so multiple test VMs can mount the same ISO cdrom
+# concurrently (block RWO would multi-attach conflict). The `storage` API
+# defers volumeMode/accessModes to the StorageProfile (RWX Filesystem here) and
+# auto-adds filesystem overhead. deleteAfterCompletion=false keeps the PVC after
+# import so it is reused across VMs.
 #
-# NOTE: initial verification (all 7 editions) was done by uploading these same
-# ISOs directly with `virtctl image-upload` while the public.igou.systems publish
-# pipeline (igou-ansible publish_windows_isos.yml + the ssd/public quota bump in
-# igou-inventory) lands. Once the ISOs are served, these DataVolumes reproduce the
-# same PVCs declaratively.
+# Other editions (older Server/desktop, LTSC, IoT) are NOT kept live — publish
+# them to public.igou.systems and image-upload/DV on demand for hands-on testing
+# (see examples/ + README). Only these two are the standing library.
 ---
 apiVersion: cdi.kubevirt.io/v1beta1
 kind: DataVolume
@@ -24,57 +27,10 @@ spec:
     http:
       url: https://public.igou.systems/isos/windows/winserver2025-eval-en-us.iso
   storage:
+    storageClassName: freenas-nfs-cold-csi
     resources:
       requests:
         storage: 9Gi
----
-apiVersion: cdi.kubevirt.io/v1beta1
-kind: DataVolume
-metadata:
-  name: iso-winserver2022-eval
-  namespace: windows-images
-  annotations:
-    cdi.kubevirt.io/storage.deleteAfterCompletion: "false"
-spec:
-  source:
-    http:
-      url: https://public.igou.systems/isos/windows/winserver2022-eval-en-us.iso
-  storage:
-    resources:
-      requests:
-        storage: 6Gi
----
-apiVersion: cdi.kubevirt.io/v1beta1
-kind: DataVolume
-metadata:
-  name: iso-winserver2019-eval
-  namespace: windows-images
-  annotations:
-    cdi.kubevirt.io/storage.deleteAfterCompletion: "false"
-spec:
-  source:
-    http:
-      url: https://public.igou.systems/isos/windows/winserver2019-eval-en-us.iso
-  storage:
-    resources:
-      requests:
-        storage: 7Gi
----
-apiVersion: cdi.kubevirt.io/v1beta1
-kind: DataVolume
-metadata:
-  name: iso-winserver2016-eval
-  namespace: windows-images
-  annotations:
-    cdi.kubevirt.io/storage.deleteAfterCompletion: "false"
-spec:
-  source:
-    http:
-      url: https://public.igou.systems/isos/windows/winserver2016-eval-en-us.iso
-  storage:
-    resources:
-      requests:
-        storage: 8Gi
 ---
 apiVersion: cdi.kubevirt.io/v1beta1
 kind: DataVolume
@@ -88,38 +44,7 @@ spec:
     http:
       url: https://public.igou.systems/isos/windows/win11-25h2-enterprise-eval-en-us.iso
   storage:
+    storageClassName: freenas-nfs-cold-csi
     resources:
       requests:
         storage: 9Gi
----
-apiVersion: cdi.kubevirt.io/v1beta1
-kind: DataVolume
-metadata:
-  name: iso-win11-ltsc2024-enterprise-eval
-  namespace: windows-images
-  annotations:
-    cdi.kubevirt.io/storage.deleteAfterCompletion: "false"
-spec:
-  source:
-    http:
-      url: https://public.igou.systems/isos/windows/win11-ltsc2024-enterprise-eval-en-us.iso
-  storage:
-    resources:
-      requests:
-        storage: 6Gi
----
-apiVersion: cdi.kubevirt.io/v1beta1
-kind: DataVolume
-metadata:
-  name: iso-win11-iot-ltsc2024-enterprise-eval
-  namespace: windows-images
-  annotations:
-    cdi.kubevirt.io/storage.deleteAfterCompletion: "false"
-spec:
-  source:
-    http:
-      url: https://public.igou.systems/isos/windows/win11-iot-ltsc2024-enterprise-eval-en-us.iso
-  storage:
-    resources:
-      requests:
-        storage: 6Gi

--- a/test-workloads/windows-vms/datavolumes.yaml
+++ b/test-workloads/windows-vms/datavolumes.yaml
@@ -1,0 +1,125 @@
+# CDI DataVolumes that import the Microsoft Evaluation Center ISOs over HTTP from
+# public.igou.systems (TrueNAS static autoindex). One PVC per release; installer
+# VMs attach these as a cdrom. See igou-io/igou-openshift#380 Phase 2.
+#
+# The `storage` API (not spec.pvc) defers volumeMode/accessModes to the
+# StorageProfile and auto-adds filesystem overhead. deleteAfterCompletion=false
+# keeps the PVC after import so multiple VMs can reuse it.
+#
+# NOTE: initial verification (all 7 editions) was done by uploading these same
+# ISOs directly with `virtctl image-upload` while the public.igou.systems publish
+# pipeline (igou-ansible publish_windows_isos.yml + the ssd/public quota bump in
+# igou-inventory) lands. Once the ISOs are served, these DataVolumes reproduce the
+# same PVCs declaratively.
+---
+apiVersion: cdi.kubevirt.io/v1beta1
+kind: DataVolume
+metadata:
+  name: iso-winserver2025-eval
+  namespace: windows-images
+  annotations:
+    cdi.kubevirt.io/storage.deleteAfterCompletion: "false"
+spec:
+  source:
+    http:
+      url: https://public.igou.systems/isos/windows/winserver2025-eval-en-us.iso
+  storage:
+    resources:
+      requests:
+        storage: 9Gi
+---
+apiVersion: cdi.kubevirt.io/v1beta1
+kind: DataVolume
+metadata:
+  name: iso-winserver2022-eval
+  namespace: windows-images
+  annotations:
+    cdi.kubevirt.io/storage.deleteAfterCompletion: "false"
+spec:
+  source:
+    http:
+      url: https://public.igou.systems/isos/windows/winserver2022-eval-en-us.iso
+  storage:
+    resources:
+      requests:
+        storage: 6Gi
+---
+apiVersion: cdi.kubevirt.io/v1beta1
+kind: DataVolume
+metadata:
+  name: iso-winserver2019-eval
+  namespace: windows-images
+  annotations:
+    cdi.kubevirt.io/storage.deleteAfterCompletion: "false"
+spec:
+  source:
+    http:
+      url: https://public.igou.systems/isos/windows/winserver2019-eval-en-us.iso
+  storage:
+    resources:
+      requests:
+        storage: 7Gi
+---
+apiVersion: cdi.kubevirt.io/v1beta1
+kind: DataVolume
+metadata:
+  name: iso-winserver2016-eval
+  namespace: windows-images
+  annotations:
+    cdi.kubevirt.io/storage.deleteAfterCompletion: "false"
+spec:
+  source:
+    http:
+      url: https://public.igou.systems/isos/windows/winserver2016-eval-en-us.iso
+  storage:
+    resources:
+      requests:
+        storage: 8Gi
+---
+apiVersion: cdi.kubevirt.io/v1beta1
+kind: DataVolume
+metadata:
+  name: iso-win11-25h2-enterprise-eval
+  namespace: windows-images
+  annotations:
+    cdi.kubevirt.io/storage.deleteAfterCompletion: "false"
+spec:
+  source:
+    http:
+      url: https://public.igou.systems/isos/windows/win11-25h2-enterprise-eval-en-us.iso
+  storage:
+    resources:
+      requests:
+        storage: 9Gi
+---
+apiVersion: cdi.kubevirt.io/v1beta1
+kind: DataVolume
+metadata:
+  name: iso-win11-ltsc2024-enterprise-eval
+  namespace: windows-images
+  annotations:
+    cdi.kubevirt.io/storage.deleteAfterCompletion: "false"
+spec:
+  source:
+    http:
+      url: https://public.igou.systems/isos/windows/win11-ltsc2024-enterprise-eval-en-us.iso
+  storage:
+    resources:
+      requests:
+        storage: 6Gi
+---
+apiVersion: cdi.kubevirt.io/v1beta1
+kind: DataVolume
+metadata:
+  name: iso-win11-iot-ltsc2024-enterprise-eval
+  namespace: windows-images
+  annotations:
+    cdi.kubevirt.io/storage.deleteAfterCompletion: "false"
+spec:
+  source:
+    http:
+      url: https://public.igou.systems/isos/windows/win11-iot-ltsc2024-enterprise-eval-en-us.iso
+  storage:
+    resources:
+      requests:
+        storage: 6Gi

--- a/test-workloads/windows-vms/examples/autoboot.py
+++ b/test-workloads/windows-vms/examples/autoboot.py
@@ -1,0 +1,60 @@
+#!/usr/bin/env python3
+"""Press Enter while the screen is dark to catch the fresh-boot CD prompt.
+Connect with retry (VNC may not be ready immediately) and start pressing ASAP.
+blue -> Windows Setup (exit 0). Persistent gray Front Page -> exit 1 so the
+wrapper power-cycles for another fresh-boot attempt."""
+import sys, os, time
+from vncdotool import api
+
+port = sys.argv[1]
+duration = int(sys.argv[2]) if len(sys.argv) > 2 else 90
+
+client = None
+t0 = time.time()
+while time.time() - t0 < 25:
+    try:
+        client = api.connect('127.0.0.1::%s' % port)
+        client.timeout = 12
+        client.refreshScreen()
+        break
+    except Exception as e:
+        print('connect retry:', e); time.sleep(2); client = None
+if client is None:
+    print('NO_VNC'); sys.exit(2)
+
+def analyze():
+    client.refreshScreen()
+    img = client.screen.convert('RGB').resize((40, 30))
+    px = list(img.getdata()); n = len(px)
+    r = sum(p[0] for p in px) / n
+    g = sum(p[1] for p in px) / n
+    b = sum(p[2] for p in px) / n
+    mean = (r + g + b) / 3
+    if mean < 45:
+        return 'dark', mean
+    if b - (r + g) / 2 > 16:
+        return 'blue', mean
+    if abs(r - g) < 22 and abs(g - b) < 22 and mean > 85:
+        return 'gray', mean
+    return 'other', mean
+
+deadline = time.time() + duration
+blue_streak = gray_streak = 0
+while time.time() < deadline:
+    try:
+        s, m = analyze()
+    except Exception as e:
+        print('err', e); time.sleep(1); continue
+    print('%-6s %5.1f' % (s, m))
+    if s == 'dark':
+        client.keyPress('enter'); gray_streak = 0; blue_streak = 0
+    elif s == 'blue':
+        blue_streak += 1; gray_streak = 0
+        if blue_streak >= 3:
+            print('SETUP'); sys.stdout.flush(); os._exit(0)
+    else:  # gray / other
+        gray_streak += 1
+        if gray_streak >= 12:
+            print('STUCK'); sys.stdout.flush(); os._exit(1)
+    time.sleep(0.8)
+print('TIMEOUT'); sys.stdout.flush(); os._exit(1)

--- a/test-workloads/windows-vms/examples/autounattend.client.xml
+++ b/test-workloads/windows-vms/examples/autounattend.client.xml
@@ -1,0 +1,167 @@
+<?xml version="1.0" encoding="utf-8"?>
+<unattend xmlns="urn:schemas-microsoft-com:unattend">
+  <settings pass="windowsPE">
+    <component name="Microsoft-Windows-International-Core-WinPE" processorArchitecture="amd64" publicKeyToken="31bf3856ad364e35" language="neutral" versionScope="nonSxS" xmlns:wcm="http://schemas.microsoft.com/WMIConfig/2002/State" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+      <SetupUILanguage>
+        <UILanguage>en-US</UILanguage>
+      </SetupUILanguage>
+      <InputLocale>en-US</InputLocale>
+      <SystemLocale>en-US</SystemLocale>
+      <UILanguage>en-US</UILanguage>
+      <UserLocale>en-US</UserLocale>
+    </component>
+    <component name="Microsoft-Windows-Setup" processorArchitecture="amd64" publicKeyToken="31bf3856ad364e35" language="neutral" versionScope="nonSxS" xmlns:wcm="http://schemas.microsoft.com/WMIConfig/2002/State" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+      <DiskConfiguration>
+        <Disk wcm:action="add">
+          <DiskID>0</DiskID>
+          <WillWipeDisk>true</WillWipeDisk>
+          <CreatePartitions>
+            <CreatePartition wcm:action="add">
+              <Order>1</Order>
+              <Type>EFI</Type>
+              <Size>260</Size>
+            </CreatePartition>
+            <CreatePartition wcm:action="add">
+              <Order>2</Order>
+              <Type>MSR</Type>
+              <Size>128</Size>
+            </CreatePartition>
+            <CreatePartition wcm:action="add">
+              <Order>3</Order>
+              <Type>Primary</Type>
+              <Extend>true</Extend>
+            </CreatePartition>
+          </CreatePartitions>
+          <ModifyPartitions>
+            <ModifyPartition wcm:action="add">
+              <Order>1</Order>
+              <PartitionID>1</PartitionID>
+              <Label>System</Label>
+              <Format>FAT32</Format>
+            </ModifyPartition>
+            <ModifyPartition wcm:action="add">
+              <Order>2</Order>
+              <PartitionID>2</PartitionID>
+            </ModifyPartition>
+            <ModifyPartition wcm:action="add">
+              <Order>3</Order>
+              <PartitionID>3</PartitionID>
+              <Label>Windows</Label>
+              <Letter>C</Letter>
+              <Format>NTFS</Format>
+            </ModifyPartition>
+          </ModifyPartitions>
+        </Disk>
+      </DiskConfiguration>
+      <ImageInstall>
+        <OSImage>
+          <InstallFrom>
+            <MetaData wcm:action="add">
+              <Key>/IMAGE/INDEX</Key>
+              <Value>@@INDEX@@</Value>
+            </MetaData>
+          </InstallFrom>
+          <InstallTo>
+            <DiskID>0</DiskID>
+            <PartitionID>3</PartitionID>
+          </InstallTo>
+        </OSImage>
+      </ImageInstall>
+      <RunSynchronous>
+        <RunSynchronousCommand wcm:action="add">
+          <Order>1</Order>
+          <Path>reg add HKLM\SYSTEM\Setup\LabConfig /v BypassTPMCheck /t REG_DWORD /d 1 /f</Path>
+        </RunSynchronousCommand>
+        <RunSynchronousCommand wcm:action="add">
+          <Order>2</Order>
+          <Path>reg add HKLM\SYSTEM\Setup\LabConfig /v BypassSecureBootCheck /t REG_DWORD /d 1 /f</Path>
+        </RunSynchronousCommand>
+        <RunSynchronousCommand wcm:action="add">
+          <Order>3</Order>
+          <Path>reg add HKLM\SYSTEM\Setup\LabConfig /v BypassRAMCheck /t REG_DWORD /d 1 /f</Path>
+        </RunSynchronousCommand>
+        <RunSynchronousCommand wcm:action="add">
+          <Order>4</Order>
+          <Path>reg add HKLM\SYSTEM\Setup\LabConfig /v BypassCPUCheck /t REG_DWORD /d 1 /f</Path>
+        </RunSynchronousCommand>
+      </RunSynchronous>
+      <UserData>
+        <AcceptEula>true</AcceptEula>
+        <FullName>Homelab</FullName>
+        <Organization>igou.systems</Organization>
+      </UserData>
+    </component>
+  </settings>
+  <settings pass="specialize">
+    <component name="Microsoft-Windows-Shell-Setup" processorArchitecture="amd64" publicKeyToken="31bf3856ad364e35" language="neutral" versionScope="nonSxS" xmlns:wcm="http://schemas.microsoft.com/WMIConfig/2002/State" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+      <ComputerName>@@HOSTNAME@@</ComputerName>
+    </component>
+    <component name="Microsoft-Windows-Deployment" processorArchitecture="amd64" publicKeyToken="31bf3856ad364e35" language="neutral" versionScope="nonSxS" xmlns:wcm="http://schemas.microsoft.com/WMIConfig/2002/State" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+      <RunSynchronous>
+        <RunSynchronousCommand wcm:action="add">
+          <Order>1</Order>
+          <Path>reg add HKLM\SOFTWARE\Microsoft\Windows\CurrentVersion\OOBE /v BypassNRO /t REG_DWORD /d 1 /f</Path>
+        </RunSynchronousCommand>
+      </RunSynchronous>
+    </component>
+  </settings>
+  <settings pass="oobeSystem">
+    <component name="Microsoft-Windows-International-Core" processorArchitecture="amd64" publicKeyToken="31bf3856ad364e35" language="neutral" versionScope="nonSxS" xmlns:wcm="http://schemas.microsoft.com/WMIConfig/2002/State" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+      <InputLocale>en-US</InputLocale>
+      <SystemLocale>en-US</SystemLocale>
+      <UILanguage>en-US</UILanguage>
+      <UserLocale>en-US</UserLocale>
+    </component>
+    <component name="Microsoft-Windows-Shell-Setup" processorArchitecture="amd64" publicKeyToken="31bf3856ad364e35" language="neutral" versionScope="nonSxS" xmlns:wcm="http://schemas.microsoft.com/WMIConfig/2002/State" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+      <OOBE>
+        <HideEULAPage>true</HideEULAPage>
+        <HideOEMRegistrationScreen>true</HideOEMRegistrationScreen>
+        <HideOnlineAccountScreens>true</HideOnlineAccountScreens>
+        <HideWirelessSetupInOOBE>true</HideWirelessSetupInOOBE>
+        <NetworkLocation>Work</NetworkLocation>
+        <ProtectYourPC>3</ProtectYourPC>
+        <SkipMachineOOBE>true</SkipMachineOOBE>
+        <SkipUserOOBE>true</SkipUserOOBE>
+      </OOBE>
+      <UserAccounts>
+        <LocalAccounts>
+          <LocalAccount wcm:action="add">
+            <Name>igou</Name>
+            <Group>Administrators</Group>
+            <DisplayName>igou</DisplayName>
+            <Password>
+              <Value>@@ADMINPW@@</Value>
+              <PlainText>true</PlainText>
+            </Password>
+          </LocalAccount>
+        </LocalAccounts>
+      </UserAccounts>
+      <AutoLogon>
+        <Password>
+          <Value>@@ADMINPW@@</Value>
+          <PlainText>true</PlainText>
+        </Password>
+        <Enabled>true</Enabled>
+        <LogonCount>2</LogonCount>
+        <Username>igou</Username>
+      </AutoLogon>
+      <FirstLogonCommands>
+        <SynchronousCommand wcm:action="add">
+          <Order>1</Order>
+          <Description>Install virtio-win guest tools (drivers + qemu-ga)</Description>
+          <CommandLine>cmd /c for %d in (D E F G H) do @if exist %d:\virtio-win-guest-tools.exe start /wait %d:\virtio-win-guest-tools.exe /install /passive /norestart</CommandLine>
+        </SynchronousCommand>
+        <SynchronousCommand wcm:action="add">
+          <Order>2</Order>
+          <Description>Ensure QEMU Guest Agent running</Description>
+          <CommandLine>cmd /c sc config "QEMU-GA" start= auto &amp; net start "QEMU-GA"</CommandLine>
+        </SynchronousCommand>
+        <SynchronousCommand wcm:action="add">
+          <Order>3</Order>
+          <Description>Marker</Description>
+          <CommandLine>cmd /c echo installed &gt; C:\windows-unattend-done.txt</CommandLine>
+        </SynchronousCommand>
+      </FirstLogonCommands>
+    </component>
+  </settings>
+</unattend>

--- a/test-workloads/windows-vms/examples/autounattend.server.xml
+++ b/test-workloads/windows-vms/examples/autounattend.server.xml
@@ -1,0 +1,134 @@
+<?xml version="1.0" encoding="utf-8"?>
+<unattend xmlns="urn:schemas-microsoft-com:unattend">
+  <settings pass="windowsPE">
+    <component name="Microsoft-Windows-International-Core-WinPE" processorArchitecture="amd64" publicKeyToken="31bf3856ad364e35" language="neutral" versionScope="nonSxS" xmlns:wcm="http://schemas.microsoft.com/WMIConfig/2002/State" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+      <SetupUILanguage>
+        <UILanguage>en-US</UILanguage>
+      </SetupUILanguage>
+      <InputLocale>en-US</InputLocale>
+      <SystemLocale>en-US</SystemLocale>
+      <UILanguage>en-US</UILanguage>
+      <UserLocale>en-US</UserLocale>
+    </component>
+    <component name="Microsoft-Windows-Setup" processorArchitecture="amd64" publicKeyToken="31bf3856ad364e35" language="neutral" versionScope="nonSxS" xmlns:wcm="http://schemas.microsoft.com/WMIConfig/2002/State" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+      <DiskConfiguration>
+        <Disk wcm:action="add">
+          <DiskID>0</DiskID>
+          <WillWipeDisk>true</WillWipeDisk>
+          <CreatePartitions>
+            <CreatePartition wcm:action="add">
+              <Order>1</Order>
+              <Type>EFI</Type>
+              <Size>260</Size>
+            </CreatePartition>
+            <CreatePartition wcm:action="add">
+              <Order>2</Order>
+              <Type>MSR</Type>
+              <Size>128</Size>
+            </CreatePartition>
+            <CreatePartition wcm:action="add">
+              <Order>3</Order>
+              <Type>Primary</Type>
+              <Extend>true</Extend>
+            </CreatePartition>
+          </CreatePartitions>
+          <ModifyPartitions>
+            <ModifyPartition wcm:action="add">
+              <Order>1</Order>
+              <PartitionID>1</PartitionID>
+              <Label>System</Label>
+              <Format>FAT32</Format>
+            </ModifyPartition>
+            <ModifyPartition wcm:action="add">
+              <Order>2</Order>
+              <PartitionID>2</PartitionID>
+            </ModifyPartition>
+            <ModifyPartition wcm:action="add">
+              <Order>3</Order>
+              <PartitionID>3</PartitionID>
+              <Label>Windows</Label>
+              <Letter>C</Letter>
+              <Format>NTFS</Format>
+            </ModifyPartition>
+          </ModifyPartitions>
+        </Disk>
+      </DiskConfiguration>
+      <ImageInstall>
+        <OSImage>
+          <InstallFrom>
+            <MetaData wcm:action="add">
+              <Key>/IMAGE/INDEX</Key>
+              <Value>@@INDEX@@</Value>
+            </MetaData>
+          </InstallFrom>
+          <InstallTo>
+            <DiskID>0</DiskID>
+            <PartitionID>3</PartitionID>
+          </InstallTo>
+        </OSImage>
+      </ImageInstall>
+      <UserData>
+        <AcceptEula>true</AcceptEula>
+        <FullName>Homelab</FullName>
+        <Organization>igou.systems</Organization>
+      </UserData>
+    </component>
+  </settings>
+  <settings pass="specialize">
+    <component name="Microsoft-Windows-Shell-Setup" processorArchitecture="amd64" publicKeyToken="31bf3856ad364e35" language="neutral" versionScope="nonSxS" xmlns:wcm="http://schemas.microsoft.com/WMIConfig/2002/State" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+      <ComputerName>@@HOSTNAME@@</ComputerName>
+    </component>
+  </settings>
+  <settings pass="oobeSystem">
+    <component name="Microsoft-Windows-International-Core" processorArchitecture="amd64" publicKeyToken="31bf3856ad364e35" language="neutral" versionScope="nonSxS" xmlns:wcm="http://schemas.microsoft.com/WMIConfig/2002/State" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+      <InputLocale>en-US</InputLocale>
+      <SystemLocale>en-US</SystemLocale>
+      <UILanguage>en-US</UILanguage>
+      <UserLocale>en-US</UserLocale>
+    </component>
+    <component name="Microsoft-Windows-Shell-Setup" processorArchitecture="amd64" publicKeyToken="31bf3856ad364e35" language="neutral" versionScope="nonSxS" xmlns:wcm="http://schemas.microsoft.com/WMIConfig/2002/State" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+      <OOBE>
+        <HideEULAPage>true</HideEULAPage>
+        <HideOEMRegistrationScreen>true</HideOEMRegistrationScreen>
+        <HideOnlineAccountScreens>true</HideOnlineAccountScreens>
+        <HideWirelessSetupInOOBE>true</HideWirelessSetupInOOBE>
+        <NetworkLocation>Work</NetworkLocation>
+        <ProtectYourPC>3</ProtectYourPC>
+        <SkipMachineOOBE>true</SkipMachineOOBE>
+        <SkipUserOOBE>true</SkipUserOOBE>
+      </OOBE>
+      <UserAccounts>
+        <AdministratorPassword>
+          <Value>@@ADMINPW@@</Value>
+          <PlainText>true</PlainText>
+        </AdministratorPassword>
+      </UserAccounts>
+      <AutoLogon>
+        <Password>
+          <Value>@@ADMINPW@@</Value>
+          <PlainText>true</PlainText>
+        </Password>
+        <Enabled>true</Enabled>
+        <LogonCount>2</LogonCount>
+        <Username>Administrator</Username>
+      </AutoLogon>
+      <FirstLogonCommands>
+        <SynchronousCommand wcm:action="add">
+          <Order>1</Order>
+          <Description>Install virtio-win guest tools (drivers + qemu-ga)</Description>
+          <CommandLine>cmd /c for %d in (D E F G H) do @if exist %d:\virtio-win-guest-tools.exe start /wait %d:\virtio-win-guest-tools.exe /install /passive /norestart</CommandLine>
+        </SynchronousCommand>
+        <SynchronousCommand wcm:action="add">
+          <Order>2</Order>
+          <Description>Ensure QEMU Guest Agent running</Description>
+          <CommandLine>cmd /c sc config "QEMU-GA" start= auto &amp; net start "QEMU-GA"</CommandLine>
+        </SynchronousCommand>
+        <SynchronousCommand wcm:action="add">
+          <Order>3</Order>
+          <Description>Marker</Description>
+          <CommandLine>cmd /c echo installed &gt; C:\windows-unattend-done.txt</CommandLine>
+        </SynchronousCommand>
+      </FirstLogonCommands>
+    </component>
+  </settings>
+</unattend>

--- a/test-workloads/windows-vms/examples/boot-vm.sh
+++ b/test-workloads/windows-vms/examples/boot-vm.sh
@@ -1,0 +1,42 @@
+#!/usr/bin/env bash
+# Reliably boot a Windows installer VM into Setup.
+#
+# autoboot.py can only catch the "Press any key to boot from CD" prompt if it is
+# already pressing when the ~5s window appears. On a cold VMI the VNC proxy
+# isn't ready that early, so a single run often lands on the UEFI Front Page and
+# misses it. This wrapper force power-cycles the VM and retries autoboot.py from
+# a known start each time, until it detects the blue Windows Setup screen.
+#
+# This step is inherent to Windows install media on any headless UEFI VM (the
+# media requires a keypress to boot); it is NOT related to any storage backend.
+#
+# Usage: boot-vm.sh <vm-name> <local-vnc-port> [namespace]
+set -u
+NAME=${1:?vm name required}
+PORT=${2:?local vnc port required}
+NS=${3:-windows-images}
+DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+for attempt in 1 2 3 4 5 6; do
+  echo "[$NAME] attempt $attempt: power-cycle"
+  virtctl stop "$NAME" -n "$NS" --force --grace-period=0 >/dev/null 2>&1
+  for i in $(seq 1 15); do
+    [ -z "$(oc get vmi "$NAME" -n "$NS" -o jsonpath='{.status.phase}' 2>/dev/null)" ] && break
+    sleep 3
+  done
+  virtctl start "$NAME" -n "$NS" >/dev/null 2>&1
+  for i in $(seq 1 25); do
+    [ "$(oc get vmi "$NAME" -n "$NS" -o jsonpath='{.status.phase}' 2>/dev/null)" = Running ] && break
+    sleep 3
+  done
+  # start the VNC proxy; autoboot.py self-retries the connection until it is up
+  virtctl vnc "$NAME" -n "$NS" --proxy-only --port "$PORT" >/dev/null 2>&1 &
+  vpid=$!
+  sleep 3
+  python3 "$DIR/autoboot.py" "$PORT" 160
+  rc=$?
+  kill "$vpid" >/dev/null 2>&1
+  echo "[$NAME] attempt $attempt autoboot rc=$rc"
+  [ "$rc" = 0 ] && { echo "[$NAME] in Setup"; exit 0; }
+done
+echo "[$NAME] FAILED to reach Setup after retries"; exit 1

--- a/test-workloads/windows-vms/examples/vm-template.yaml
+++ b/test-workloads/windows-vms/examples/vm-template.yaml
@@ -1,0 +1,103 @@
+apiVersion: kubevirt.io/v1
+kind: VirtualMachine
+metadata:
+  name: @@NAME@@
+  namespace: windows-images
+  labels:
+    app.kubernetes.io/part-of: windows-vm-verify
+    windows-edition: "@@NAME@@"
+spec:
+  runStrategy: RerunOnFailure
+  preference:
+    kind: virtualmachineclusterpreference
+    name: @@PREFERENCE@@
+  dataVolumeTemplates:
+  - metadata:
+      name: @@NAME@@-rootdisk
+    spec:
+      source:
+        blank: {}
+      storage:
+        resources:
+          requests:
+            storage: 50Gi
+  template:
+    metadata:
+      labels:
+        kubevirt.io/domain: @@NAME@@
+    spec:
+      # Keep Windows VMs OFF the TrueNAS-hosted worker (nested virt unsupported).
+      # Belt-and-suspenders with the HCO workloads nodePlacement exclusion.
+      affinity:
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+              - matchExpressions:
+                  - key: kubernetes.io/hostname
+                    operator: NotIn
+                    values:
+                      # SHORT hostname — the node's kubernetes.io/hostname label is
+                      # "truenas-w1", not the FQDN (verified on the live cluster;
+                      # every other node uses its FQDN). FQDN here silently never
+                      # matches, so the exclusion is a no-op. See README / #420.
+                      - truenas-w1
+      domain:
+        cpu:
+          # windows.11 client preference requires the 2 vCPUs presented as
+          # sockets (server preferences accept it too). Win11 supports 2 sockets.
+          cores: 1
+          sockets: 2
+          threads: 1
+        memory:
+          guest: 6Gi
+        firmware:
+          # Non-persistent EFI: NVRAM lives in the virt-launcher for the life of
+          # the VMI and survives guest reboots (install completes fine). Only a
+          # full VM stop/start resets it — acceptable for install-and-verify.
+          # secureBoot required for Windows 11 client install; harmless for Server.
+          bootloader:
+            efi:
+              secureBoot: true
+        features:
+          smm:
+            enabled: true
+          acpi: {}
+        devices:
+          # Non-persistent vTPM (satisfies Win 11 TPM 2.0 install check).
+          tpm: {}
+          disks:
+          - name: rootdisk
+            bootOrder: 1
+            disk:
+              bus: sata
+          - name: installcd
+            bootOrder: 2
+            cdrom:
+              bus: sata
+          - name: virtiodrivers
+            cdrom:
+              bus: sata
+          - name: sysprep
+            cdrom:
+              bus: sata
+          interfaces:
+          - name: default
+            masquerade: {}
+            model: e1000e
+      networks:
+      - name: default
+        pod: {}
+      volumes:
+      - name: rootdisk
+        dataVolume:
+          name: @@NAME@@-rootdisk
+      - name: installcd
+        persistentVolumeClaim:
+          claimName: @@ISOPVC@@
+      - name: virtiodrivers
+        containerDisk:
+          image: registry.redhat.io/container-native-virtualization/virtio-win-rhel9@sha256:cc98b37978b84b5fe7127c08d52a09c8c136c61ae51085a3f3180e3e11275497
+      - name: sysprep
+        sysprep:
+          configMap:
+            name: @@NAME@@-unattend

--- a/test-workloads/windows-vms/kustomization.yaml
+++ b/test-workloads/windows-vms/kustomization.yaml
@@ -1,0 +1,10 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+# Testing-only Windows VM workloads (igou-io/igou-openshift#380). Apply directly:
+#   oc apply -k test-workloads/windows-vms/
+# The namespace + ISO DataVolumes are the git-managed set. Per-edition installer
+# VMs are inherently imperative (see examples/) and are created per test run.
+resources:
+  - namespace.yaml
+  - datavolumes.yaml

--- a/test-workloads/windows-vms/namespace.yaml
+++ b/test-workloads/windows-vms/namespace.yaml
@@ -1,0 +1,7 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: windows-images
+  labels:
+    kubernetes.io/metadata.name: windows-images
+    app.kubernetes.io/part-of: windows-vms


### PR DESCRIPTION
Implements #380 Phase 2/3 (test-workloads). Adds `windows-images` namespace + CDI DataVolumes (HTTP import from public.igou.systems) for all seven Microsoft eval ISOs, plus `examples/` with the parameterized VM template, server/client `autounattend.xml`, and the `autoboot.py` CD-prompt helper.

All seven editions (Server 2016/2019/2022/2025 + Win11 25H2/LTSC2024/IoT-LTSC2024) were deployed and verified booting on the `ocp` cluster with this pattern. VMs use non-persistent vTPM/EFI (no dependency on #417) and `NotIn truenas-w1` affinity.

Depends on the public.igou.systems publish pipeline for the HTTP-import DataVolumes (igou-ansible + igou-inventory quota bump); live verification used `virtctl image-upload` in the meantime.

🤖 Generated with [Claude Code](https://claude.com/claude-code)