### PR TITLE
feat(node-tuning): cap intel_pstate max_perf_pct at 75% on control plane

### DIFF
--- a/clusters/ocp/node-tuning/openshift-control-plane-epp-tuned.yaml
+++ b/clusters/ocp/node-tuning/openshift-control-plane-epp-tuned.yaml
@@ -14,6 +14,12 @@ spec:
         [cpu]
         governor=powersave
         energy_performance_preference=balance_performance
+        # Cap intel_pstate to 75% of max turbo (~3.9GHz on the i9-13900H).
+        # The steady ~2.3-core control-plane load was boosting to 4.6-4.9GHz
+        # for no measurable latency benefit (apiserver/etcd p99s identical at
+        # 3.5GHz vs 4.9GHz) while holding the package at ~34W/87C. 50 = base
+        # clocks (full turbo-off equivalent) if 75 proves insufficient.
+        max_perf_pct=75
   recommend:
     # Priority MUST be numerically lower than the default openshift-control-plane
     # recommend (priority 30) so this profile wins on master nodes. The


### PR DESCRIPTION
## Problem

Follow-up to #447. The EPP/governor change deployed and verified cleanly (all 20 CPUs on `balance_performance`/`powersave`, idle cores park at 400MHz, **zero control-plane regression** — etcd WAL fsync p99 7.89ms and apiserver GET p99 49.6ms, identical to baseline). However, a 30-minute A/B showed package power and temps **unchanged** (~34W, ~87°C avg, ~105k throttle events/hr, daily Tjmax hits).

Root cause refined: the heat is not idle-clock pinning but the constant ~2.3-core control-plane floor load (kube-apiserver ~48% of a core, argocd app-controller ~21%, kubelet ~17%, etcd ~13%). Under `balance_performance` those loaded P-cores opportunistically boost to **4.6–4.9GHz**, the most voltage-expensive part of the V/f curve, for no measurable latency benefit.

## Change

Add `max_perf_pct=75` to the `[cpu]` section of the `openshift-control-plane-epp` Tuned profile — caps intel_pstate at ~3.9GHz on the i9-13900H (MS-01). tuned's cpu plugin writes this to `/sys/devices/system/cpu/intel_pstate/max_perf_pct`.

- Graduated and instantly reversible via GitOps — no BIOS access needed.
- `max_perf_pct=50` = 2.6GHz base clocks = full BIOS-turbo-off equivalent, available as a next step if 75% proves insufficient.

## Verification plan (post-merge)

1. `oc get profile.tuned.openshift.io ocp.igou.systems` still shows `openshift-control-plane-epp` applied, not degraded
2. On node: `/sys/devices/system/cpu/intel_pstate/max_perf_pct` = 75; `/proc/cpuinfo` MHz snapshot shows no core above ~3.9GHz
3. Package power (RAPL) and coretemp should drop; throttle-event rate should fall
4. etcd WAL fsync p99 stays <10ms, apiserver GET p99 ~50ms over the following day

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XbJatM2nf9eZU7Zs54HkLV