### PR TITLE
fix(uwm): pin action:replace on netdata disk metricRelabeling (SSA drift)

### DIFF
--- a/components/user-workload-monitoring/exporters/truenas/truenas-netdata.yaml
+++ b/components/user-workload-monitoring/exporters/truenas/truenas-netdata.yaml
@@ -62,7 +62,11 @@ spec:
           targetLabel: instance
           replacement: truenas.igou.systems
       metricRelabelings:
-        - sourceLabels: [chart]
+        # action: replace is the CRD default - set explicitly (as above) so
+        # the rendered manifest matches the live object and ArgoCD stays
+        # Synced instead of perpetually OutOfSync on the defaulted field.
+        - action: replace
+          sourceLabels: [chart]
           regex: '.*_serial(?:_lunid)?_([^_]+).*'
           targetLabel: disk
           replacement: '${1}'


### PR DESCRIPTION
Follow-up to #423's rollout: `user-workload-monitoring` sat permanently OutOfSync because the truenas-netdata ServiceMonitor's `metricRelabelings` entry omits `action`, which the CRD defaults to `replace` server-side — live always differs from git on that one field. One-line pin, same pattern the sibling `relabelings` entry (and the new truenas-zfs ServiceMonitor) already use.

Verified semantically: git spec == live spec after this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WUtdajwapSxyjYzcZdzVHE