### PR TITLE
chore(alertmanager-config): drop intentional UnsupportedHCOModification alert

### DIFF
--- a/components/alertmanager-config/drop-unsupported-hco-modification-alertrelabelconfig.yaml
+++ b/components/alertmanager-config/drop-unsupported-hco-modification-alertrelabelconfig.yaml
@@ -1,0 +1,33 @@
+---
+# Durably suppress the UnsupportedHCOModification alert on the path to the
+# platform Alertmanager. The HyperConverged CR intentionally carries a CDI
+# jsonpatch annotation (containerizeddataimporter.kubevirt.io/jsonpatch) that
+# adds the burst-worker tolerations to CDI prime/import pods (see
+# components/openshift-virt burst CDI scale-up). HCO flags any jsonpatch as an
+# "unsafe modification" and fires UnsupportedHCOModification (severity=info)
+# permanently. The modification is deliberate and must stay.
+#
+# The drop is scoped by BOTH alertname AND annotation_name so it only ever
+# matches THIS deliberate CDI jsonpatch. A genuinely new unsupported HCO
+# modification carrying a DIFFERENT annotation_name still fires normally.
+# Tradeoff: a future modification that reuses the SAME annotation_name
+# (containerizeddataimporter.kubevirt.io/jsonpatch) would also be silenced.
+#
+# NOTE: AlertRelabelConfig only relabels alerts on the Prometheus ->
+# Alertmanager path. Per OpenShift docs, dropped alerts are NOT removed from
+# the web console Observe > Alerting list (the console reads the Prometheus
+# rules API, which is upstream of this relabeling). severity=info is already
+# null-routed in alertmanager.yaml, so this object's practical effect is
+# defense-in-depth + intent-as-code at the Alertmanager boundary. See PR body.
+apiVersion: monitoring.openshift.io/v1
+kind: AlertRelabelConfig
+metadata:
+  name: drop-unsupported-hco-modification
+  namespace: openshift-monitoring
+spec:
+  configs:
+    - sourceLabels:
+        - alertname
+        - annotation_name
+      regex: 'UnsupportedHCOModification;containerizeddataimporter\.kubevirt\.io/jsonpatch'
+      action: Drop

--- a/components/alertmanager-config/kustomization.yaml
+++ b/components/alertmanager-config/kustomization.yaml
@@ -5,6 +5,7 @@ namespace: openshift-monitoring
 resources:
   - alertmanager-eda-event-stream-externalsecret.yaml
   - alertmanager-slack-bot-token-externalsecret.yaml
+  - drop-unsupported-hco-modification-alertrelabelconfig.yaml
 secretGenerator:
   - name: alertmanager-main
     namespace: openshift-monitoring


### PR DESCRIPTION
## What

Adds an `AlertRelabelConfig` (`monitoring.openshift.io/v1`) named
`drop-unsupported-hco-modification` in the `openshift-monitoring` namespace,
wired into the existing `components/alertmanager-config` component. It `Drop`s
the `UnsupportedHCOModification` alert, scoped by **both** `alertname` **and**
`annotation_name`.

## Why

`UnsupportedHCOModification` (severity `info`, namespace `openshift-cnv`) fires
**permanently** because the `HyperConverged` CR intentionally carries the CDI
jsonpatch annotation `containerizeddataimporter.kubevirt.io/jsonpatch` — the
burst CDI scale-up tolerations that let CDI prime/import pods schedule onto the
`casval` burst worker. That modification is **deliberate and must stay**; HCO
flags any jsonpatch as an "unsafe modification" and raises this alert as a
warning. It is pure intentional noise.

The alert rule is `kubevirt-hyperconverged-prometheus-rule` in `openshift-cnv`:

```
sum by(annotation_name, namespace) ((kubevirt_hco_unsafe_modifications) > 0)
```

so the firing alert carries `annotation_name=containerizeddataimporter.kubevirt.io/jsonpatch`.

## Manifest

```yaml
apiVersion: monitoring.openshift.io/v1
kind: AlertRelabelConfig
metadata:
  name: drop-unsupported-hco-modification
  namespace: openshift-monitoring
spec:
  configs:
    - sourceLabels:
        - alertname
        - annotation_name
      regex: 'UnsupportedHCOModification;containerizeddataimporter\.kubevirt\.io/jsonpatch'
      action: Drop
```

## Scoping / tradeoff

The drop is matched on `alertname` **and** `annotation_name` (concatenated with
the default `;` separator), so it only ever matches **this** deliberate CDI
jsonpatch. A genuinely new unsupported HCO modification carrying a **different**
`annotation_name` still fires normally.

⚠️ **Tradeoff:** a *future* modification that reuses the **same**
`annotation_name` (`containerizeddataimporter.kubevirt.io/jsonpatch`) would also
be silenced by this drop. This is the tightest scoping the alert's labels allow
— it is not scoped to `alertname` alone, so the blast radius is limited to that
one annotation key rather than all HCO modifications.

## ⚠️ Important limitation — console visibility

Per the OpenShift/OKD docs (consistent across 4.11 → 4.21), **`AlertRelabelConfig`
`Drop` does NOT remove an alert from the web console** *Observe → Alerting →
Alerts* list. The console reads the **Prometheus/Thanos rules API**, which is
**upstream** of alert relabeling; relabeling only affects the Prometheus →
Alertmanager path. Quote from the docs: *"any dropped alerts still appear in the
web console even though they are no longer forwarded to Alertmanager."*

There is **no supported, durable, config-as-code mechanism** in OpenShift to
remove a *firing platform alert* from the console list:
- the source `PrometheusRule` is owned/reconciled by the HCO operator (cannot be
  durably edited via GitOps);
- the only tool that hides an alert from the console is an Alertmanager
  **silence**, which expires and is therefore out of scope for this change;
- modifying core platform rules via `AlertRelabelConfig` explicitly does **not**
  reflect in the Prometheus alerts API / console.

Separately, notifications for this alert are **already** suppressed today: the
Alertmanager route in `alertmanager.yaml` null-routes `severity = info`.

**Net effect of this PR:** durable, self-documenting, precisely-scoped
intent-as-code + defense-in-depth suppression at the Alertmanager boundary
(guaranteed no-notification even if the `severity=info` null route is ever
changed). Please **verify in the console after ArgoCD syncs** — if the docs'
behavior holds, the alert will still be listed as firing in the console (just
never notified); if it must be gone from the console UI too, the only options
are removing the deliberate jsonpatch (not desired) or a manual silence.

## Validation

- `kustomize build components/alertmanager-config/` passes.
- `kubeconform` (repo flags): 3 valid, 1 skipped (AlertRelabelConfig has no
  published schema → `-ignore-missing-schemas`), 0 errors.
- `AlertRelabelConfig` CRD confirmed present on-cluster
  (`alertrelabelconfigs.monitoring.openshift.io`); schema verified via
  `oc explain` and the 4.21 "Modifying core platform alerting rules" module.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XbJatM2nf9eZU7Zs54HkLV