### PR TITLE
feat(service-accounts): grant ansible-molecule the windows golden-image build permissions

### DIFF
--- a/components/service-accounts/values.yaml
+++ b/components/service-accounts/values.yaml
@@ -43,6 +43,54 @@ clusterRoles:
         verbs:
           - get
           - list
+      # VMI reads let scenarios wait on install progress (phase, guest-agent
+      # AgentConnected condition) — the VMI carries that status, not the VM.
+      - apiGroups:
+          - kubevirt.io
+        resources:
+          - virtualmachineinstances
+        verbs:
+          - get
+          - list
+          - watch
+      # The Windows golden-image build (igou-ansible#343) drives the VM
+      # imperatively: start/stop around sysprep, and VNC for the ISO
+      # "press any key" CD-boot keypress helper.
+      - apiGroups:
+          - subresources.kubevirt.io
+        resources:
+          - virtualmachines/start
+          - virtualmachines/stop
+          - virtualmachines/restart
+          - virtualmachineinstances/console
+          - virtualmachineinstances/vnc
+        verbs:
+          - get
+          - update
+      # Sysprep/autounattend payloads mounted into the build VM. Secrets
+      # included because the rendered autounattend carries the admin password.
+      - apiGroups:
+          - ""
+        resources:
+          - configmaps
+          - secrets
+        verbs:
+          - get
+          - list
+          - watch
+          - create
+          - delete
+          - patch
+          - update
+      # Read-only: watch DV-owned PVCs reach Bound during import/clone.
+      - apiGroups:
+          - ""
+        resources:
+          - persistentvolumeclaims
+        verbs:
+          - get
+          - list
+          - watch
       # DataVolumes let molecule scenarios boot from CDI-managed golden images
       # (dataVolumeTemplates on the VM). Paired with golden-image-cloner below
       # for the cross-namespace clone authorization.
@@ -56,11 +104,35 @@ clusterRoles:
           - watch
           - create
           - delete
+      # Same-namespace clone authorization (capture the generalized disk and
+      # boot verify VMs from it, all inside the molecule namespace).
+      - apiGroups:
+          - cdi.kubevirt.io
+        resources:
+          - datavolumes/source
+        verbs:
+          - create
+      # Golden images built by molecule are published as DataSources in the
+      # molecule namespace itself — never in openshift-virtualization-os-images.
+      - apiGroups:
+          - cdi.kubevirt.io
+        resources:
+          - datasources
+        verbs:
+          - get
+          - list
+          - watch
+          - create
+          - delete
+          - patch
+          - update
 
   # CDI cross-namespace clone authorization: creating a DataVolume that clones
   # from another namespace requires `datavolumes/source create` in the SOURCE
-  # namespace. Bound to ansible-molecule in openshift-virtualization-os-images
-  # so molecule VMs can boot from the DataImportCron golden images.
+  # namespace, plus read on the source DataVolume to check it is ready. Bound
+  # to ansible-molecule in openshift-virtualization-os-images (boot from the
+  # DataImportCron golden images) and in windows-images (clone the installer
+  # ISO DVs into the molecule namespace for the golden-image build).
   - name: golden-image-cloner
     rules:
       - apiGroups:
@@ -69,6 +141,14 @@ clusterRoles:
           - datavolumes/source
         verbs:
           - create
+      - apiGroups:
+          - cdi.kubevirt.io
+        resources:
+          - datavolumes
+        verbs:
+          - get
+          - list
+          - watch
 
   - name: virtualmachine-reader
     rules:
@@ -232,6 +312,11 @@ serviceAccounts:
         clusterRoles:
           - molecule-kubernetes
       - namespace: openshift-virtualization-os-images
+        clusterRoles:
+          - golden-image-cloner
+      # Source-side grant for the windows-build-golden-image scenario: clone
+      # the installer ISO DataVolumes into the molecule build namespace.
+      - namespace: windows-images
         clusterRoles:
           - golden-image-cloner
     clusterRoleBindings:


### PR DESCRIPTION
## Summary

Pre-flight RBAC for **igou-io/igou-ansible#343 phase 1** (the `windows-build-golden-image` molecule scenario). The scenario clones a preexisting installer ISO DataVolume from `windows-images` into the `molecule` namespace, installs Windows in a build VM, syspreps, captures the generalized disk, and publishes it as a `DataSource`.

**Scope decision: the golden image is published in the `molecule` namespace, not `openshift-virtualization-os-images`.** The test SA gets no write access to the real boot-source namespace; populating the stock `win*` DataSources remains a production-playbook concern with a differently-scoped account.

## What changed

Validated with `oc auth can-i` as `system:serviceaccount:service-accounts:ansible-molecule` — #428 granted only the *consume* direction (boot VMs **from** golden images). The build additionally needs, and this PR adds:

`molecule-kubernetes` ClusterRole (bound in `molecule`):
- `virtualmachineinstances` get/list/watch — poll install progress / guest-agent `AgentConnected`
- `subresources.kubevirt.io` `virtualmachines/{start,stop,restart}`, `virtualmachineinstances/{console,vnc}` — drive the VM around sysprep; VNC is the ISO "press any key" CD-boot keypress helper
- `configmaps` + `secrets` CRUD — rendered sysprep/autounattend payloads (secret because it carries the admin password)
- `persistentvolumeclaims` get/list/watch — watch DV-owned PVCs reach Bound
- `datavolumes/source` create — same-namespace capture/verify clones
- `datasources` CRUD — publish the golden image in-namespace

`golden-image-cloner` ClusterRole:
- adds `datavolumes` get/list/watch (see/readiness-check the source you may clone)
- now **also bound in `windows-images`** — CDI authorizes cross-namespace clones against `datavolumes/source create` in the *source* namespace

## Validation

- `kustomize build --enable-helm` renders cleanly; new RoleBinding `windows-images/ansible-molecule-golden-image-cloner` and the extended rules confirmed in the rendered output
- repo `yamllint` green
- Post-merge check: re-run the `oc auth can-i` matrix as the SA (VMI read, vnc subresource, configmaps in `molecule`; `datavolumes.cdi.kubevirt.io/source` create in `windows-images` — note the `resource.group/subresource` syntax)

Relates igou-io/igou-ansible#343 · follows #428

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018HvzcoALBzEpwoBvuqFegi