### PR TITLE
fix(openshift-virt): truenas-w1 exclusion uses wrong hostname (FQDN vs short label)

### DIFF
--- a/components/openshift-virt/kubevirt-hyperconverged.yml
+++ b/components/openshift-virt/kubevirt-hyperconverged.yml
@@ -60,7 +60,7 @@ spec:
                   - key: kubernetes.io/hostname
                     operator: NotIn
                     values:
-                      - truenas-w1.igou.systems
+                      - truenas-w1
       tolerations:
         - key: workload
           operator: Equal


### PR DESCRIPTION
The HCO `workloads.nodePlacement` excludes `truenas-w1.igou.systems`, but that node's `kubernetes.io/hostname` label is **`truenas-w1`** (short name — every other node uses its FQDN). The `NotIn` never matches, so the exclusion silently does nothing: virt-handler runs on truenas-w1, and CDI importer/uploader pods schedule there too (where they fail readiness on that node's networking and stall image uploads). HCO propagates this placement to KubeVirt + CDI, so this one-line fix corrects VM, virt-handler, and CDI pod placement. Discovered while deploying Windows VMs (#380).

🤖 Generated with [Claude Code](https://claude.com/claude-code)