### PR TITLE
feat(windows-vms): re-point installer ISO DVs to no-prompt remastered media

### DIFF
--- a/test-workloads/windows-vms/README.md
+++ b/test-workloads/windows-vms/README.md
@@ -32,14 +32,20 @@ for testing (see below).
 
 - `namespace.yaml` — the `windows-images` namespace.
 - `datavolumes.yaml` — **only two** CDI DataVolumes, the standing library kept
-  live on the cluster: the **latest Server** (`iso-winserver2025-eval`) and the
-  **latest desktop** (`iso-win11-25h2-enterprise-eval`). Each imports over HTTP
-  from `public.igou.systems` onto the **cold pool over NFS**
-  (`freenas-nfs-cold-csi`) — bulk read-mostly ISOs belong on cold RAIDZ2, and NFS
-  gives RWX so several test VMs can share one ISO cdrom. Applied via
-  `kustomization.yaml`: `oc apply -k test-workloads/windows-vms/`. The ISOs are
-  published on `public.igou.systems` (hydrated from the igounas archive), so these
-  imports resolve as-is.
+  live on the cluster: the **latest Server** (`iso-winserver2025-eval-noprompt`)
+  and the **latest desktop** (`iso-win11-25h2-enterprise-eval-noprompt`). Both
+  point at the **`-noprompt` remastered media** — the "Press any key to boot from
+  CD" prompt is compiled into the shipped `cdboot.efi`, so the remaster swaps in
+  Microsoft's shipped-but-undocumented `efisys_noprompt.bin`/`cdboot_noprompt.efi`
+  so EFI VMs enter Setup hands-free (feedstock for igou-ansible's declarative
+  `build_windows_golden.yml`; produced by
+  `playbooks/truenas/publish_windows_isos.yml`). Each imports over HTTP from
+  `public.igou.systems` onto the **cold pool over NFS** (`freenas-nfs-cold-csi`) —
+  bulk read-mostly ISOs belong on cold RAIDZ2, and NFS gives RWX so several test
+  VMs can share one ISO cdrom. Applied via `kustomization.yaml`:
+  `oc apply -k test-workloads/windows-vms/`. The ISOs are published on
+  `public.igou.systems` (hydrated from the igounas archive), so these imports
+  resolve as-is.
 
 Deliberately **not** GitOps-managed:
 - The other five editions (older Server, Win11 LTSC/IoT). They were all verified
@@ -85,6 +91,13 @@ Deliberately **not** GitOps-managed:
 - **`boot-vm.sh`** — **the reliable driver.** `autoboot.py` alone is a timing
   gamble; this wrapper force power-cycles the VM and retries `autoboot.py` until
   Setup appears. Use this, not bare `autoboot.py`.
+
+> **`-noprompt` media makes the keypress dance unnecessary.** The standing
+> DataVolumes (`iso-*-noprompt`) boot straight into Setup with no "Press any key"
+> prompt, so `autoboot.py`/`boot-vm.sh` are **not needed** when a VM attaches one
+> of them. The keypress kit is kept only for **pristine** (un-remastered) ISOs —
+> e.g. an on-demand edition uploaded straight from the Evaluation Center that
+> still carries the prompt-compiled `cdboot.efi`.
 
 ### Reproduce one edition (hands-free path, works today)
 

--- a/test-workloads/windows-vms/datavolumes.yaml
+++ b/test-workloads/windows-vms/datavolumes.yaml
@@ -14,18 +14,28 @@
 # Other editions (older Server/desktop, LTSC, IoT) are NOT kept live — publish
 # them to public.igou.systems and image-upload/DV on demand for hands-on testing
 # (see examples/ + README). Only these two are the standing library.
+#
+# -noprompt media: the "Press any key to boot from CD or DVD" prompt is compiled
+# into the shipped cdboot.efi, so a headless EFI VM misses the keypress and drops
+# to no-boot. Microsoft ships (but does not document) efisys_noprompt.bin /
+# cdboot_noprompt.efi that boot straight into Setup with no keypress; the
+# remaster swaps those in so EFI VMs enter Setup hands-free. This is a feedstock
+# requirement for igou-ansible's declarative golden-image path
+# (build_windows_golden.yml) — no autoboot.py/boot-vm.sh keypress dance needed.
+# The remastered ISOs are produced by igou-ansible
+# playbooks/truenas/publish_windows_isos.yml.
 ---
 apiVersion: cdi.kubevirt.io/v1beta1
 kind: DataVolume
 metadata:
-  name: iso-winserver2025-eval
+  name: iso-winserver2025-eval-noprompt
   namespace: windows-images
   annotations:
     cdi.kubevirt.io/storage.deleteAfterCompletion: "false"
 spec:
   source:
     http:
-      url: https://public.igou.systems/isos/windows/winserver2025-eval-en-us.iso
+      url: https://public.igou.systems/isos/windows/winserver2025-eval-en-us-noprompt.iso
   storage:
     storageClassName: freenas-nfs-cold-csi
     resources:
@@ -35,14 +45,14 @@ spec:
 apiVersion: cdi.kubevirt.io/v1beta1
 kind: DataVolume
 metadata:
-  name: iso-win11-25h2-enterprise-eval
+  name: iso-win11-25h2-enterprise-eval-noprompt
   namespace: windows-images
   annotations:
     cdi.kubevirt.io/storage.deleteAfterCompletion: "false"
 spec:
   source:
     http:
-      url: https://public.igou.systems/isos/windows/win11-25h2-enterprise-eval-en-us.iso
+      url: https://public.igou.systems/isos/windows/win11-25h2-enterprise-eval-en-us-noprompt.iso
   storage:
     storageClassName: freenas-nfs-cold-csi
     resources:


### PR DESCRIPTION
Increment 2 of design v3 (igou-io/igou-ansible#343). Renames the two standing installer ISO DataVolumes with a `-noprompt` suffix and re-points their URLs at the remastered media that the igou-ansible publish playbook emits (increment 1):

| Old | New |
|---|---|
| `iso-winserver2025-eval` ← `winserver2025-eval-en-us.iso` | `iso-winserver2025-eval-noprompt` ← `winserver2025-eval-en-us-noprompt.iso` |
| `iso-win11-25h2-enterprise-eval` ← `win11-25h2-enterprise-eval-en-us.iso` | `iso-win11-25h2-enterprise-eval-noprompt` ← `win11-25h2-enterprise-eval-en-us-noprompt.iso` |

Why: the CD-boot prompt is compiled into `cdboot.efi`; remastered media (shipped `_noprompt` bootloaders swapped in, xorriso repack) enters Setup hands-free, deleting the VNC keypress layer from the golden-image build (igou-ansible increment 3).

**Merge gate: after the increment-1 remaster run has produced both `-noprompt.iso` files on public.igou.systems** — merging earlier makes the new DVs 404 on import.

Note: the old live DVs persist after merge (repo-wide auto-prune disabled) and get cleaned up manually post-cutover.

Gates: `make lint` / `make validate-kustomize` / `make validate-schemas` all pass (windows-vms: 3 resources valid).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018HvzcoALBzEpwoBvuqFegi