### PR TITLE
fix(mktxp): pin ExternalSecret namespace so UWM app can sync

### DIFF
--- a/components/user-workload-monitoring/exporters/mktxp/kustomization.yaml
+++ b/components/user-workload-monitoring/exporters/mktxp/kustomization.yaml
@@ -237,3 +237,16 @@ helmCharts:
                     key: mktxp-exporter
                     metadataPolicy: None
                     nullBytePolicy: Ignore
+patches:
+  # The mktxp-secret ExternalSecret is emitted by the app-template chart's
+  # rawResources without a namespace, and kustomize's top-level `namespace:`
+  # transformer does not reach helm-inflated rawResources. Without an explicit
+  # namespace, ArgoCD rejects every sync of the parent app with
+  # "InvalidSpecError: Namespace for mktxp-secret ... is missing". Pin it.
+  - target:
+      kind: ExternalSecret
+      name: mktxp-secret
+    patch: |
+      - op: add
+        path: /metadata/namespace
+        value: mktxp


### PR DESCRIPTION
The `mktxp-secret` ExternalSecret is emitted by the app-template chart's `rawResources` **without a namespace**, and kustomize's top-level `namespace: mktxp` transformer does not reach helm-inflated rawResources. ArgoCD validates every managed resource's namespace before a sync, so this one broken resource makes **every** sync of the `user-workload-monitoring` app fail with:

`InvalidSpecError: Namespace for mktxp-secret external-secrets.io/v1, Kind=ExternalSecret is missing`

That blocked adb-exporter (#456/#457) — and any future change — from syncing. Dormant until now only because the app's comparison was separately failing.

Fix: a targeted kustomize `patches` entry setting `metadata.namespace=mktxp` on the ExternalSecret. Verified the render now emits `namespace: mktxp` and the full `kustomize build --enable-helm` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)