### PR TITLE
fix(rk8s-federate): rewrite __address__ to DNS name for Host-header routing

### DIFF
--- a/components/user-workload-monitoring/exporters/rk8s-federate/rk8s-federate.yaml
+++ b/components/user-workload-monitoring/exporters/rk8s-federate/rk8s-federate.yaml
@@ -69,6 +69,19 @@ spec:
       # insecureSkipVerify.
       tlsConfig:
         serverName: federate.rk8s.igou.systems
+      # The rk8s ingress routes /federate by HTTP Host header. A bare-IP
+      # Endpoints target makes Prometheus send `Host: 10.10.150.129` (the
+      # __address__), which the ingress answers with 404 -
+      # tlsConfig.serverName above only sets the TLS SNI, NOT the HTTP Host
+      # header. Rewrite __address__ to the DNS name so both the Host header
+      # and SNI are federate.rk8s.igou.systems; the OCP cluster resolves it to
+      # the same MetalLB VIP (10.10.150.129) and routes there directly over
+      # the LAN. Target discovery still comes from the bare-IP Endpoints above
+      # - this only fixes the scrape connection's Host header.
+      relabelings:
+        - action: replace
+          targetLabel: __address__
+          replacement: federate.rk8s.igou.systems:443
       # Federation runs a touch slower than the 30s house default because the
       # payload is large (see sampleLimit).
       interval: 60s


### PR DESCRIPTION
## Problem

After #438 merged and synced, the `rk8s-federate` UWM target came up **DOWN**:
- `up{namespace="rk8s-federate"}` = **0**
- target `lastError`: `server returned HTTP status 404 Not Found`
- `scrape_samples_scraped{namespace="rk8s-federate"}` = **0**
- no `cluster="rk8s"` series ingested

## Root cause

The rk8s `/federate` ingress routes by **HTTP Host header**. The house pattern uses a bare-IP `Endpoints` object (10.10.150.129), so Prometheus sends `Host: 10.10.150.129`. `tlsConfig.serverName` only sets the **TLS SNI**, not the HTTP Host header, so the ingress has no matching vhost and returns 404.

Reproduced from inside `prometheus-user-workload-0` (SNI pinned to `federate.rk8s.igou.systems` in all three):

| Host header | Result |
|---|---|
| `federate.rk8s.igou.systems` | **200**, 3.4 MB federation payload |
| `10.10.150.129` | **404**, 146 bytes |

The OCP cluster resolves `federate.rk8s.igou.systems` -> 10.10.150.129 via DNS (verified from the pod).

## Fix

Add a target relabeling that rewrites `__address__` to `federate.rk8s.igou.systems:443`. This makes both the HTTP Host header and the TLS SNI carry the DNS name; Prometheus resolves it to the same MetalLB VIP and routes over the LAN. Target discovery still comes from the bare-IP `Endpoints` (unchanged); this only fixes the scrape connection's Host header.

Scoped strictly to the file added in #438. `kustomize build` and `yamllint` pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017UuTBEb3CiUhuYRDDT4nKx