### PR TITLE
fix(user-workload-monitoring): add defaulted relabeling action to apc-pdu Probe for SSA diff

### DIFF
--- a/components/user-workload-monitoring/exporters/snmp-exporter/probes/apc-pdu-probe.yaml
+++ b/components/user-workload-monitoring/exporters/snmp-exporter/probes/apc-pdu-probe.yaml
@@ -30,5 +30,7 @@ spec:
       relabelingConfigs:
         - targetLabel: __param_auth
           replacement: apc_v1
+          action: replace
         - sourceLabels: [__param_target]
           targetLabel: instance
+          action: replace


### PR DESCRIPTION
## Problem

ArgoCD app `user-workload-monitoring` (which syncs with `ServerSideApply=true`) reports the `snmp-exporter/apc-pdu` **Probe** as permanently **OutOfSync**.

The live object has `action: replace` on both entries under `spec.targets.staticConfig.relabelingConfigs`. This field is API-defaulted by the Prometheus Operator / apiserver: a `RelabelConfig` with no explicit `action` defaults to `replace`. Git omits the field, so under server-side apply the managed-fields/live object always carries `action: replace` that git does not, and the diff never settles — the app loops OutOfSync.

## Cause

This is the same SSA defaulted-field diff class this repo has hit before (HTTPRoute/Gateway needed all API defaults written into git for the Argo SSA diff to settle). With `ServerSideApply=true`, ArgoCD compares against the live object including server-defaulted fields; any field the API defaults but git omits shows as a persistent diff.

## Fix

Add the defaulted `action: replace` to both `relabelingConfigs` entries in `components/user-workload-monitoring/exporters/snmp-exporter/probes/apc-pdu-probe.yaml` so git matches the server-defaulted live state.

```diff
       relabelingConfigs:
         - targetLabel: __param_auth
           replacement: apc_v1
+          action: replace
         - sourceLabels: [__param_target]
           targetLabel: instance
+          action: replace
```

No behavior change — `replace` is exactly what the API was already defaulting to. Only effect is that the Argo SSA diff settles and the Probe stops reporting OutOfSync.

## Validation

- `kustomize build --enable-helm components/user-workload-monitoring` succeeds; rendered apc-pdu Probe carries `action: replace` on both relabeling entries.
- Sync-clearing to be confirmed live after merge.