### PR TITLE
fix(grafana): truenas-zfs capacity panels use dataset accounting, not raw zpool

### DIFF
--- a/components/grafana/dashboards/truenas-zfs.json
+++ b/components/grafana/dashboards/truenas-zfs.json
@@ -74,7 +74,7 @@
     },
     {
       "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
-      "description": "Allocated / size per pool.",
+      "description": "Root-dataset used / (used + available) - matches the TrueNAS UI. Includes zvol refreservations (committed but unwritten) and, for RAIDZ, uses usable rather than parity-inclusive raw bytes; zpool-level alloc/size reads lower and understates real exposure.",
       "fieldConfig": {
         "defaults": {
           "color": { "mode": "thresholds" },
@@ -112,7 +112,7 @@
         {
           "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
           "editorMode": "code",
-          "expr": "100 * zfs_pool_allocated_bytes{pool=~\"$pool\"} / zfs_pool_size_bytes{pool=~\"$pool\"}",
+          "expr": "100 * zfs_dataset_used_bytes{pool=~\"$pool\",type=\"filesystem\",name!~\".+/.+\"} / (zfs_dataset_used_bytes{pool=~\"$pool\",type=\"filesystem\",name!~\".+/.+\"} + zfs_dataset_available_bytes{pool=~\"$pool\",type=\"filesystem\",name!~\".+/.+\"})",
           "legendFormat": "{{pool}}",
           "range": true,
           "refId": "A"
@@ -782,7 +782,7 @@
     },
     {
       "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
-      "description": "Provisioned zvol size vs pool free - CSI volumes are thin, >1 means overcommitted.",
+      "description": "Provisioned zvol size vs usable free space (root-dataset available, not raw zpool free - raw includes RAIDZ parity and overstates headroom). CSI volumes are thin, >1 means overcommitted.",
       "fieldConfig": {
         "defaults": {
           "color": { "mode": "palette-classic" },
@@ -830,7 +830,7 @@
         {
           "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
           "editorMode": "code",
-          "expr": "sum by (pool) (zfs_dataset_volume_size_bytes{type=\"volume\"}) / on (pool) zfs_pool_free_bytes",
+          "expr": "sum by (pool) (zfs_dataset_volume_size_bytes{type=\"volume\"}) / on (pool) zfs_dataset_available_bytes{type=\"filesystem\",name!~\".+/.+\"}",
           "legendFormat": "{{pool}}",
           "range": true,
           "refId": "A"


### PR DESCRIPTION
Follow-up to #423. The **Capacity used** panel read from `zpool_allocated/size` (raw allocation): ssd showed **17.7%** while the TrueNAS UI shows **22.6%**. The UI uses root-dataset `used/(used+available)`, which is also the operationally correct basis:

- includes zvol **refreservations** (~83 GiB committed-but-unwritten on ssd right now) — space the allocator cannot hand out;
- for RAIDZ uses **usable** rather than parity-inclusive raw bytes (cold: 9.4 TiB usable free vs 14.3 TiB raw).

Changes (4 lines — two exprs + two descriptions):
- Capacity used → `zfs_dataset_used_bytes / (used + available)` on root datasets (`name!~".+/.+"`, so no per-pool hardcoding).
- Zvol thin-provision exposure denominator → root-dataset `available` instead of `zfs_pool_free_bytes` (raw free overstated cold headroom ~52%).

Live-verified against the box: new capacity expr returns ssd 22.56% / cold 20.56% / fast 0.08% / boot-pool 56.5%, matching `zfs list -p used,avail` exactly; overcommit returns ssd 0.70, fast 0.017. Remaining Row-1/2 readings validated accurate as-is (fragmentation, freeing, ARC size exact; IOPS/throughput magnitudes consistent with `zpool iostat`, noting rules sum physical per-disk ops so mirrors count both sides).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WUtdajwapSxyjYzcZdzVHE