### PR TITLE
fix(truenas): drop netdata pool.usage series causing PrometheusDuplicateTimestamps

### DIFF
--- a/components/user-workload-monitoring/exporters/truenas/truenas-netdata.yaml
+++ b/components/user-workload-monitoring/exporters/truenas/truenas-netdata.yaml
@@ -70,3 +70,15 @@ spec:
           regex: '.*_serial(?:_lunid)?_([^_]+).*'
           targetLabel: disk
           replacement: '${1}'
+        # Drop netdata's truenas_pool.usage chart. The TrueNAS collector emits
+        # one instance per pool but does NOT encode the pool name into the
+        # chart/family label, so all pools collapse to an identical label set
+        # (chart="truenas_pool.usage", family="pool.usage", dimension=
+        # available|used|total). With 4 pools that is 12 samples sharing only 3
+        # unique series keys at the same scrape timestamp, so Prometheus keeps
+        # 3 and drops 9 - the source of PrometheusDuplicateTimestamps
+        # (num_dropped=9). No relabeling can recover the lost pool identity, and
+        # per-pool usage already comes from zfs_exporter, so drop the series.
+        - action: drop
+          sourceLabels: [__name__]
+          regex: 'netdata_pool_usage_bytes_average'


### PR DESCRIPTION
## Problem

`PrometheusDuplicateTimestamps` fires against the UWM Prometheus. `prometheus-user-workload-0` logs, on every 30s scrape:

```
msg="Error on ingesting samples with different value but same timestamp"
scrape_pool=serviceMonitor/truenas/truenas-netdata/0
target="http://10.10.9.243:9998/api/v1/allmetrics?format=prometheus" num_dropped=9
```

## Root cause

The netdata TrueNAS collector emits the `truenas_pool.usage` chart **once per pool** but does **not** encode the pool name into the `chart`/`family` label. Fetching the endpoint shows all pools collapse to an identical label set:

```
netdata_pool_usage_bytes_average{chart="truenas_pool.usage",family="pool.usage",dimension="available"} 13132161000 ...
netdata_pool_usage_bytes_average{chart="truenas_pool.usage",family="pool.usage",dimension="used"}      17033710000 ...
netdata_pool_usage_bytes_average{chart="truenas_pool.usage",family="pool.usage",dimension="total"}     30165870000 ...
... (repeated 4x, one block per pool, differing only in value) ...
```

With **4 pools x 3 dimensions = 12 samples** sharing only **3 unique series keys** at the same scrape timestamp, Prometheus keeps 3 and drops 9 -- exactly the observed `num_dropped=9`.

## Fix

No relabeling can recover the lost per-pool identity (the source lines are byte-identical in name+labels), and per-pool usage already comes from `zfs_exporter` and its recording rules. So drop the unusable series entirely via a `metricRelabelings` `drop` rule on `__name__ = netdata_pool_usage_bytes_average` in the `truenas-netdata` ServiceMonitor. Nothing in the repo consumes this series (verified via grep). Host untouched.

## Verification

- Identified duplicates account for exactly 9 dropped samples (12 lines, 3 unique keys).
- `kustomize build components/user-workload-monitoring/exporters/truenas/` passes; drop rule renders.
- Live ServiceMonitor patch intentionally NOT applied; verification is post-merge via ArgoCD.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XbJatM2nf9eZU7Zs54HkLV