### PR TITLE
fix(service-accounts): datavolumes patch/update for molecule re-runs

### DIFF
--- a/components/service-accounts/values.yaml
+++ b/components/service-accounts/values.yaml
@@ -93,7 +93,10 @@ clusterRoles:
           - watch
       # DataVolumes let molecule scenarios boot from CDI-managed golden images
       # (dataVolumeTemplates on the VM). Paired with golden-image-cloner below
-      # for the cross-namespace clone authorization.
+      # for the cross-namespace clone authorization. patch/update are needed
+      # for re-runnability: kubernetes.core.k8s state=present PATCHes an
+      # existing object, so a second run over a leftover DataVolume is
+      # forbidden without them (hit live by windows-build-golden-image).
       - apiGroups:
           - cdi.kubevirt.io
         resources:
@@ -104,6 +107,8 @@ clusterRoles:
           - watch
           - create
           - delete
+          - patch
+          - update
       # Same-namespace clone authorization (capture the generalized disk and
       # boot verify VMs from it, all inside the molecule namespace).
       - apiGroups:


### PR DESCRIPTION
Follow-up to #429, hit live during the first `windows-build-golden-image` e2e (igou-io/igou-ansible#343 phase 1):

`kubernetes.core.k8s state=present` issues a **PATCH** when the object already exists, so a second converge over a leftover DataVolume dies with `cannot patch resource "datavolumes"`. Re-runnability is an explicit requirement of the golden-image spec ("pointing at a refreshed ISO rebuilds + republishes"). VMs, services, configmaps/secrets, and datasources in `molecule-kubernetes` already carry `patch`/`update` — datavolumes were the one gap.

Adds `patch` + `update` to the `cdi.kubevirt.io/datavolumes` rule in `molecule-kubernetes`, with a comment recording why.

Validation: `kustomize build --enable-helm` renders clean, repo `yamllint` green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018HvzcoALBzEpwoBvuqFegi