### PR TITLE
feat: ComfyUI on casval GPUs (applications/comfyui)

### DIFF
--- a/applications/comfyui/README.md
+++ b/applications/comfyui/README.md
@@ -1,0 +1,75 @@
+# comfyui
+
+[ComfyUI](https://github.com/comfyanonymous/ComfyUI) — node-based Stable
+Diffusion / Flux image-generation UI — running on an NVIDIA GPU on the
+on-demand `casval` burst node.
+
+- **URL**: <https://comfyui.apps.ocp.igou.systems>
+- No app-level auth: internal admin-VLAN ingress only, same posture as the
+  llmkube routes.
+- Image: `docker.io/yanwk/comfyui-boot`, slim CUDA 13.0 family (digest-pinned,
+  Renovate-managed). CUDA 13.0 runtime runs on casval's 595 driver (CUDA 13.2).
+
+## Scaling (this is a manually-scaled, autoscale-aware app)
+
+`casval` is an on-demand CAPI burst node; the cluster-autoscaler powers it down
+when nothing needs it. A permanently-Running GPU pod would pin it on, so the
+Deployment ships **`replicas: 0`** and ArgoCD ignores `/spec/replicas`
+(`clusters/ocp/values.yaml`) — scale-ups are never reverted.
+
+```bash
+# Start it — a pending GPU pod triggers the autoscaler to boot casval.
+oc -n comfyui scale deploy/comfyui --replicas=1
+
+# Stop it when done so casval can power off.
+oc -n comfyui scale deploy/comfyui --replicas=0
+```
+
+First start on an empty PVC copies the image-bundled ComfyUI into `/root`
+(the PVC mount) and warms caches — the generous `startupProbe` allows up to
+~15 min before liveness can act.
+
+## GPU
+
+- Requests/limits **`nvidia.com/gpu: 1`** — one of casval's two GPUs. The
+  second stays free for llmkube (hermes qwen35-2b). ComfyUI is single-GPU per
+  process: to use both, either bump to `2` plus the ComfyUI-MultiGPU custom
+  node, or run a second instance.
+- GPU metrics come from the existing DCGM exporter dashboards.
+
+## Storage layout
+
+One 300Gi RWO PVC (`freenas-nvmeof-ssd-csi`) mounted at `/root` — the image's
+runner home. Everything ComfyUI writes lives under it:
+
+```
+/root/ComfyUI/models/<type>/   checkpoints, loras, vae, controlnet, upscale_models, ...
+/root/ComfyUI/input/           uploaded images
+/root/ComfyUI/output/          generated images
+/root/ComfyUI/custom_nodes/    ComfyUI-Manager + installed nodes
+/root/user-scripts/            optional set-proxy.sh / pre-start.sh hooks
+```
+
+### Getting models onto the PVC
+
+- Sideload from a workstation into the running pod:
+  ```bash
+  oc -n comfyui rsync ./my-model.safetensors \
+    comfyui-<pod>:/root/ComfyUI/models/checkpoints/
+  # or: oc -n comfyui cp ./my-model.safetensors comfyui-<pod>:/root/ComfyUI/models/checkpoints/
+  ```
+- Or use ComfyUI-Manager's model downloader from the UI.
+
+## Security context
+
+Runs under OpenShift **restricted-v2** with an arbitrary namespace UID — no SCC
+changes, no ServiceAccount RoleBinding. The image hardcodes `/root` as its home
+and writes everything there; mounting the PVC at `/root` makes that tree
+fsGroup-owned and group-writable, so the assigned UID can write it. `HOME` is
+set to `/root` because the arbitrary UID has no `/etc/passwd` home. No
+`runAsUser`/`fsGroup` is pinned — the SCC assigns them (pinned values break on
+namespace recreation).
+
+Verified empirically with rootless podman before writing this: the image starts
+under a non-root UID it doesn't expect (no passwd entry, GID 0, writable `/root`)
+and reaches ComfyUI's HTTP server — see the PR body for the command and output.

--- a/applications/comfyui/README.md
+++ b/applications/comfyui/README.md
@@ -31,10 +31,23 @@ First start on an empty PVC copies the image-bundled ComfyUI into `/root`
 
 ## GPU
 
-- Requests/limits **`nvidia.com/gpu: 1`** — one of casval's two GPUs. The
-  second stays free for llmkube (hermes qwen35-2b). ComfyUI is single-GPU per
-  process: to use both, either bump to `2` plus the ComfyUI-MultiGPU custom
-  node, or run a second instance.
+- Requests/limits **`nvidia.com/gpu: 2`** — **both** of casval's GPUs back one
+  ComfyUI process. ComfyUI core is single-GPU per process and execution stays
+  sequential; the [ComfyUI-MultiGPU](https://github.com/pollockjj/ComfyUI-MultiGPU)
+  custom node spreads a model's **components** across the two cards for VRAM
+  headroom — e.g. UNet on `cuda:0`, CLIP/VAE on `cuda:1`, with DisTorch layer
+  offload — so bigger models fit than either 16 GB card holds alone.
+- **Contention**: claiming both GPUs means llmkube's casval-hosted models (e.g.
+  `qwen3-35b`) **cannot run concurrently** with ComfyUI. Scale comfyui to `0`
+  before starting them (and vice-versa).
+- ComfyUI-MultiGPU is auto-installed on first boot by the `pre-start.sh` hook
+  (see below) — a SHA-pinned `git clone`, zero extra pip deps. It auto-discovers
+  both cards via `torch.cuda.device_count()`; **do not** set `--cuda-device` in
+  `CLI_ARGS` or it only sees one.
+- **Bumping the node**: it has no upstream release tags and Renovate can't manage
+  a raw `git clone`, so the pin lives in
+  `comfyui-user-scripts-configmap.yaml` (`MULTIGPU_PIN`). Edit that SHA to
+  update; the next pod restart re-pins the PVC checkout.
 - GPU metrics come from the existing DCGM exporter dashboards.
 
 ## Storage layout
@@ -47,8 +60,16 @@ runner home. Everything ComfyUI writes lives under it:
 /root/ComfyUI/input/           uploaded images
 /root/ComfyUI/output/          generated images
 /root/ComfyUI/custom_nodes/    ComfyUI-Manager + installed nodes
-/root/user-scripts/            optional set-proxy.sh / pre-start.sh hooks
+/root/user-scripts/            pre-start.sh hook (seeded from ConfigMap each boot)
 ```
+
+`pre-start.sh` is **not** hand-edited on the PVC. The `seed-user-scripts`
+initContainer copies it (`cp -f`) from the `comfyui-user-scripts` ConfigMap onto
+the PVC on **every** start, so the ConfigMap in git is the source of truth and
+any manual PVC edit is overwritten. The copy is what lets the entrypoint
+`chmod +x` the file (a read-only ConfigMap mount would fail that chmod under
+`set -e`); it lands owned by the pod's UID because init and main containers share
+the SCC-assigned `runAsUser`.
 
 ### Getting models onto the PVC
 

--- a/applications/comfyui/README.md
+++ b/applications/comfyui/README.md
@@ -52,15 +52,27 @@ First start on an empty PVC copies the image-bundled ComfyUI into `/root`
 
 ## Storage layout
 
-One 300Gi RWO PVC (`freenas-nvmeof-ssd-csi`) mounted at `/root` — the image's
-runner home. Everything ComfyUI writes lives under it:
+Two RWO PVCs, split by access pattern:
+
+- **`comfyui-data`** — 300Gi on `freenas-nvmeof-ssd-csi` (fast ssd pool),
+  mounted at `/root`. The app home: the ComfyUI app bundle, custom_nodes,
+  input/output, user config, and `.cache`/`.local`. 300Gi is oversized for a
+  home-only volume (an artifact of the original single-PVC layout) and could be
+  reduced on a future clean recreate.
+- **`comfyui-models`** — 200Gi on `freenas-nvmeof-cold-csi` (cheaper cold
+  pool), mounted at the deeper `/root/ComfyUI/models`. The bulk model weights
+  (checkpoints, unets, GGUF, text-encoders, VAEs, LoRAs). Model loads are large
+  sequential reads that tolerate the cold pool fine.
+
+The `/root/ComfyUI/models` mount is deeper than the `/root` mount and
+**shadows** the ssd copy — intentional, so models never consume ssd space.
 
 ```
-/root/ComfyUI/models/<type>/   checkpoints, loras, vae, controlnet, upscale_models, ...
-/root/ComfyUI/input/           uploaded images
-/root/ComfyUI/output/          generated images
-/root/ComfyUI/custom_nodes/    ComfyUI-Manager + installed nodes
-/root/user-scripts/            pre-start.sh hook (seeded from ConfigMap each boot)
+/root/ComfyUI/models/<type>/   checkpoints, loras, vae, controlnet, upscale_models, ...   [cold PVC]
+/root/ComfyUI/input/           uploaded images                                            [ssd PVC]
+/root/ComfyUI/output/          generated images                                           [ssd PVC]
+/root/ComfyUI/custom_nodes/    ComfyUI-Manager + installed nodes                          [ssd PVC]
+/root/user-scripts/            pre-start.sh hook (seeded from ConfigMap each boot)         [ssd PVC]
 ```
 
 `pre-start.sh` is **not** hand-edited on the PVC. The `seed-user-scripts`
@@ -72,6 +84,9 @@ any manual PVC edit is overwritten. The copy is what lets the entrypoint
 the SCC-assigned `runAsUser`.
 
 ### Getting models onto the PVC
+
+Models land on the `comfyui-models` cold PVC — `/root/ComfyUI/models` in the
+pod is that PVC, not the ssd home.
 
 - Sideload from a workstation into the running pod:
   ```bash

--- a/applications/comfyui/comfyui-data-pvc.yaml
+++ b/applications/comfyui/comfyui-data-pvc.yaml
@@ -1,0 +1,19 @@
+---
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: comfyui-data
+  namespace: comfyui
+spec:
+  accessModes:
+    - ReadWriteOnce
+  resources:
+    requests:
+      # Single volume holds the whole ComfyUI runner home (/root): the app
+      # itself, custom_nodes, input/output, user config, and the model tree.
+      # Models dominate — 300Gi leaves room for a handful of SDXL/Flux
+      # checkpoints plus LoRAs/VAEs/upscalers.
+      storage: 300Gi
+  # Pin explicitly (lab convention): NVMe-oF on the ssd pool, the cluster
+  # default. RWO is fine — replicas stay 0/1 with a Recreate strategy.
+  storageClassName: freenas-nvmeof-ssd-csi

--- a/applications/comfyui/comfyui-data-pvc.yaml
+++ b/applications/comfyui/comfyui-data-pvc.yaml
@@ -9,10 +9,13 @@ spec:
     - ReadWriteOnce
   resources:
     requests:
-      # Single volume holds the whole ComfyUI runner home (/root): the app
-      # itself, custom_nodes, input/output, user config, and the model tree.
-      # Models dominate — 300Gi leaves room for a handful of SDXL/Flux
-      # checkpoints plus LoRAs/VAEs/upscalers.
+      # App home only (/root): the ComfyUI app bundle, custom_nodes,
+      # input/output, user config, and .cache/.local. The model tree no longer
+      # lives here — it's on the separate `comfyui-models` cold PVC mounted at
+      # /root/ComfyUI/models. 300Gi is oversized for a home-only volume (an
+      # artifact of the original single-PVC layout) and could be reduced on a
+      # future clean recreate; it's kept here because the live PVC is bound at
+      # 300Gi and CSI can't shrink in place.
       storage: 300Gi
   # Pin explicitly (lab convention): NVMe-oF on the ssd pool, the cluster
   # default. RWO is fine — replicas stay 0/1 with a Recreate strategy.

--- a/applications/comfyui/comfyui-deployment.yaml
+++ b/applications/comfyui/comfyui-deployment.yaml
@@ -37,6 +37,37 @@ spec:
         runAsNonRoot: true
         seccompProfile:
           type: RuntimeDefault
+      initContainers:
+        # Copy pre-start.sh from the ConfigMap onto the PVC so it lands OWNED by
+        # the SCC-assigned UID (initContainers share the main container's
+        # runAsUser). The entrypoint does `chmod +x` on it under `set -e`; a
+        # direct ConfigMap subPath mount is read-only, so that chmod would fail
+        # and abort startup — hence this copy. cp -f is unconditional so
+        # ConfigMap edits propagate on every restart (the PVC copy is not the
+        # source of truth). Same image as main = already on the node, no pull.
+        - name: seed-user-scripts
+          image: docker.io/yanwk/comfyui-boot:cu130-slim-20260706@sha256:a2c861b1b30840eeece704e883d4a9af6428da2a6b483688f4cd95a5616efcb7
+          command:
+            - bash
+            - -c
+            - mkdir -p /root/user-scripts && cp -f /seed/pre-start.sh /root/user-scripts/pre-start.sh
+          securityContext:
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop:
+                - ALL
+          volumeMounts:
+            - name: data
+              mountPath: /root
+            - name: user-scripts-seed
+              mountPath: /seed
+              readOnly: true
+          resources:
+            requests:
+              cpu: 50m
+              memory: 64Mi
+            limits:
+              memory: 128Mi
       containers:
         - name: comfyui
           # yanwk/comfyui-boot, slim CUDA 13.0 family (CUDA 13.0 runtime <= the
@@ -73,24 +104,36 @@ spec:
               path: /
               port: http
             periodSeconds: 10
+          # Loose thresholds: large checkpoint loads / CUDA init can block the
+          # aiohttp main thread for a while — a long model load must not trip
+          # a restart mid-generation.
           livenessProbe:
             httpGet:
               path: /
               port: http
             periodSeconds: 30
+            timeoutSeconds: 5
+            failureThreshold: 6
           resources:
             requests:
-              # One GPU only — the second stays free for llmkube. cpu/memory
-              # sized for a single generation pipeline; memory limit gives
-              # headroom for large models without cpu-throttling GPU work (no
-              # cpu limit, matching sands-of-time / the lab batch-work habit).
+              # Both of casval's GPUs go to this one ComfyUI process for
+              # multi-GPU model placement (ComfyUI-MultiGPU, seeded by
+              # pre-start.sh). This claims the whole node's GPU capacity:
+              # llmkube's casval-hosted models (e.g. qwen3-35b) cannot run
+              # concurrently — scale comfyui to 0 before starting them.
+              # cpu/memory sized for a single generation pipeline; memory limit
+              # gives headroom for large models without cpu-throttling GPU work
+              # (no cpu limit, matching sands-of-time / the lab batch-work habit).
               cpu: "4"
               memory: 16Gi
-              nvidia.com/gpu: "1"
+              nvidia.com/gpu: "2"
             limits:
               memory: 48Gi
-              nvidia.com/gpu: "1"
+              nvidia.com/gpu: "2"
       volumes:
         - name: data
           persistentVolumeClaim:
             claimName: comfyui-data
+        - name: user-scripts-seed
+          configMap:
+            name: comfyui-user-scripts

--- a/applications/comfyui/comfyui-deployment.yaml
+++ b/applications/comfyui/comfyui-deployment.yaml
@@ -90,6 +90,14 @@ spec:
           volumeMounts:
             - name: data
               mountPath: /root
+            # The model tree lives on its own cold-backed PVC; the rest of /root
+            # (app bundle, custom_nodes, .cache/.local, user config) stays on the
+            # fast ssd `data` PVC. Ordering matters: `data` mounts at /root and
+            # `models` mounts at the deeper /root/ComfyUI/models — the deeper
+            # mount shadows whatever would sit under the ssd copy, which is
+            # intentional (models never touch the ssd PVC).
+            - name: models
+              mountPath: /root/ComfyUI/models
           # First boot on an empty PVC copies the bundled ComfyUI into place and
           # may compile/warm caches — allow up to ~15 min before the liveness
           # probe can act (startup gates it).
@@ -134,6 +142,9 @@ spec:
         - name: data
           persistentVolumeClaim:
             claimName: comfyui-data
+        - name: models
+          persistentVolumeClaim:
+            claimName: comfyui-models
         - name: user-scripts-seed
           configMap:
             name: comfyui-user-scripts

--- a/applications/comfyui/comfyui-deployment.yaml
+++ b/applications/comfyui/comfyui-deployment.yaml
@@ -1,0 +1,96 @@
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: comfyui
+  namespace: comfyui
+spec:
+  # Checked in at 0 on purpose. casval is an on-demand CAPI burst node that the
+  # cluster-autoscaler powers down when idle; a permanently-Running GPU pod
+  # would pin it on. Scale to 1 by hand to run (autoscaler boots casval), back
+  # to 0 when done. ArgoCD ignores /spec/replicas so it never reverts a
+  # scale-up (see clusters/ocp/values.yaml).
+  replicas: 0
+  # Exclusive GPU + a RWO PVC: the old pod must release both before the new one
+  # starts.
+  strategy:
+    type: Recreate
+  selector: {}
+  template:
+    metadata: {}
+    spec:
+      # Land on casval (the only GPU burst node) and tolerate its dedicated
+      # taint so nothing else drifts onto it.
+      nodeSelector:
+        node-role.kubernetes.io/burst: ""
+      tolerations:
+        - key: workload
+          operator: Equal
+          value: burst
+          effect: NoSchedule
+      # restricted-v2 baseline. No runAsUser/fsGroup: the SCC assigns them from
+      # the namespace range (pinned values break on namespace recreation). The
+      # image hardcodes /root as its home and writes everything there
+      # (ComfyUI/, .cache, .local) — mounting the PVC at /root makes that tree
+      # fsGroup-owned and group-writable, so the arbitrary UID can write it.
+      securityContext:
+        runAsNonRoot: true
+        seccompProfile:
+          type: RuntimeDefault
+      containers:
+        - name: comfyui
+          # yanwk/comfyui-boot, slim CUDA 13.0 family (CUDA 13.0 runtime <= the
+          # node's 13.2; runs on driver 595). Digest-pinned, Renovate-managed.
+          image: docker.io/yanwk/comfyui-boot:cu130-slim-20260706@sha256:a2c861b1b30840eeece704e883d4a9af6428da2a6b483688f4cd95a5616efcb7
+          securityContext:
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop:
+                - ALL
+          ports:
+            - name: http
+              containerPort: 8188
+          env:
+            # The entrypoint cd's to /root and writes ComfyUI/, .cache, .local
+            # there; the PVC is mounted at /root. Set HOME too since the
+            # arbitrary UID has no passwd home.
+            - name: HOME
+              value: /root
+          volumeMounts:
+            - name: data
+              mountPath: /root
+          # First boot on an empty PVC copies the bundled ComfyUI into place and
+          # may compile/warm caches — allow up to ~15 min before the liveness
+          # probe can act (startup gates it).
+          startupProbe:
+            httpGet:
+              path: /
+              port: http
+            periodSeconds: 15
+            failureThreshold: 60
+          readinessProbe:
+            httpGet:
+              path: /
+              port: http
+            periodSeconds: 10
+          livenessProbe:
+            httpGet:
+              path: /
+              port: http
+            periodSeconds: 30
+          resources:
+            requests:
+              # One GPU only — the second stays free for llmkube. cpu/memory
+              # sized for a single generation pipeline; memory limit gives
+              # headroom for large models without cpu-throttling GPU work (no
+              # cpu limit, matching sands-of-time / the lab batch-work habit).
+              cpu: "4"
+              memory: 16Gi
+              nvidia.com/gpu: "1"
+            limits:
+              memory: 48Gi
+              nvidia.com/gpu: "1"
+      volumes:
+        - name: data
+          persistentVolumeClaim:
+            claimName: comfyui-data

--- a/applications/comfyui/comfyui-models-pvc.yaml
+++ b/applications/comfyui/comfyui-models-pvc.yaml
@@ -1,0 +1,21 @@
+---
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: comfyui-models
+  namespace: comfyui
+spec:
+  accessModes:
+    - ReadWriteOnce
+  resources:
+    requests:
+      # Holds the bulk model weights — checkpoints, unets, GGUF, text-encoders,
+      # VAEs, LoRAs — the multi-hundred-GB tree that dominates ComfyUI's disk
+      # use. Parked on the cheaper NVMe-oF cold pool: model loads are large
+      # sequential reads that tolerate the cold pool fine, while the app home
+      # stays on the fast ssd pool. 200Gi fits a working set of SDXL/Flux
+      # checkpoints plus LoRAs/VAEs/upscalers.
+      storage: 200Gi
+  # Pin explicitly (lab convention): NVMe-oF on the cold pool. RWO is fine —
+  # replicas stay 0/1 with a Recreate strategy.
+  storageClassName: freenas-nvmeof-cold-csi

--- a/applications/comfyui/comfyui-namespace.yaml
+++ b/applications/comfyui/comfyui-namespace.yaml
@@ -1,0 +1,5 @@
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: comfyui

--- a/applications/comfyui/comfyui-route.yaml
+++ b/applications/comfyui/comfyui-route.yaml
@@ -1,0 +1,24 @@
+---
+apiVersion: route.openshift.io/v1
+kind: Route
+metadata:
+  name: comfyui
+  namespace: comfyui
+  annotations:
+    # Image generation and the websocket progress stream stay open well past
+    # the router's 30s default — match the llmkube routes' 10m budget.
+    haproxy.router.openshift.io/timeout: 10m
+spec:
+  host: comfyui.apps.ocp.igou.systems
+  to:
+    kind: Service
+    name: comfyui
+    weight: 100
+  port:
+    targetPort: http
+  # Edge termination: the router terminates TLS (default wildcard cert for
+  # *.apps.ocp.igou.systems) and forwards plaintext HTTP to ComfyUI on :8188.
+  tls:
+    termination: edge
+    insecureEdgeTerminationPolicy: Redirect
+  wildcardPolicy: None

--- a/applications/comfyui/comfyui-service.yaml
+++ b/applications/comfyui/comfyui-service.yaml
@@ -1,0 +1,12 @@
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: comfyui
+  namespace: comfyui
+spec:
+  selector: {}
+  ports:
+    - name: http
+      port: 8188
+      targetPort: http

--- a/applications/comfyui/comfyui-user-scripts-configmap.yaml
+++ b/applications/comfyui/comfyui-user-scripts-configmap.yaml
@@ -1,0 +1,46 @@
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: comfyui-user-scripts
+  namespace: comfyui
+data:
+  # Seeded onto the PVC (/root/user-scripts/pre-start.sh) by the
+  # seed-user-scripts initContainer each boot; the image entrypoint chmod +x's
+  # and `source`s it under `set -e` before starting ComfyUI. This ConfigMap is
+  # the source of truth — the PVC copy is overwritten (cp -f) every start, so
+  # edit here, not the PVC.
+  #
+  # Installs the pollockjj/ComfyUI-MultiGPU custom node so both of casval's GPUs
+  # back one ComfyUI process (model components spread across cuda:0/cuda:1 for
+  # VRAM headroom). Zero extra pip deps (torch/ComfyUI only), so a git clone is
+  # the whole install.
+  #
+  # SHA-pinned: upstream cuts no release tags, and Renovate can't manage a raw
+  # git clone — bump PIN by hand when you want a newer node.
+  pre-start.sh: |
+    #!/usr/bin/env bash
+    # Sourced by the entrypoint under `set -e`. First-boot clone failures SHOULD
+    # abort (loud) so we never launch a half-provisioned PVC without multi-GPU;
+    # restart-path failures (offline re-pin) must NOT abort an already-good clone.
+    # Deliberately no `set`/`shopt` here — options would leak into the entrypoint.
+    MULTIGPU_REPO="https://github.com/pollockjj/ComfyUI-MultiGPU"
+    MULTIGPU_PIN="b51c99a525e9607e43545ee2a8b7694c74a4775a"
+    MULTIGPU_DIR="/root/ComfyUI/custom_nodes/ComfyUI-MultiGPU"
+
+    if [ ! -d "${MULTIGPU_DIR}/.git" ]; then
+      echo "[multigpu] first boot: cloning ${MULTIGPU_REPO}"
+      # No `|| true`: a first-boot clone/checkout failure must fail the pod.
+      git clone "${MULTIGPU_REPO}" "${MULTIGPU_DIR}"
+      git -C "${MULTIGPU_DIR}" checkout "${MULTIGPU_PIN}"
+      echo "[multigpu] cloned and pinned to ${MULTIGPU_PIN}"
+    elif [ "$(git -C "${MULTIGPU_DIR}" rev-parse HEAD 2>/dev/null)" != "${MULTIGPU_PIN}" ]; then
+      echo "[multigpu] existing clone off pin; re-pinning to ${MULTIGPU_PIN}"
+      # Guarded: a network blip on restart must not kill startup of a PVC that
+      # already has a working node checked out.
+      git -C "${MULTIGPU_DIR}" fetch --depth 1 origin "${MULTIGPU_PIN}" \
+        && git -C "${MULTIGPU_DIR}" checkout "${MULTIGPU_PIN}" \
+        || echo "[multigpu] WARN: re-pin failed (offline?); keeping existing HEAD"
+    else
+      echo "[multigpu] existing clone already at ${MULTIGPU_PIN}"
+    fi

--- a/applications/comfyui/kustomization.yaml
+++ b/applications/comfyui/kustomization.yaml
@@ -1,0 +1,16 @@
+---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+namespace: comfyui
+
+resources:
+  - comfyui-namespace.yaml
+  - comfyui-data-pvc.yaml
+  - comfyui-deployment.yaml
+  - comfyui-service.yaml
+  - comfyui-route.yaml
+
+labels:
+  - pairs:
+      app.kubernetes.io/name: comfyui
+    includeSelectors: true

--- a/applications/comfyui/kustomization.yaml
+++ b/applications/comfyui/kustomization.yaml
@@ -6,6 +6,7 @@ namespace: comfyui
 resources:
   - comfyui-namespace.yaml
   - comfyui-data-pvc.yaml
+  - comfyui-user-scripts-configmap.yaml
   - comfyui-deployment.yaml
   - comfyui-service.yaml
   - comfyui-route.yaml

--- a/applications/comfyui/kustomization.yaml
+++ b/applications/comfyui/kustomization.yaml
@@ -6,6 +6,7 @@ namespace: comfyui
 resources:
   - comfyui-namespace.yaml
   - comfyui-data-pvc.yaml
+  - comfyui-models-pvc.yaml
   - comfyui-user-scripts-configmap.yaml
   - comfyui-deployment.yaml
   - comfyui-service.yaml

--- a/clusters/ocp/values.yaml
+++ b/clusters/ocp/values.yaml
@@ -317,6 +317,22 @@ applications:
     source:
       path: applications/hermes-agent
 
+  comfyui:
+    project: cluster-apps
+    annotations:
+      argocd.argoproj.io/compare-options: IgnoreExtraneous
+      argocd.argoproj.io/sync-wave: '20'
+    source:
+      path: applications/comfyui
+    # Replicas are scaled manually (and the cluster-autoscaler powers casval
+    # up/down in response) — leave them alone so ArgoCD doesn't revert
+    # scale-ups back to the 0 checked into git.
+    ignoreDifferences:
+      - group: apps
+        kind: Deployment
+        jsonPointers:
+          - /spec/replicas
+
   firecrawl:
     project: cluster-apps
     annotations:


### PR DESCRIPTION
## Summary

Stages (does **not** deploy) a GitOps app that runs [ComfyUI](https://github.com/comfyanonymous/ComfyUI) on the `casval.igou.systems` on-demand burst node, using one of its NVIDIA RTX 4060 Ti GPUs. Raw-manifest style matching `applications/sands-of-time/`.

- `applications/comfyui/` — namespace, 300Gi RWO PVC (`freenas-nvmeof-ssd-csi`), Deployment, Service (8188), Route (`comfyui.apps.ocp.igou.systems`, edge TLS, 10m timeout), README.
- `clusters/ocp/values.yaml` — app-of-apps entry, sync-wave 20, `ignoreDifferences` on `apps/Deployment /spec/replicas`.

## Key decisions

- **`replicas: 0` checked into git.** casval is a CAPI burst node the cluster-autoscaler powers down when idle; a permanently-Running GPU pod would pin it on. Scale to 1 on demand; ArgoCD ignores `/spec/replicas` so scale-ups aren't reverted (same rationale/shape as the existing `llmkube` entry).
- **Both GPUs** (`nvidia.com/gpu: 2` in requests + limits) — multi-GPU mode via the [ComfyUI-MultiGPU](https://github.com/pollockjj/ComfyUI-MultiGPU) custom node (ComfyUI core is single-GPU per process; MultiGPU spreads model components across `cuda:0`/`cuda:1` for VRAM headroom; execution stays sequential). Auto-installed on first boot by a `pre-start.sh` hook: ConfigMap `comfyui-user-scripts` is the source of truth, a `seed-user-scripts` initContainer copies it onto the PVC each start (a read-only ConfigMap subPath mount would break the entrypoint's `chmod +x` under `set -e`). SHA-pinned to `b51c99a5` (upstream has no release tags; zero pip deps beyond torch/ComfyUI). No `--cuda-device` in CLI_ARGS so both cards stay visible. **Contention:** llmkube's casval-hosted models (e.g. qwen3-35b) cannot run concurrently — scale comfyui to 0 first.
- **`Recreate` strategy** — exclusive GPU + RWO PVC.
- **nodeSelector `node-role.kubernetes.io/burst: ""` + toleration `workload=burst:NoSchedule`** — lands only on casval.
- **No cpu limit** (memory limit 48Gi only) — matches the lab habit of not cpu-throttling GPU/batch work (see `sands-of-time`).
- **restricted-v2 arbitrary UID** — no SCC changes, no ServiceAccount/RoleBinding (see UID experiment below).
- Generous `startupProbe` (15s × 60 = 900s) — first boot on an empty PVC copies the bundled ComfyUI into `/root` and warms caches.
- No ExternalSecret, no NetworkPolicy (not the app-dir norm; internal ingress only).

## Image

`docker.io/yanwk/comfyui-boot:cu130-slim-20260706@sha256:a2c861b1b30840eeece704e883d4a9af6428da2a6b483688f4cd95a5616efcb7`

Newest dated **slim** tag (CUDA 13.0 runtime ≤ node's CUDA 13.2 / driver 595). Digest-pinned, Renovate-managed.

```
$ skopeo inspect docker://docker.io/yanwk/comfyui-boot:cu130-slim-20260706 | jq -r .Digest
sha256:a2c861b1b30840eeece704e883d4a9af6428da2a6b483688f4cd95a5616efcb7
$ podman pull docker.io/yanwk/comfyui-boot@sha256:a2c861b1b30840eeece704e883d4a9af6428da2a6b483688f4cd95a5616efcb7
...
docker.io/yanwk/comfyui-boot  <none>  9c01de06b142  10.8 GB   # pull OK
```

Image config (`skopeo inspect --config`): `USER=root`, `WORKDIR=/root`, `CMD=["bash","/runner-scripts/entrypoint.sh"]`, no `HOME` env. The entrypoint hardcodes `/root` and writes everything there — `/root/ComfyUI/`, `/root/.cache/pycache`, `/root/.local`, `/root/user-scripts` — using `cd /root`, not `$HOME`.

## Podman UID experiment (why restricted-v2, no anyuid)

OpenShift restricted-v2 runs the container as an arbitrary namespace UID. Since the image writes only under `/root` and the PVC is mounted at `/root` (so that tree becomes fsGroup-owned + group-writable), an arbitrary non-root UID that is a member of GID 0 can write it. Verified with rootless podman before writing the securityContext.

> Note: rootless podman's subuid range can't map OpenShift's literal `1000700000` (`crun: setresuid to 1000700000: Invalid argument`), so the run below uses a representative arbitrary UID `1234:0`. The filesystem/permission semantics are identical: non-root, no `/etc/passwd` entry, GID 0, writable `/root` standing in for the fsGroup-owned PVC (world-writable scratch dir).

```
$ mkdir scratch-root && chmod 777 scratch-root
$ podman run --rm --user 1234:0 -e HOME=/root -e CLI_ARGS=--cpu \
    -v "$PWD/scratch-root:/root:Z" \
    docker.io/yanwk/comfyui-boot@sha256:a2c861b1b30840eeece704e883d4a9af6428da2a6b483688f4cd95a5616efcb7
```

Result — the image copied its bundle into the writable `/root`, ran its SQLite migrations, and reached the HTTP server:

```
[INFO] Using image-bundled ComfyUI (copied to workdir).
[INFO] Total VRAM 31838 MB, total RAM 31838 MB
[INFO] pytorch version: 2.12.1+cu130
[INFO] Device: cpu
[INFO] ComfyUI version: 0.27.0
[INFO] Starting server
[INFO] To see the GUI go to: http://0.0.0.0:8188
```

(GPU init reports `CUDA not available` / `Device: cpu` — expected, no GPU in the local container; the spec accepts this.) The scratch dir confirmed the arbitrary UID actually wrote the tree:

```
$ ls -la scratch-root
drwxr-xr-x  4 525521 igou  .cache        # 525521 = subuid mapping of container UID 1234
drwxr-xr-x 26 525521 igou  ComfyUI
drwxr-xr-x  2 525521 igou  user-scripts
```

**Outcome: works under arbitrary UID → restricted-v2, no SCC changes.** securityContext: pod `runAsNonRoot: true` + `seccompProfile: RuntimeDefault`; container `allowPrivilegeEscalation: false` + `capabilities.drop: [ALL]`. `HOME=/root` set explicitly (arbitrary UID has no passwd home). No `runAsUser`/`fsGroup` pinned — the SCC assigns them. `system:openshift:scc:nonroot-v2` was verified to exist but is not needed.

## Multi-GPU smoke test (rootless podman, CPU-only, arbitrary UID 1234:0)

Simulated the exact pod flow: initContainer sim copies `pre-start.sh` from a read-only seed mount onto the scratch `/root` (lands owned by the pod UID), then the main container boots.

First boot:
```
[INFO] Running pre-start script...
[multigpu] first boot: cloning https://github.com/pollockjj/ComfyUI-MultiGPU
[multigpu] cloned and pinned to b51c99a525e9607e43545ee2a8b7694c74a4775a
[MultiGPU] Registration complete. Final mappings: CheckpointLoaderAdvancedMultiGPU, ... (26 nodes)
Import times for custom nodes:
   0.0 seconds: /root/ComfyUI/custom_nodes/ComfyUI-MultiGPU
To see the GUI go to: http://0.0.0.0:8188
```
`git rev-parse HEAD` in the clone = `b51c99a525e9607e43545ee2a8b7694c74a4775a` (pin verified).

Restart path (rerun initContainer sim + main): idempotent — `Using existing ComfyUI in user storage...`, `[multigpu] existing clone already at b51c99a5...`, node imports clean, GUI line reached.

(MultiGPU imports cleanly CPU-only — it guards on `torch.cuda.is_available()`; real `cuda:1` placement obviously needs the node's second card.)

## Review-driven probe hardening

Liveness probe now sets `timeoutSeconds: 5` + `failureThreshold: 6` (was implicit 1/3 = 90s window): large checkpoint loads / CUDA init can briefly block the aiohttp main thread and must not trip a restart mid-generation. Readiness and startup probes unchanged.

## Validation gates

**Gate 1 — kustomize build:**
```
$ kustomize build applications/comfyui   → OK, 6 resources (ConfigMap added)
```

**Gate 2 — rendered Deployment fields:**
```
replicas: 0 | strategy: Recreate
nodeSelector: {node-role.kubernetes.io/burst: ''}
tolerations: [{key: workload, operator: Equal, value: burst, effect: NoSchedule}]
gpu requests: 2 | limits: 2
initContainer: seed-user-scripts (data→/root, user-scripts-seed→/seed ro)
liveness: periodSeconds 30, timeoutSeconds 5, failureThreshold 6
cpu req: 4 | mem req: 16Gi | mem lim: 48Gi | cpu lim: none
pod securityContext: {runAsNonRoot: true, seccompProfile: {type: RuntimeDefault}}
container securityContext: {allowPrivilegeEscalation: false, capabilities: {drop: [ALL]}}
startup budget: 900s (15s × 60)
```

**Gate 3 — values.yaml parses + app-of-apps renders:**
```
$ python3 -c "import yaml; yaml.safe_load(open('clusters/ocp/values.yaml'))"   → OK
$ kustomize build --enable-helm clusters/ocp   → 52 Applications incl. comfyui
    (path: applications/comfyui, ignoreDifferences apps/Deployment /spec/replicas)
```

**Gate 4 — image digest pullable:** ✅ (see Image section — `podman pull` by digest succeeded).

**Gate 5 — podman UID experiment recorded:** ✅ (see above).

**Bonus — CI parity:**
```
$ yamllint -c .yamllint applications/comfyui/ clusters/ocp/values.yaml   → clean
$ kustomize build applications/comfyui | kubeconform -strict ...   → Valid: 5, Skipped: 1 (Route), Errors: 0
```

## Operations (see README)

- Up: `oc -n comfyui scale deploy/comfyui --replicas=1` (autoscaler boots casval).
- Down: `oc -n comfyui scale deploy/comfyui --replicas=0` (lets casval power off).
- Models: land under `/root/ComfyUI/models/<type>/`; sideload via `oc rsync`/`oc cp` or ComfyUI-Manager's downloader.
- URL: <https://comfyui.apps.ocp.igou.systems> (no app auth — internal ingress only).

---

**Not merged, not deployed.** Draft. Deployment happens only on merge; no live-cluster changes were made (read-only `oc` verification of casval labels/taints and ClusterRole existence only).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
