### PR TITLE
feat(monitoring): SAS backplane aggregate throughput panel + recording rule

### DIFF
--- a/components/grafana/dashboards/truenas-zfs.json
+++ b/components/grafana/dashboards/truenas-zfs.json
@@ -1239,6 +1239,65 @@
       ],
       "title": "Storage NIC throughput + drops",
       "type": "timeseries"
+    },
+    {
+      "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
+      "description": "Aggregate read/write across all 12 drives on the SAS backplane (826EL1 expander behind the SAS3008) - ssd EVOs, BX500 scratch, cold members, and spares; SATADOM and NVMe do not ride this fabric. Full duplex: each direction is independently capped. Dashed lines: ~6.8 GB/s practical / 7.88 GB/s raw PCIe Gen3 x8 (the binding hop; the 8x12Gb SAS uplink is 9.6 GB/s). Current drive population tops out ~3.9 GB/s aggregate, so sustained values near the lines mean the fabric, not the drives, is the story.",
+      "fieldConfig": {
+        "defaults": {
+          "color": { "mode": "palette-classic" },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 10,
+            "gradientMode": "none",
+            "hideFrom": { "legend": false, "tooltip": false, "viz": false },
+            "insertNulls": false,
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": { "type": "linear" },
+            "showPoints": "never",
+            "spanNulls": false,
+            "stacking": { "group": "A", "mode": "none" },
+            "thresholdsStyle": { "mode": "dashed" }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              { "color": "green", "value": 0 },
+              { "color": "yellow", "value": 6800000000 },
+              { "color": "red", "value": 7880000000 }
+            ]
+          },
+          "unit": "Bps"
+        },
+        "overrides": []
+      },
+      "gridPos": { "h": 8, "w": 24, "x": 0, "y": 75 },
+      "id": 105,
+      "options": {
+        "legend": { "calcs": ["lastNotNull", "max"], "displayMode": "list", "placement": "bottom", "showLegend": true },
+        "tooltip": { "hideZeros": false, "mode": "multi", "sort": "desc" }
+      },
+      "pluginVersion": "12.1.0",
+      "targets": [
+        {
+          "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
+          "editorMode": "code",
+          "expr": "sas:truenas_backplane_throughput_bytes:sum",
+          "legendFormat": "{{dimension}}",
+          "range": true,
+          "refId": "A"
+        }
+      ],
+      "title": "SAS backplane aggregate throughput (vs PCIe Gen3 x8 cap)",
+      "type": "timeseries"
     }
   ],
   "refresh": "30s",

--- a/components/user-workload-monitoring/exporters/truenas/truenas-prometheusrule.yaml
+++ b/components/user-workload-monitoring/exporters/truenas/truenas-prometheusrule.yaml
@@ -269,3 +269,17 @@ spec:
           expr: sum by (pool, dimension) (disk:truenas_disk_throughput_bytes)
         - record: pool:truenas_disk_iops:sum
           expr: sum by (pool, dimension) (disk:truenas_disk_iops)
+    # Aggregate throughput across EVERY drive on the SAS backplane
+    # (826EL1 expander behind the SAS3008), regardless of pool membership:
+    # ssd EVOs + BX500 scratch + cold members + both spares. Excluded: the
+    # SATADOM (mobo ata9) and all NVMe - they do not ride this fabric.
+    # Ceiling per direction (full duplex, verified 2026-07-10): HBA uplink
+    # 8x12Gb wide port = 9.6 GB/s; binding cap = PCIe Gen3 x8 = 7.88 GB/s
+    # raw / ~6.8 GB/s practical. Current 12-drive population tops out
+    # ~3.9 GB/s, so this is capacity-planning telemetry, not an alert basis.
+    - name: truenas.recording.backplane
+      rules:
+        - record: sas:truenas_backplane_throughput_bytes:sum
+          expr: >
+            sum by (dimension, instance) ({__name__=~"netdata_Read_Write_for_disk_.*_KiB_persec_average",
+            disk=~"S753NS0X206644B|S753NS0X206645D|2515E9B3E0E1|2515E9B3E121|ZC16MM71|YVKX3BSK|YVKU4R7K|YHJBKNGA|YHJDPJTA|PN2234P9JSE1UW|ZC16Q4Z6|P9JTUH8W"}) * 1024


### PR DESCRIPTION
Adds fabric-level congestion visibility to the TrueNAS ZFS & Storage Health dashboard (igou-io/igou-inventory#154 follow-up).

**Verified topology** (live via sysfs, 2026-07-10): 12 drive bays → BPN-SAS3-826EL1 (28 phys, all trained 12 Gb) → SAS3008 over an **8×12 Gb wide port** (9.6 GB/s usable) → **PCIe Gen3 x8** negotiated (7.88 GB/s raw / ~6.8 GB/s practical) — PCIe is the binding hop, per direction (full duplex).

- New recording rule `sas:truenas_backplane_throughput_bytes:sum` (group `truenas.recording.backplane`): sums per-disk read/write across **every** backplane drive regardless of pool membership — ssd EVOs, BX500 scratch, cold members, both spares. SATADOM (mobo ata9) and NVMe excluded: different fabrics. Serial list documented in-file alongside the pool groups.
- New full-width Row 5 panel "SAS backplane aggregate throughput (vs PCIe Gen3 x8 cap)" with dashed lines at 6.8 GB/s (practical) and 7.88 GB/s (raw).

Context in panel description: current 12-drive population can only generate ~3.9 GB/s aggregate, so the fabric cannot congest today — the panel is capacity-planning telemetry for when HDD bays become SSDs (or the 25G NICs light up).

Live-tested the expr via thanos before vendoring: returns reads/writes per second across the 12-drive set (idle sample ~3.6 MB/s writes).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WUtdajwapSxyjYzcZdzVHE