### PR TITLE
feat(service-accounts): let ansible-molecule boot VMs from golden images

### DIFF
--- a/components/service-accounts/values.yaml
+++ b/components/service-accounts/values.yaml
@@ -43,6 +43,32 @@ clusterRoles:
         verbs:
           - get
           - list
+      # DataVolumes let molecule scenarios boot from CDI-managed golden images
+      # (dataVolumeTemplates on the VM). Paired with golden-image-cloner below
+      # for the cross-namespace clone authorization.
+      - apiGroups:
+          - cdi.kubevirt.io
+        resources:
+          - datavolumes
+        verbs:
+          - get
+          - list
+          - watch
+          - create
+          - delete
+
+  # CDI cross-namespace clone authorization: creating a DataVolume that clones
+  # from another namespace requires `datavolumes/source create` in the SOURCE
+  # namespace. Bound to ansible-molecule in openshift-virtualization-os-images
+  # so molecule VMs can boot from the DataImportCron golden images.
+  - name: golden-image-cloner
+    rules:
+      - apiGroups:
+          - cdi.kubevirt.io
+        resources:
+          - datavolumes/source
+        verbs:
+          - create
 
   - name: virtualmachine-reader
     rules:
@@ -205,6 +231,9 @@ serviceAccounts:
       - namespace: molecule
         clusterRoles:
           - molecule-kubernetes
+      - namespace: openshift-virtualization-os-images
+        clusterRoles:
+          - golden-image-cloner
     clusterRoleBindings:
       - name: ansible-molecule-node-reader
         clusterRole: system:node-reader


### PR DESCRIPTION
RBAC prerequisite for golden-image boot parity in the igou-ansible `devenv-e2e` molecule scenario (igou-io/igou-ansible#341): the scenario currently boots `quay.io/containerdisks/centos-stream:10`, which diverges from the production `centos-stream10` DataSource golden image (the containerdisk was missing `kernel-modules-extra`, for example). Booting from the golden image requires DataVolumes with a `sourceRef`, and the `ansible-molecule` SA lacks the CDI permissions.

## Changes

- `molecule-kubernetes` (bound only in the `molecule` namespace): add `cdi.kubevirt.io/datavolumes` get/list/watch/create/delete for VM `dataVolumeTemplates`.
- New `golden-image-cloner` ClusterRole — `datavolumes/source create` — bound to `ansible-molecule` in `openshift-virtualization-os-images` only. This is CDI's cross-namespace clone authorization: creating a DataVolume that clones from another namespace requires this verb in the **source** namespace.

## Validation

- `kustomize build --enable-helm components/service-accounts/` renders the new ClusterRole, the datavolumes rule, and `RoleBinding ansible-molecule-golden-image-cloner` in `openshift-virtualization-os-images` as intended; yamllint clean.
- Blast radius: the SA gains no read access to secrets/PVC contents in the golden-image namespace — only the CDI clone-source authorization subresource and namespaced DataVolume CRUD in `molecule`.

After merge + Argo sync, the devenv-e2e scenario switches its `boot_source` to the golden image (paired with a `molecule_provisioners` sourceRef feature, PR incoming).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01E111DtdewtbY27csDfJBMN