### PR TITLE
feat(node-tuning): balanced-EPP Tuned profile to curb control-plane idle heat

### DIFF
--- a/clusters/ocp/node-tuning/kustomization.yaml
+++ b/clusters/ocp/node-tuning/kustomization.yaml
@@ -1,0 +1,4 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - openshift-control-plane-epp-tuned.yaml

--- a/clusters/ocp/node-tuning/openshift-control-plane-epp-tuned.yaml
+++ b/clusters/ocp/node-tuning/openshift-control-plane-epp-tuned.yaml
@@ -1,0 +1,25 @@
+apiVersion: tuned.openshift.io/v1
+kind: Tuned
+metadata:
+  name: openshift-control-plane-epp
+  namespace: openshift-cluster-node-tuning-operator
+spec:
+  profile:
+    - name: openshift-control-plane-epp
+      data: |
+        [main]
+        summary=openshift-control-plane with balanced EPP to reduce idle clocks/heat
+        include=openshift-control-plane
+
+        [cpu]
+        governor=powersave
+        energy_performance_preference=balance_performance
+  recommend:
+    # Priority MUST be numerically lower than the default openshift-control-plane
+    # recommend (priority 30) so this profile wins on master nodes. The
+    # include= above keeps every other control-plane tuning intact; only the
+    # [cpu] block (governor + HWP energy-performance preference) is overridden.
+    - match:
+        - label: node-role.kubernetes.io/master
+      priority: 20
+      profile: openshift-control-plane-epp

--- a/clusters/ocp/values.yaml
+++ b/clusters/ocp/values.yaml
@@ -45,6 +45,20 @@ applications:
     source:
       path: clusters/ocp/kubeletconfig
 
+  # Custom Tuned profile that lets the single MS-01 control-plane node drop
+  # clocks at idle (HWP balance_performance EPP) instead of the stock
+  # openshift-control-plane profile pinning performance governor/EPP. Reduces
+  # idle package power/heat and thermal-throttle events. See
+  # clusters/ocp/node-tuning/openshift-control-plane-epp-tuned.yaml.
+  node-tuning:
+    annotations:
+      argocd.argoproj.io/compare-options: IgnoreExtraneous
+      argocd.argoproj.io/sync-wave: '3'
+    destination:
+      namespace: openshift-cluster-node-tuning-operator
+    source:
+      path: clusters/ocp/node-tuning
+
   nmstate:
     annotations:
       argocd.argoproj.io/compare-options: IgnoreExtraneous


### PR DESCRIPTION
## Problem

The single MS-01 (i9-13900H) control-plane node `ocp.igou.systems` idles hot. Live investigation on 2026-07-12 found:

- The node idles at **~3.5 GHz P-cores / ~2.8 GHz E-cores drawing 36 W package power at ~11% CPU utilization**. This is because the default `openshift-control-plane` Tuned profile inherits `throughput-performance`, which sets `governor=performance` and `EPP=performance` — pinning clocks high even when idle.
- Result: **24h average package temp 87 °C, daily peaks hitting 100 °C (Tjmax), and ~2.6M package thermal-throttle events per 24h.**
- The control plane has enormous headroom, so the performance pinning buys nothing but heat: **etcd WAL fsync p99 7.9 ms, apiserver ~135 req/s at ~50 ms p99, node 11% avg CPU (69% 7d-peak).**

## The change

Adds a custom `Tuned` CR (`openshift-control-plane-epp`, namespace `openshift-cluster-node-tuning-operator`) that keeps turbo available but lets clocks drop at idle via the HWP energy-performance preference. It `include=`s the stock `openshift-control-plane` profile and overrides **only** the `[cpu]` section:

```
[cpu]
governor=powersave
energy_performance_preference=balance_performance
```

New files:
- `clusters/ocp/node-tuning/openshift-control-plane-epp-tuned.yaml` — the Tuned CR
- `clusters/ocp/node-tuning/kustomization.yaml`

Wired into the app-of-apps in `clusters/ocp/values.yaml` as a new `node-tuning` Application at **sync-wave 3** (alongside `kubeletconfig`, destination namespace `openshift-cluster-node-tuning-operator`).

### Two gotchas (load-bearing — do not "simplify" away)

1. **`governor=powersave` is REQUIRED alongside the EPP setting.** With `intel_pstate` in active mode, the `performance` governor forces EPP to `performance` and rejects any other value. In `intel_pstate` active mode, `powersave` is the *normal* HWP-managed governor — not a slow mode. It is what allows `balance_performance` EPP to take effect while still turbo-boosting under load.
2. **`priority: 20` must be numerically LOWER than the default `openshift-control-plane` recommend priority (30)** so this profile wins on the master node.

The `include=openshift-control-plane` keeps every other OpenShift control-plane tuning intact; only `[cpu]` is overridden.

## Verification plan (after merge + ArgoCD sync)

1. Confirm the profile is applied to the node:
   ```
   oc get profile.tuned.openshift.io ocp.igou.systems -n openshift-cluster-node-tuning-operator
   ```
   It should show `openshift-control-plane-epp` as the applied profile.
2. On the node, confirm the CPU settings took effect:
   ```
   cat /sys/devices/system/cpu/cpu0/cpufreq/energy_performance_preference   # => balance_performance
   cat /sys/devices/system/cpu/cpu0/cpufreq/scaling_governor                 # => powersave
   ```
3. Watch package power and temperatures drop from the idle baseline (36 W / 87 °C avg / 100 °C peaks) and confirm the package thermal-throttle counter growth flattens.
4. Confirm the control plane stays healthy: **etcd WAL fsync p99 stays < 10 ms** over the following day (baseline was 7.9 ms), and apiserver latency is unchanged.

## Complementary follow-ups (outside this repo)

- **BIOS-level PL1 cap** (~35–45 W package power limit) to bound sustained draw.
- **Physical cooling check** on the MS-01 (airflow / thermal paste / fan curve).

These are hardware/firmware changes and are intentionally not part of this GitOps PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XbJatM2nf9eZU7Zs54HkLV
