### PR TITLE
fix(adb-exporter): correct image tag (ImagePullBackOff on :v0.1.0)

### DIFF
--- a/components/user-workload-monitoring/exporters/adb-exporter/adb-exporter-deployment.yaml
+++ b/components/user-workload-monitoring/exporters/adb-exporter/adb-exporter-deployment.yaml
@@ -42,7 +42,11 @@ spec:
           type: RuntimeDefault
       containers:
         - name: adb-exporter
-          image: ghcr.io/igou-io/adb-exporter:v0.1.0
+          # renovate: datasource=docker depName=ghcr.io/igou-io/adb-exporter
+          # Immutable date tag from the igou-containers build of source tag
+          # v0.1.0 (v0.1.0 is the source git tag, NOT an image tag). Renovate
+          # auto-merges igou images, so this tracks forward automatically.
+          image: ghcr.io/igou-io/adb-exporter:2026.07.12@sha256:532073ecdc3f71ebeb74f9de713b7b991fcab078201002c60e2f2bcb8457514f
           args:
             - -adb.address=10.10.9.22:5555
           ports:


### PR DESCRIPTION
Follow-up to #456. The Deployment referenced `ghcr.io/igou-io/adb-exporter:v0.1.0`, but the igou-containers build (docker/metadata-action) publishes `latest`, a date tag (`2026.07.12`), the git SHA, and the branch name — **there is no `:v0.1.0` image tag** (`v0.1.0` is the adb-exporter *source* git tag consumed as a build arg). Result: `ImagePullBackOff` / `manifest unknown`.

Pins the immutable date tag `2026.07.12` + digest `sha256:532073e…` (multi-arch amd64+arm64). Renovate auto-merges `igou` images, so it tracks forward. Package is public — no pull secret needed.

Verified: ExternalSecret resolves the adb keypair (SecretSynced), Service/ServiceMonitor/PrometheusRule sync clean; only the image tag was wrong.

🤖 Generated with [Claude Code](https://claude.com/claude-code)