### PR TITLE
fix(node-tuning): override inherited min_perf_pct so max_perf_pct cap applies

### DIFF
--- a/clusters/ocp/node-tuning/openshift-control-plane-epp-tuned.yaml
+++ b/clusters/ocp/node-tuning/openshift-control-plane-epp-tuned.yaml
@@ -19,6 +19,13 @@ spec:
         # for no measurable latency benefit (apiserver/etcd p99s identical at
         # 3.5GHz vs 4.9GHz) while holding the package at ~34W/87C. 50 = base
         # clocks (full turbo-off equivalent) if 75 proves insufficient.
+        #
+        # min_perf_pct MUST be overridden here: the inherited
+        # throughput-performance profile (via openshift) sets min_perf_pct=100,
+        # and the kernel clamps max_perf_pct writes to >= min_perf_pct — with
+        # the inherited value, the max_perf_pct=75 write is silently clamped
+        # back to 100. 8% ~= the 400MHz hardware floor on this SKU.
+        min_perf_pct=8
         max_perf_pct=75
   recommend:
     # Priority MUST be numerically lower than the default openshift-control-plane


### PR DESCRIPTION
Follow-up to #451, which merged and synced cleanly but had no effect: `/sys/devices/system/cpu/intel_pstate/max_perf_pct` stayed at 100.

**Root cause:** the inherited `throughput-performance` profile (via `openshift` → `openshift-control-plane` → this profile's `include=` chain) sets `min_perf_pct=100`, and the kernel clamps `max_perf_pct` writes to ≥ `min_perf_pct`. tuned wrote 75, the kernel clamped it back to 100, no error or warning anywhere (tuned logs the write only at debug level).

**Fix:** override `min_perf_pct=8` (≈ the 400MHz hardware floor on the i9-13900H) in the child `[cpu]` section so the `max_perf_pct=75` (~3.9GHz) cap actually lands.

**Verification:** `cat /sys/devices/system/cpu/intel_pstate/{min,max}_perf_pct` → 8 / 75; `/proc/cpuinfo` shows no core above ~3.9GHz; package power and temps drop; etcd fsync p99 <10ms unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XbJatM2nf9eZU7Zs54HkLV