### PR TITLE
fix(openshift-virt): make CDI toleration strip actually apply (jsonpatch replace, not remove)

### DIFF
--- a/components/openshift-virt/kubevirt-hyperconverged.yml
+++ b/components/openshift-virt/kubevirt-hyperconverged.yml
@@ -18,11 +18,22 @@ metadata:
     # while CDI worker pods stay on the always-on workers. Note: HCO reports
     # jsonpatch annotations as an unsupported modification
     # (kubevirt_hco_unsafe_modification_count metric) — accepted trade-off.
+    #
+    # This must be "replace" with an empty list, NOT "remove": HCO applies the
+    # patch to the marshaled desired CDI and then json.Unmarshals the result
+    # back into the same populated Go struct (applyAnnotationPatch in
+    # controllers/operands/operand.go). Go's Unmarshal leaves struct fields
+    # untouched when their key is absent from the JSON, so a removed key
+    # silently keeps its old value — "remove" ops are no-ops for every HCO
+    # jsonpatch annotation. "replace" keeps the key present so the unmarshal
+    # actually clears the field, and HCO's ReformatObj normalizes the empty
+    # list back to nil, so the operand doesn't flap.
     containerizeddataimporter.kubevirt.io/jsonpatch: |-
       [
         {
-          "op": "remove",
-          "path": "/spec/workload/tolerations"
+          "op": "replace",
+          "path": "/spec/workload/tolerations",
+          "value": []
         }
       ]
 spec:


### PR DESCRIPTION
## Problem

#419 merged and is live on the HyperConverged CR (`TaintedConfiguration=True`, `kubevirt_hco_unsafe_modifications=1`), but it never took effect: the CDI CR still carries the `workload=burst:NoSchedule` toleration, and the casval burst worker scaled up again on 2026-07-10 ~12:55 UTC when the two `windows-images` ISO DataVolume imports spawned `importer-prime-*` pods (autoscaler event: `pod triggered scale-up: [{MachineSet/openshift-cluster-api/casval-worker 0->1 (max: 1)}]`). Both prime pods scheduled on hpg5 anyway — the burst node came up empty, as before.

## Root cause

`op: remove` is a **silent no-op in every HCO jsonpatch annotation**. `applyAnnotationPatch` (HCO `controllers/operands/operand.go`, same on release-1.17 / CNV 4.21) marshals the desired CDI object to JSON, applies the patch — the key is genuinely removed — then `json.Unmarshal`s the result **back into the same populated Go struct**. Go's Unmarshal leaves struct fields untouched when their key is absent from the JSON, so the tolerations slice survives. Desired == existing, HCO logs `CDI already exists` every reconcile, never updates, never errors — which is why CI, the admission webhook, and the operator all looked green on #419.

## Fix

Switch the patch to `op: replace` with `value: []`. The key stays present in the patched JSON, so the unmarshal actually overwrites the field. HCO's `ReformatObj` round-trips the desired object afterward, normalizing the empty list back to nil, so the operand won't flap between reconciles.

## Verification (post-merge/sync)

```
oc get cdi cdi-kubevirt-hyperconverged -o jsonpath='{.spec.workload.tolerations}'   # expect empty
```

Then confirm the next CDI import no longer emits a `TriggeredScaleUp` event for `casval-worker`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012fKDW34NvZrqbMdLNroEVg