### PR TITLE
feat(monitoring): snmp-exporter for APC AP7900 PDU via UWM

### DIFF
--- a/components/user-workload-monitoring/exporters/snmp-exporter/apc-pdu-snmp-externalsecret.yaml
+++ b/components/user-workload-monitoring/exporters/snmp-exporter/apc-pdu-snmp-externalsecret.yaml
@@ -1,0 +1,124 @@
+---
+# Renders the snmp_exporter config (snmp.yml) into a Secret. The OID/module
+# definition is non-secret and lives here; only the SNMPv1 read community is
+# pulled from 1Password (item apc-pdu-snmp in vault lab_routeros) and injected
+# into auths.apc_v1.community. The snmp-exporter Deployment mounts the rendered
+# Secret at /etc/snmp_exporter/snmp.yml (see kustomization.yaml patch).
+#
+# AP7900 = Switched Rack PDU: aggregate load only (rPDULoadStatusLoad, tenths
+# of Amps) + per-outlet on/off state (no per-outlet power). SNMPv1 only (AOS
+# 3.7.4 has no v2c). Validated end-to-end against the live PDU with
+# snmp_exporter v0.30.1 before commit.
+apiVersion: external-secrets.io/v1
+kind: ExternalSecret
+metadata:
+  name: apc-pdu-snmp-config
+  namespace: snmp-exporter
+spec:
+  refreshInterval: 1h
+  secretStoreRef:
+    kind: ClusterSecretStore
+    name: onepassword-lab-routeros
+  target:
+    name: snmp-exporter-config
+    creationPolicy: Owner
+    deletionPolicy: Retain
+    template:
+      engineVersion: v2
+      data:
+        snmp.yml: |-
+          auths:
+            apc_v1:
+              version: 1
+              community: "{{ .community }}"
+          modules:
+            apc_pdu:
+              walk:
+                - 1.3.6.1.4.1.318.1.1.12.2.3.1
+                - 1.3.6.1.4.1.318.1.1.12.3.5.1
+              get:
+                - 1.3.6.1.2.1.1.3.0
+                - 1.3.6.1.2.1.1.5.0
+                - 1.3.6.1.4.1.318.1.1.12.1.1.0
+                - 1.3.6.1.4.1.318.1.1.12.1.5.0
+                - 1.3.6.1.4.1.318.1.1.12.1.6.0
+                - 1.3.6.1.4.1.318.1.1.12.1.7.0
+                - 1.3.6.1.4.1.318.1.1.12.1.8.0
+              metrics:
+                - name: sysUpTime
+                  oid: 1.3.6.1.2.1.1.3
+                  type: gauge
+                  help: Time since the NMC was last re-initialized - 1.3.6.1.2.1.1.3
+                - name: sysName
+                  oid: 1.3.6.1.2.1.1.5
+                  type: DisplayString
+                  help: Administratively-assigned name - 1.3.6.1.2.1.1.5
+                - name: rPDUIdentName
+                  oid: 1.3.6.1.4.1.318.1.1.12.1.1
+                  type: DisplayString
+                  help: User-assigned rPDU name - 1.3.6.1.4.1.318.1.1.12.1.1
+                - name: rPDUIdentModelNumber
+                  oid: 1.3.6.1.4.1.318.1.1.12.1.5
+                  type: DisplayString
+                  help: rPDU model number - 1.3.6.1.4.1.318.1.1.12.1.5
+                - name: rPDUIdentSerialNumber
+                  oid: 1.3.6.1.4.1.318.1.1.12.1.6
+                  type: DisplayString
+                  help: rPDU serial number - 1.3.6.1.4.1.318.1.1.12.1.6
+                - name: rPDUIdentDeviceRating
+                  oid: 1.3.6.1.4.1.318.1.1.12.1.7
+                  type: gauge
+                  help: Device rating in Amps - 1.3.6.1.4.1.318.1.1.12.1.7
+                - name: rPDUIdentDeviceNumOutlets
+                  oid: 1.3.6.1.4.1.318.1.1.12.1.8
+                  type: gauge
+                  help: Number of outlets - 1.3.6.1.4.1.318.1.1.12.1.8
+                - name: rPDULoadStatusLoad
+                  oid: 1.3.6.1.4.1.318.1.1.12.2.3.1.1.2
+                  type: gauge
+                  help: Load in tenths of Amps (divide by 10) - 1.3.6.1.4.1.318.1.1.12.2.3.1.1.2
+                  indexes:
+                    - labelname: rPDULoadStatusIndex
+                      type: gauge
+                - name: rPDULoadStatusLoadState
+                  oid: 1.3.6.1.4.1.318.1.1.12.2.3.1.1.3
+                  type: EnumAsStateSet
+                  help: Overload state of the load - 1.3.6.1.4.1.318.1.1.12.2.3.1.1.3
+                  indexes:
+                    - labelname: rPDULoadStatusIndex
+                      type: gauge
+                  enum_values:
+                    1: phaseLoadNormal
+                    2: phaseLoadLow
+                    3: phaseLoadNearOverload
+                    4: phaseLoadOverload
+                - name: rPDUOutletStatusOutletName
+                  oid: 1.3.6.1.4.1.318.1.1.12.3.5.1.1.2
+                  type: DisplayString
+                  help: Outlet name - 1.3.6.1.4.1.318.1.1.12.3.5.1.1.2
+                  indexes:
+                    - labelname: rPDUOutletStatusIndex
+                      type: gauge
+                - name: rPDUOutletStatusOutletState
+                  oid: 1.3.6.1.4.1.318.1.1.12.3.5.1.1.4
+                  type: EnumAsStateSet
+                  help: Outlet switched state - 1.3.6.1.4.1.318.1.1.12.3.5.1.1.4
+                  indexes:
+                    - labelname: rPDUOutletStatusIndex
+                      type: gauge
+                  lookups:
+                    - labels: [rPDUOutletStatusIndex]
+                      labelname: rPDUOutletStatusOutletName
+                      oid: 1.3.6.1.4.1.318.1.1.12.3.5.1.1.2
+                      type: DisplayString
+                  enum_values:
+                    1: outletStatusOn
+                    2: outletStatusOff
+  data:
+    - secretKey: community
+      remoteRef:
+        key: apc-pdu-snmp
+        property: community
+        conversionStrategy: Default
+        decodingStrategy: None
+        metadataPolicy: None

--- a/components/user-workload-monitoring/exporters/snmp-exporter/kustomization.yaml
+++ b/components/user-workload-monitoring/exporters/snmp-exporter/kustomization.yaml
@@ -1,0 +1,56 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+namespace: snmp-exporter
+resources:
+  - snmp-exporter-namespace.yaml
+  - apc-pdu-snmp-externalsecret.yaml
+  - snmp-exporter-prometheusrule.yaml
+  - probes/apc-pdu-probe.yaml
+helmCharts:
+  - name: prometheus-snmp-exporter
+    namespace: snmp-exporter
+    version: 9.16.1
+    releaseName: snmp-exporter
+    repo: https://prometheus-community.github.io/helm-charts
+    valuesInline:
+      fullnameOverride: snmp-exporter
+      image:
+        registry: quay.io
+        repository: prometheus/snmp-exporter
+        tag: v0.30.1@sha256:e5fd5e8b43ace6c088fe9bf0b37b7fff0e04380bee352be7ec41b853a4dd5859
+      # config is supplied out-of-band via the ExternalSecret-rendered
+      # Secret snmp-exporter-config (mounted at /etc/snmp_exporter/snmp.yml
+      # by the patch below), so the read community never lands in git.
+      serviceMonitor:
+        enabled: false
+      resources:
+        requests:
+          cpu: 10m
+          memory: 32Mi
+        limits:
+          memory: 64Mi
+# Post-render patches:
+#   1. Mount the ESO-rendered snmp.yml over the image default config path.
+#   2. OpenShift restricted-v2 SCC assigns runAsUser from the namespace UID
+#      range; the chart hard-codes runAsUser=1000, so remove it (same shape
+#      as the blackbox-exporter precedent).
+patches:
+  - target:
+      kind: Deployment
+      name: snmp-exporter
+    patch: |
+      - op: remove
+        path: /spec/template/spec/containers/0/securityContext/runAsUser
+      - op: replace
+        path: /spec/template/spec/volumes
+        value:
+          - name: snmp-config
+            secret:
+              secretName: snmp-exporter-config
+      - op: replace
+        path: /spec/template/spec/containers/0/volumeMounts
+        value:
+          - name: snmp-config
+            mountPath: /etc/snmp_exporter/snmp.yml
+            subPath: snmp.yml
+            readOnly: true

--- a/components/user-workload-monitoring/exporters/snmp-exporter/kustomization.yaml
+++ b/components/user-workload-monitoring/exporters/snmp-exporter/kustomization.yaml
@@ -15,8 +15,7 @@ helmCharts:
     valuesInline:
       fullnameOverride: snmp-exporter
       image:
-        registry: quay.io
-        repository: prometheus/snmp-exporter
+        repository: quay.io/prometheus/snmp-exporter
         tag: v0.30.1@sha256:e5fd5e8b43ace6c088fe9bf0b37b7fff0e04380bee352be7ec41b853a4dd5859
       # config is supplied out-of-band via the ExternalSecret-rendered
       # Secret snmp-exporter-config (mounted at /etc/snmp_exporter/snmp.yml

--- a/components/user-workload-monitoring/exporters/snmp-exporter/probes/apc-pdu-probe.yaml
+++ b/components/user-workload-monitoring/exporters/snmp-exporter/probes/apc-pdu-probe.yaml
@@ -1,0 +1,34 @@
+---
+# Scrapes the APC AP7900 rack PDU (UP-HortWoods-PDU01) on VLAN60 through the
+# snmp-exporter. The Probe operator turns each staticConfig target into
+# /snmp?target=<ip>&module=apc_pdu; the relabelingConfigs add ?auth=apc_v1
+# (snmp_exporter v0.23+ split auth out of the module) and label each series
+# by the PDU it came from.
+apiVersion: monitoring.coreos.com/v1
+kind: Probe
+metadata:
+  name: apc-pdu
+  namespace: snmp-exporter
+  labels:
+    app.kubernetes.io/name: snmp-exporter
+spec:
+  interval: 60s
+  scrapeTimeout: 30s
+  module: apc_pdu
+  prober:
+    url: snmp-exporter.snmp-exporter.svc:9116
+    path: /snmp
+  targets:
+    staticConfig:
+      static:
+        - 10.10.60.22
+      labels:
+        tier: standard
+        category: power
+        owner: platform
+        device: UP-HortWoods-PDU01
+      relabelingConfigs:
+        - targetLabel: __param_auth
+          replacement: apc_v1
+        - sourceLabels: [__param_target]
+          targetLabel: instance

--- a/components/user-workload-monitoring/exporters/snmp-exporter/snmp-exporter-namespace.yaml
+++ b/components/user-workload-monitoring/exporters/snmp-exporter/snmp-exporter-namespace.yaml
@@ -1,0 +1,9 @@
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: snmp-exporter
+  labels:
+    pod-security.kubernetes.io/enforce: restricted
+    pod-security.kubernetes.io/audit: restricted
+    pod-security.kubernetes.io/warn: restricted

--- a/components/user-workload-monitoring/exporters/snmp-exporter/snmp-exporter-prometheusrule.yaml
+++ b/components/user-workload-monitoring/exporters/snmp-exporter/snmp-exporter-prometheusrule.yaml
@@ -1,0 +1,44 @@
+---
+apiVersion: monitoring.coreos.com/v1
+kind: PrometheusRule
+metadata:
+  name: snmp-exporter
+  namespace: snmp-exporter
+  labels:
+    app.kubernetes.io/name: snmp-exporter
+spec:
+  groups:
+    - name: apc-pdu.rules
+      rules:
+        - alert: APCPDUUnreachable
+          # staticConfig labels (category=power) propagate to `up`
+          expr: up{category="power"} == 0
+          for: 5m
+          labels:
+            severity: warning
+          annotations:
+            summary: APC PDU SNMP scrape failing ({{ $labels.instance }})
+            description: >-
+              snmp-exporter could not scrape the APC PDU at {{ $labels.instance }}
+              for 5 minutes. Check the PDU NMC, VLAN60 reachability, and the
+              SNMP community.
+        - alert: APCPDULoadNearOverload
+          expr: rPDULoadStatusLoadState{rPDULoadStatusLoadState="phaseLoadNearOverload"} == 1
+          for: 5m
+          labels:
+            severity: warning
+          annotations:
+            summary: APC PDU load near overload ({{ $labels.instance }})
+            description: >-
+              PDU {{ $labels.instance }} phase/bank {{ $labels.rPDULoadStatusIndex }}
+              load is near overload. Redistribute load before it trips.
+        - alert: APCPDULoadOverload
+          expr: rPDULoadStatusLoadState{rPDULoadStatusLoadState="phaseLoadOverload"} == 1
+          for: 1m
+          labels:
+            severity: critical
+          annotations:
+            summary: APC PDU load OVERLOAD ({{ $labels.instance }})
+            description: >-
+              PDU {{ $labels.instance }} phase/bank {{ $labels.rPDULoadStatusIndex }}
+              is in OVERLOAD. Shed load immediately to avoid a breaker trip.

--- a/components/user-workload-monitoring/kustomization.yaml
+++ b/components/user-workload-monitoring/kustomization.yaml
@@ -8,6 +8,7 @@ resources:
   - exporters/mktxp
   - exporters/upsmonitor
   - exporters/truenas
+  - exporters/snmp-exporter
   - servicemonitors/argocd-servicemonitor.yaml
   - servicemonitors/cert-manager-servicemonitor.yaml
   - servicemonitors/external-secrets-podmonitor.yaml


### PR DESCRIPTION
## What
Adds a prometheus-snmp-exporter (prometheus-community chart 9.16.1, snmp_exporter v0.30.1) under user-workload-monitoring, polling the APC AP7900 rack PDU (UP-HortWoods-PDU01) at 10.10.60.22 over SNMPv1. Scraped by a Probe CR, mirroring the blackbox-exporter pattern.

## Metrics (apc_pdu module)
- rPDULoadStatusLoad (aggregate load, tenths of Amps; AP7900 has no per-outlet metering)
- rPDULoadStatusLoadState (normal/low/near-overload/overload)
- rPDUOutletStatusOutletState (per-outlet on/off, joined with outlet name)
- rPDUIdent* (model/serial/rating/outlet count), sysUpTime, sysName

Validated end-to-end against the live PDU with snmp_exporter v0.30.1 before commit (OIDs, SNMPv1 auth, and outlet-state enum 1=On/2=Off all confirmed).

## How it ties together
- Read community stored in 1Password (lab_routeros/apc-pdu-snmp), injected via an ExternalSecret that templates the full snmp.yml into a Secret mounted at /etc/snmp_exporter/snmp.yml; the community never lands in git.
- Probe: ?target=10.10.60.22&module=apc_pdu&auth=apc_v1 (auth split from module in v0.23+, set via relabelingConfigs).
- SCC: strips chart-hardcoded runAsUser (restricted-v2 assigns it).
- PrometheusRule: PDU-unreachable + load near-overload/overload alerts.

## Validation
make lint, validate-kustomize (snmp-exporter OK), validate-schemas (all Valid), lint-helm (0 failed) all pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
