### PR TITLE
fix(openshift-virt): stop CDI pods from waking the casval burst worker

### DIFF
--- a/components/openshift-virt/kubevirt-hyperconverged.yml
+++ b/components/openshift-virt/kubevirt-hyperconverged.yml
@@ -6,6 +6,25 @@ metadata:
   annotations:
     argocd.argoproj.io/sync-wave: "3"
     argocd.argoproj.io/sync-options: SkipDryRunOnMissingResource=true
+    # HCO copies spec.workloads.nodePlacement verbatim onto every workload
+    # component it manages, including the CDI CR. That made transient CDI pods
+    # (importer-prime / cdi-upload-prime) tolerate casval's workload=burst
+    # taint, so the CAPI cluster-autoscaler treated the casval-worker node
+    # group as a valid home for them and booted the burst node during plain
+    # DataVolume imports/clones (3x on 2026-07-09, each node came up empty and
+    # was scaled back down ~40min later). Strip the tolerations from the CDI CR
+    # only: virt-handler keeps them (it must run on casval for opt-in VMs to
+    # schedule there, and DaemonSet pods never trigger autoscaler scale-up),
+    # while CDI worker pods stay on the always-on workers. Note: HCO reports
+    # jsonpatch annotations as an unsupported modification
+    # (kubevirt_hco_unsafe_modification_count metric) — accepted trade-off.
+    containerizeddataimporter.kubevirt.io/jsonpatch: |-
+      [
+        {
+          "op": "remove",
+          "path": "/spec/workload/tolerations"
+        }
+      ]
 spec:
   # This cluster does NOT support live migration by design: we run RWO block
   # storage only (no RWX block), so VM disks can't be shared across nodes and
@@ -24,7 +43,9 @@ spec:
   # Allow virt-handler (and virt-launcher pods it spawns) onto the casval burst
   # worker, which carries workload=burst:NoSchedule from the CAPI MachineSet.
   # HCO propagates this to the virt-handler DaemonSet so VMs that opt in via
-  # matching nodeSelector + toleration can run there.
+  # matching nodeSelector + toleration can run there. CDI is deliberately
+  # excluded via the containerizeddataimporter.kubevirt.io/jsonpatch
+  # annotation above — see the comment there.
   workloads:
     nodePlacement:
       # Keep virt-handler (and therefore VM scheduling) OFF truenas-w1:


### PR DESCRIPTION
## Problem

The `casval-worker` burst machineset scaled 0→1 three times on 2026-07-09 (21:22, 22:44, 23:49 UTC) with nothing to run — each node came up empty and was scale-down-deleted ~40 minutes later. Every scale-up was triggered by a transient CDI pod (`importer-prime-*` / `cdi-upload-prime-*`) from DataVolume imports/clones in `windows-images` (autoscaler `TriggeredScaleUp` events confirm all three).

## Cause

HCO copies `spec.workloads.nodePlacement` verbatim onto every workload component it manages, including the CDI CR. The `workload=burst:NoSchedule` toleration — added so virt-handler can run on casval — therefore also landed on CDI worker pods. While a prime pod waits on its NVMe-oF PVC to bind it sits unschedulable, and the CAPI cluster-autoscaler sees a pending pod that tolerates casval's taint → boots the burst node. The real scheduler then places the pod on an always-on worker as soon as the PVC binds, leaving casval empty.

## Fix

Strip `tolerations` from the CDI CR only, using HCO's `containerizeddataimporter.kubevirt.io/jsonpatch` annotation:

- virt-handler keeps the toleration — it must run on casval for opt-in burst VMs, and DaemonSet pods never trigger autoscaler scale-up, so it's harmless there
- CDI importer/upload/clone pods lose it and stay on the always-on workers (they have no reason to run on casval)
- The truenas-w1 node-affinity exclusion still propagates to CDI unchanged

Trade-off: HCO flags jsonpatch annotations as an "unsupported modification" (surfaces via the `kubevirt_hco_unsafe_modification_count` metric). It's the only mechanism to diverge one component from `workloads.nodePlacement`, since HCO reverts direct edits to the CDI CR.

## Validation

- `make test` green locally (yamllint, kustomize build, kubeconform, helm lint)
- Trigger chain verified live: autoscaler logs, `TriggeredScaleUp` events, and the toleration present on the in-cluster CDI CR

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JBjk9QNFLZnMqrMrrjAxTm